### PR TITLE
fix(git): fix returned value for GitCommit.message when body is empty

### DIFF
--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -21,10 +21,7 @@ class GitCommit(GitObject):
 
     @property
     def message(self):
-        message = self.title
-        if self.body:
-            message = message + f"\n\n{self.body}"
-        return message
+        return f"{self.title}\n\n{self.body}".strip()
 
     def __repr__(self):
         return f"{self.title} ({self.rev})"

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -21,7 +21,10 @@ class GitCommit(GitObject):
 
     @property
     def message(self):
-        return f"{self.title}\n\n{self.body}"
+        message = self.title
+        if self.body:
+            message = message + f"\n\n{self.body}"
+        return message
 
     def __repr__(self):
         return f"{self.title} ({self.rev})"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -47,3 +47,10 @@ def test_get_tag_names(mocker):
         "commitizen.cmd.run", return_value=FakeCommand(out="", err="No tag available")
     )
     assert git.get_tag_names() == []
+
+
+def test_git_message_with_empty_body():
+    commit_title = "Some Title"
+    commit = git.GitCommit("test_rev", "Some Title", body="")
+
+    assert commit.message == commit_title


### PR DESCRIPTION
GitCommit.message should return only title without excess newlines if commit body is empty.