### PR TITLE
ci(github/bumpversion): fix workflow to not skip commits with bump word

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: "!contains(github.event.head_commit.message, 'bump')"
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/docs/tutorials/github_actions.md
+++ b/docs/tutorials/github_actions.md
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    if: "!contains(github.event.head_commit.message, 'bump')"
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
fix: #157

skip only commits that startsWith: `bump:`