### PR TITLE
fix(docs): change old url woile.github.io to commitizen-tools.github.io

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -67,9 +67,9 @@ The extra tab before the square brackets (`]`) at the end is required.
 | -------- | ---- | ------- | ----------- |
 | `name` | `str` | `"cz_conventional_commits"` | Name of the committing rules to use |
 | `version` | `str` | `None` | Current version. Example: "0.1.2" |
-| `version_files` | `list` | `[ ]` | Files were the version will be updated. A pattern to match a line, can also be specified, separated by `:` [See more](https://woile.github.io/commitizen/bump#files) |
-| `tag_format` | `str` | `None` | Format for the git tag, useful for old projects, that use a convention like `"v1.2.1"`. [See more](https://woile.github.io/commitizen/bump#tag_format) |
-| `bump_message` | `str` | `None` | Create custom commit message, useful to skip ci. [See more](https://woile.github.io/commitizen/bump#bump_message) |
+| `version_files` | `list` | `[ ]` | Files were the version will be updated. A pattern to match a line, can also be specified, separated by `:` [See more](https://commitizen-tools.github.io/commitizen/bump/#version_files) |
+| `tag_format` | `str` | `None` | Format for the git tag, useful for old projects, that use a convention like `"v1.2.1"`. [See more](https://commitizen-tools.github.io/commitizen/bump/#tag_format) |
+| `bump_message` | `str` | `None` | Create custom commit message, useful to skip ci. [See more](https://commitizen-tools.github.io/commitizen/bump/#bump_message) |
 | `changelog_file` | `str` | `CHANGELOG.md` | filename of exported changelog |
 | `style` | `list` | see above | Style for the prompts (It will merge this value with default style.) [See More (Styling your prompts with your favorite colors)](https://github.com/tmbo/questionary#additional-features) |
 | `customize` | `dict` | `None` | **This is only supported when config through `toml`.** Custom rules for committing and bumping. [See more](https://commitizen-tools.github.io/commitizen/customization/) |


### PR DESCRIPTION
There was some urls from previous documentation url