### PR TITLE
feat(bump): add optional --no-verify argument for bump command

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -93,6 +93,12 @@ data = {
                         "help": "generate the changelog for the newest version",
                     },
                     {
+                        "name": ["--no-verify"],
+                        "action": "store_true",
+                        "default": False,
+                        "help": "this option bypasses the pre-commit and commit-msg hooks",
+                    },
+                    {
                         "name": "--yes",
                         "action": "store_true",
                         "help": "accept automatically questions done",

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -31,6 +31,7 @@ class Bump:
         }
         self.cz = factory.commiter_factory(self.config)
         self.changelog = arguments["changelog"]
+        self.no_verify = arguments["no_verify"]
 
     def is_initial_tag(self, current_tag_version: str, is_yes: bool = False) -> bool:
         """Check if reading the whole git tree up to HEAD is needed."""
@@ -145,7 +146,7 @@ class Bump:
             changelog()
 
         self.config.set_key("version", new_version.public)
-        c = git.commit(message, args="-a")
+        c = git.commit(message, args=self._get_commit_args())
         if c.err:
             out.error('git.commit errror: "{}"'.format(c.err.strip()))
             raise SystemExit(COMMIT_FAILED)
@@ -154,3 +155,9 @@ class Bump:
             out.error(c.err)
             raise SystemExit(TAG_FAILED)
         out.success("Done!")
+
+    def _get_commit_args(self):
+        commit_args = ["-a"]
+        if self.no_verify:
+            commit_args.append("--no-verify")
+        return " ".join(commit_args)

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -54,7 +54,7 @@ Some examples:
 
 ```bash
 $ cz bump --help
-usage: cz bump [-h] [--dry-run] [--files-only] [--changelog] [--yes]
+usage: cz bump [-h] [--dry-run] [--files-only] [--changelog] [--no-verify] [--yes]
                [--tag-format TAG_FORMAT] [--bump-message BUMP_MESSAGE]
                [--prerelease {alpha,beta,rc}]
                [--increment {MAJOR,MINOR,PATCH}]
@@ -64,6 +64,7 @@ optional arguments:
   --dry-run             show output to stdout, no commit, no modified files
   --files-only          bump version in the files from the config
   --changelog, -ch      generate the changelog for the newest version
+  --no-verify           this option bypasses the pre-commit and commit-msg hooks
   --yes                 accept automatically questions done
   --tag-format TAG_FORMAT
                         the format used to tag the commit and read it, use it


### PR DESCRIPTION
fix: #164

When we have in repo some pre-commit hooks, like black, mypy or anything like that
cz bump fails, even if pre-commit hooks passed.

it is strange as pre-commit write messages to sys.stdout.buffer not stderr...

example pre-commit config:
```
repos:
  - repo: local
    hooks:
      - id: flake8
        name: flake8
        stages: [commit]
        language: system
        entry: poetry run flake8
        types: [python]
        exclude: setup.py

      - id: mypy
        name: mypy
        stages: [commit]
        language: system
        entry: poetry run mypy
        types: [python]
        pass_filenames: false
```


This PR add optional --no-verify argument to bump command