### PR TITLE
docs(third-party): add third-party template documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,10 @@ commands:
     init                init commitizen configuration
 ```
 
+## Third-Party Commitizen Templates
+
+See [docs/third-party-commitizen.md](third-party-commitizen.md).
+
 ## FAQ
 
 ### Why are `revert` and `chore` valid types in the check pattern of cz conventional_commits but not types we can select?

--- a/docs/third-party-commitizen.md
+++ b/docs/third-party-commitizen.md
@@ -1,0 +1,12 @@
+## Third-Party Commitizen Templates
+
+In addition to the native templates, some alternative commit format templates
+are available as PyPI packages (installable with `pip`).
+
+### [Conventional JIRA](https://pypi.org/project/conventional-JIRA/)
+
+Just like *conventional commit* format, but the scope has been restricted to a
+JIRA issue format, i.e. `project-issueNumber`. This standardises scopes in a
+meaningful way.
+
+It can be installed with `pip install conventional-JIRA`.


### PR DESCRIPTION
Add a new docs section for third-party contributed commit templates.
This way new templates do not need to be merged into the main codebase,
and instead exist as satellite repositories.

I wasn't exactly sure if you wanted all the third-party commit templates in the `README.md` itself, so I placed them inside a separate `docs` file instead.

See #158 for motivation.