### PR TITLE
Add help to check command

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -160,7 +160,7 @@ data = {
                     },
                     {
                         "name": "--rev-range",
-                        "help": ("a reange of git rev to check. e.g, master..HEAD"),
+                        "help": "a range of git rev to check. e.g, master..HEAD",
                         "exclusive_group": "group1",
                     },
                 ],

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -32,7 +32,12 @@ class Check:
 
     def _valid_command_argument(self):
         if bool(self.commit_msg_file) is bool(self.rev_range):
-            out.error("One and only one argument is required for check command!")
+            out.error(
+                (
+                    "One and only one argument is required for check command! "
+                    "See 'cz check -h' for more information"
+                )
+            )
             raise SystemExit()
 
     def __call__(self):


### PR DESCRIPTION
Currently, `cz check` without argument shows `One and only one argument is required for check command!` which does not give users a hint of how to fix it. Thus, this pr adds a "See 'cz check -h' for more information" after it.