### PR TITLE
remove trailing space in keep_a_changelog and other minor improvement

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -27,6 +29,14 @@ jobs:
         git config --global user.email "action@github.com"
         git config --global user.name "GitHub Action"
         ./scripts/test
+    - name: Check commit
+      run: |
+        poetry run python -m commitizen check --rev-range ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} || \
+        if [ $$? == 3 ] ; then
+          exit 0;
+        else
+          exit 1;
+        fi
     - name: Upload coverage to Codecov
       if: runner.os == 'Linux'
       uses: codecov/codecov-action@v1.0.3

--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -138,7 +138,7 @@ def update_version_in_files(
     So for example, your tag could look like `v1.0.0` while your version in
     the package like `1.0.0`.
     """
-    # TODO: sepearte check step and write step
+    # TODO: separate check step and write step
     for location in files:
         filepath, *regexes = location.split(":", maxsplit=1)
         regex = regexes[0] if regexes else None

--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -55,7 +55,8 @@ def find_increment(
 
 
 def prerelease_generator(current_version: str, prerelease: Optional[str] = None) -> str:
-    """
+    """Generate prerelease
+
     X.YaN   # Alpha release
     X.YbN   # Beta release
     X.YrcN  # Release Candidate
@@ -179,13 +180,11 @@ def create_tag(version: Union[Version, str], tag_format: Optional[str] = None):
     That's why this function exists.
 
     Example:
-
     | tag | version (PEP 0440) |
     | --- | ------- |
     | v0.9.0 | 0.9.0 |
     | ver1.0.0 | 1.0.0 |
     | ver1.0.0.a0 | 1.0.0a0 |
-
     """
     if isinstance(version, str):
         version = Version(version)

--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -1,5 +1,4 @@
-"""
-# DESIGN
+"""Design
 
 ## Metadata CHANGELOG.md
 
@@ -62,7 +61,6 @@ def transform_change_type(change_type: str) -> str:
 
 
 def get_commit_tag(commit: GitCommit, tags: List[GitTag]) -> Optional[GitTag]:
-    """"""
     return next((tag for tag in tags if tag.rev == commit.rev), None)
 
 
@@ -211,13 +209,13 @@ def incremental_build(new_content: str, lines: List, metadata: Dict) -> List:
     The metadata holds information enough to remove the old unreleased and
     where to place the new content
 
-    Arguments:
-        lines -- the lines from the changelog
-        new_content -- this should be placed somewhere in the lines
-        metadata -- information about the changelog
+    Args:
+        lines: The lines from the changelog
+        new_content: This should be placed somewhere in the lines
+        metadata: Information about the changelog
 
     Returns:
-        List -- updated lines
+        Updated lines
     """
     unreleased_start = metadata.get("unreleased_start")
     unreleased_end = metadata.get("unreleased_end")

--- a/commitizen/changelog_parser.py
+++ b/commitizen/changelog_parser.py
@@ -1,5 +1,4 @@
-"""
-# DESIGN
+"""CHNAGLOG PARSER DESIGN
 
 ## Parse CHANGELOG.md
 
@@ -36,8 +35,7 @@ CATEGORIES = [
 
 
 def find_version_blocks(filepath: str) -> Generator:
-    """
-    version block: contains all the information about a version.
+    """Find version block (version block: contains all the information about a version.)
 
     E.g:
     ```

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -114,7 +114,7 @@ data = {
                     {
                         "name": "--bump-message",
                         "help": (
-                            "template used to create the release commmit, "
+                            "template used to create the release commit, "
                             "useful when working with CI"
                         ),
                     },

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -154,7 +154,7 @@ class Bump:
         self.config.set_key("version", new_version.public)
         c = git.commit(message, args=self._get_commit_args())
         if c.err:
-            out.error('git.commit errror: "{}"'.format(c.err.strip()))
+            out.error('git.commit error: "{}"'.format(c.err.strip()))
             raise SystemExit(COMMIT_FAILED)
         c = git.tag(new_tag_version)
         if c.err:

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -12,16 +12,12 @@ class Check:
     """Check if the current commit msg matches the commitizen format."""
 
     def __init__(self, config: BaseConfig, arguments: Dict[str, str], cwd=os.getcwd()):
-        """Init method.
+        """Initial check command.
 
-        Parameters
-        ----------
-        config : BaseConfig
-            the config object required for the command to perform its action
-        arguments : dict
-            the arguments object that contains all
-            the flags provided by the user
-
+        Args:
+            config: The config object required for the command to perform its action
+            arguments: All the flags provided by the user
+            cwd: Current work directory
         """
         self.commit_msg_file: Optional[str] = arguments.get("commit_msg_file")
         self.rev_range: Optional[str] = arguments.get("rev_range")
@@ -44,11 +40,8 @@ class Check:
     def __call__(self):
         """Validate if commit messages follows the conventional pattern.
 
-        Raises
-        ------
-        SystemExit
-            if the commit provided not follows the conventional pattern
-
+        Raises:
+            SystemExit: if the commit provided not follows the conventional pattern
         """
         commit_msgs = self._get_commit_messages()
         if not commit_msgs:

--- a/commitizen/config/__init__.py
+++ b/commitizen/config/__init__.py
@@ -16,7 +16,7 @@ def load_global_conf() -> Optional[IniConfig]:
     if not global_cfg.exists():
         return None
 
-    # global conf doesnt make sense with commitizen bump
+    # global conf doesn't make sense with commitizen bump
     # so I'm deprecating it and won't test it
     message = (
         "Global conf will be deprecated in next major version. "

--- a/commitizen/cz/base.py
+++ b/commitizen/cz/base.py
@@ -69,7 +69,7 @@ class BaseCommitizen(metaclass=ABCMeta):
         raise NotImplementedError("Not Implemented yet")
 
     def schema_pattern(self) -> Optional[str]:
-        """Regex matching the schema used for message validation"""
+        """Regex matching the schema used for message validation."""
         raise NotImplementedError("Not Implemented yet")
 
     def info(self) -> Optional[str]:

--- a/commitizen/factory.py
+++ b/commitizen/factory.py
@@ -11,7 +11,7 @@ def commiter_factory(config: BaseConfig) -> BaseCommitizen:
         _cz = registry[name](config)
     except KeyError:
         msg_error = (
-            "The commiter has not been found in the system.\n\n"
+            "The committer has not been found in the system.\n\n"
             f"Try running 'pip install {name}'\n"
         )
         out.error(msg_error)

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -63,7 +63,7 @@ def get_commits(
     delimiter: str = "----------commit-delimiter----------",
     args: str = "",
 ) -> List[GitCommit]:
-    """Get the commits betweeen start and end."""
+    """Get the commits between start and end."""
     git_log_cmd = f"git log --pretty={log_format}{delimiter} {args}"
 
     if start:

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -63,9 +63,7 @@ def get_commits(
     delimiter: str = "----------commit-delimiter----------",
     args: str = "",
 ) -> List[GitCommit]:
-    """
-    Get the commits betweeen start and end
-    """
+    """Get the commits betweeen start and end."""
     git_log_cmd = f"git log --pretty={log_format}{delimiter} {args}"
 
     if start:
@@ -133,7 +131,7 @@ def find_git_project_root() -> Optional[Path]:
 
 
 def is_staging_clean() -> bool:
-    """Check if staing is clean"""
+    """Check if staing is clean."""
     c = cmd.run("git diff --no-ext-diff --name-only")
     c_cached = cmd.run("git diff --no-ext-diff --cached --name-only")
     return not (bool(c.out) or bool(c_cached.out))

--- a/commitizen/templates/keep_a_changelog_template.j2
+++ b/commitizen/templates/keep_a_changelog_template.j2
@@ -1,6 +1,6 @@
 {% for entry in tree %}
 
-## {{ entry.version }} {% if entry.date %}({{ entry.date }}){% endif %}
+## {{ entry.version }}{% if entry.date %} ({{ entry.date }}){% endif %}
 
 {% for change_key, changes in entry.changes.items() %}
 

--- a/docs/tutorials/github_actions.md
+++ b/docs/tutorials/github_actions.md
@@ -97,5 +97,6 @@ jobs:
 ```
 
 Notice that we are calling a bash script in `./scripts/publish`, you should configure it with your tools (twine, poetry, etc.). Check [commitizen example](https://github.com/commitizen-tools/commitizen/blob/master/scripts/publish)
+You can also use [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) to publish your package.
 
 Push the changes and that's it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ mkdocs = "^1.0"
 mkdocs-material = "^4.1"
 isort = "^4.3.21"
 freezegun = "^0.3.15"
+pydocstyle = "^5.0.2"
 
 [tool.poetry.scripts]
 cz = "commitizen.cli:main"

--- a/scripts/test
+++ b/scripts/test
@@ -11,3 +11,4 @@ ${PREFIX}isort --recursive --check-only commitizen tests
 ${PREFIX}flake8 commitizen/ tests/
 ${PREFIX}mypy commitizen/ tests/
 ${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415
+${PREFIX}commitizen check --rev-range master..

--- a/scripts/test
+++ b/scripts/test
@@ -10,3 +10,4 @@ ${PREFIX}black commitizen tests --check
 ${PREFIX}isort --recursive --check-only commitizen tests
 ${PREFIX}flake8 commitizen/ tests/
 ${PREFIX}mypy commitizen/ tests/
+${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415

--- a/scripts/test
+++ b/scripts/test
@@ -11,4 +11,3 @@ ${PREFIX}isort --recursive --check-only commitizen tests
 ${PREFIX}flake8 commitizen/ tests/
 ${PREFIX}mypy commitizen/ tests/
 ${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415
-${PREFIX}commitizen check --rev-range master..

--- a/tests/CHANGELOG_FOR_TEST.md
+++ b/tests/CHANGELOG_FOR_TEST.md
@@ -29,7 +29,7 @@
 - update given files with new version
 - **config**: new set key, used to set version to cfg
 - support for pyproject.toml
-- first semantic version bump implementaiton
+- first semantic version bump implementation
 
 ### fix
 
@@ -92,11 +92,11 @@
 
 ### refactor
 
-- **conventionalCommit**: moved fitlers to questions instead of message
+- **conventionalCommit**: moved filters to questions instead of message
 
 ### fix
 
-- **manifest**: inluded missing files
+- **manifest**: included missing files
 
 ## v0.9.5 (2018-08-24)
 
@@ -114,7 +114,7 @@
 
 ### feat
 
-- **commiter**: conventional commit is a bit more intelligent now
+- **committer**: conventional commit is a bit more intelligent now
 
 ## v0.9.2 (2017-11-11)
 

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -77,7 +77,7 @@ def test_bump_on_git_with_hooks_no_verify_disabled(mocker, capsys):
         cli.main()
 
     _, err = capsys.readouterr()
-    assert 'git.commit errror: "0.1.0"' in err
+    assert 'git.commit error: "0.1.0"' in err
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -38,7 +38,7 @@ def test_changlog_from_version_zero_point_two(mocker, capsys):
         cli.main()
 
     out, _ = capsys.readouterr()
-    assert out == "\n## Unreleased \n\n### Feat\n\n- after 0.2\n- after 0.2.0\n\n"
+    assert out == "\n## Unreleased\n\n### Feat\n\n- after 0.2\n- after 0.2.0\n\n"
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
@@ -54,7 +54,7 @@ def test_changlog_with_different_cz(mocker, capsys):
     out, _ = capsys.readouterr()
     assert (
         out
-        == "\n## Unreleased \n\n\n- JRA-35 #time 1w 2d 4h 30m Total work logged\n- JRA-34 #comment corrected indent issue\n\n"
+        == "\n## Unreleased\n\n\n- JRA-35 #time 1w 2d 4h 30m Total work logged\n- JRA-34 #comment corrected indent issue\n\n"
     )
 
 
@@ -74,7 +74,7 @@ def test_changlog_from_start(mocker, capsys):
 
     assert (
         out
-        == "\n## Unreleased \n\n### Refactor\n\n- is in changelog\n\n### Feat\n\n- new file\n"
+        == "\n## Unreleased\n\n### Refactor\n\n- is in changelog\n\n### Feat\n\n- new file\n"
     )
 
 
@@ -108,7 +108,7 @@ def test_changlog_replacing_unreleased_using_incremental(mocker, capsys):
     today = date.today().isoformat()
     assert (
         out
-        == f"\n\n## Unreleased \n\n### Feat\n\n- add more stuff\n\n### Fix\n\n- mama gotta work\n\n## 0.2.0 ({today})\n\n### Fix\n\n- output glitch\n\n### Feat\n\n- add new output\n"
+        == f"\n\n## Unreleased\n\n### Feat\n\n- add more stuff\n\n### Fix\n\n- mama gotta work\n\n## 0.2.0 ({today})\n\n### Fix\n\n- output glitch\n\n### Feat\n\n- add new output\n"
     )
 
 
@@ -146,7 +146,7 @@ def test_changlog_is_persisted_using_incremental(mocker, capsys):
     today = date.today().isoformat()
     assert (
         out
-        == f"\n\n## Unreleased \n\n### Feat\n\n- add more stuff\n\n### Fix\n\n- mama gotta work\n\n## 0.2.0 ({today})\n\n### Fix\n\n- output glitch\n\n### Feat\n\n- add new output\n\nnote: this should be persisted using increment\n"
+        == f"\n\n## Unreleased\n\n### Feat\n\n- add more stuff\n\n### Fix\n\n- mama gotta work\n\n## 0.2.0 ({today})\n\n### Fix\n\n- output glitch\n\n### Feat\n\n- add new output\n\nnote: this should be persisted using increment\n"
     )
 
 
@@ -180,7 +180,7 @@ def test_changlog_incremental_angular_sample(mocker, capsys):
 
     assert (
         out
-        == "\n## Unreleased \n\n### Feat\n\n- add more stuff\n- add new output\n\n### Fix\n\n- mama gotta work\n- output glitch\n\n# [10.0.0-next.3](https://github.com/angular/angular/compare/10.0.0-next.2...10.0.0-next.3) (2020-04-22)\n\n### Bug Fixes\n* **common:** format day-periods that cross midnight ([#36611](https://github.com/angular/angular/issues/36611)) ([c6e5fc4](https://github.com/angular/angular/commit/c6e5fc4)), closes [#36566](https://github.com/angular/angular/issues/36566)\n"
+        == "\n## Unreleased\n\n### Feat\n\n- add more stuff\n- add new output\n\n### Fix\n\n- mama gotta work\n- output glitch\n\n# [10.0.0-next.3](https://github.com/angular/angular/compare/10.0.0-next.2...10.0.0-next.3) (2020-04-22)\n\n### Bug Fixes\n* **common:** format day-periods that cross midnight ([#36611](https://github.com/angular/angular/issues/36611)) ([c6e5fc4](https://github.com/angular/angular/commit/c6e5fc4)), closes [#36566](https://github.com/angular/angular/issues/36566)\n"
     )
 
 
@@ -233,7 +233,7 @@ def test_changlog_incremental_keep_a_changelog_sample(mocker, capsys):
 
     assert (
         out
-        == """# Changelog\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\n\n## Unreleased \n\n### Feat\n\n- add more stuff\n- add new output\n\n### Fix\n\n- mama gotta work\n- output glitch\n\n## [1.0.0] - 2017-06-20\n### Added\n- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).\n- Version navigation.\n\n### Changed\n- Start using "changelog" over "change log" since it\'s the common usage.\n\n### Removed\n- Section about "changelog" vs "CHANGELOG".\n\n## [0.3.0] - 2015-12-03\n### Added\n- RU translation from [@aishek](https://github.com/aishek).\n"""
+        == """# Changelog\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n\n\n## Unreleased\n\n### Feat\n\n- add more stuff\n- add new output\n\n### Fix\n\n- mama gotta work\n- output glitch\n\n## [1.0.0] - 2017-06-20\n### Added\n- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).\n- Version navigation.\n\n### Changed\n- Start using "changelog" over "change log" since it\'s the common usage.\n\n### Removed\n- Section about "changelog" vs "CHANGELOG".\n\n## [0.3.0] - 2015-12-03\n### Added\n- RU translation from [@aishek](https://github.com/aishek).\n"""
     )
 
 
@@ -251,6 +251,6 @@ def test_changlog_hook(mocker, config):
     )
     mocker.patch.object(changelog.cz, "changelog_hook", changelog_hook_mock)
     changelog()
-    full_changelog = "\n## Unreleased \n\n### Refactor\n\n- is in changelog\n\n### Feat\n\n- new file\n"
+    full_changelog = "\n## Unreleased\n\n### Refactor\n\n- is in changelog\n\n### Feat\n\n- new file\n"
 
     changelog_hook_mock.assert_called_with(full_changelog, full_changelog)

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -125,7 +125,7 @@ COMMITS_DATA = [
     },
     {
         "rev": "3127e05077288a5e2b62893345590bf1096141b7",
-        "title": "feat: first semantic version bump implementaiton",
+        "title": "feat: first semantic version bump implementation",
         "body": "",
     },
     {
@@ -255,12 +255,12 @@ COMMITS_DATA = [
     },
     {
         "rev": "72472efb80f08ee3fd844660afa012c8cb256e4b",
-        "title": "refactor(conventionalCommit): moved fitlers to questions instead of message",
+        "title": "refactor(conventionalCommit): moved filters to questions instead of message",
         "body": "",
     },
     {
         "rev": "b5561ce0ab3b56bb87712c8f90bcf37cf2474f1b",
-        "title": "fix(manifest): inluded missing files",
+        "title": "fix(manifest): included missing files",
         "body": "",
     },
     {
@@ -290,7 +290,7 @@ COMMITS_DATA = [
     },
     {
         "rev": "4368f3c3cbfd4a1ced339212230d854bc5bab496",
-        "title": "feat(commiter): conventional commit is a bit more intelligent now",
+        "title": "feat(committer): conventional commit is a bit more intelligent now",
         "body": "",
     },
     {
@@ -472,7 +472,7 @@ def test_generate_tree_from_commits(gitcommits, tags):
                     {
                         "scope": None,
                         "breaking": None,
-                        "message": "first semantic version bump implementaiton",
+                        "message": "first semantic version bump implementation",
                     },
                 ],
                 "fix": [
@@ -591,14 +591,14 @@ def test_generate_tree_from_commits(gitcommits, tags):
                     {
                         "scope": "conventionalCommit",
                         "breaking": None,
-                        "message": "moved fitlers to questions instead of message",
+                        "message": "moved filters to questions instead of message",
                     }
                 ],
                 "fix": [
                     {
                         "scope": "manifest",
                         "breaking": None,
-                        "message": "inluded missing files",
+                        "message": "included missing files",
                     }
                 ],
             },
@@ -629,7 +629,7 @@ def test_generate_tree_from_commits(gitcommits, tags):
             "changes": {
                 "feat": [
                     {
-                        "scope": "commiter",
+                        "scope": "committer",
                         "breaking": None,
                         "message": "conventional commit is a bit more intelligent now",
                     }

--- a/tests/test_cz_customize.py
+++ b/tests/test_cz_customize.py
@@ -10,7 +10,7 @@ def config():
     toml_str = r"""
     [tool.commitizen.customize]
     message_template = "{{change_type}}:{% if show_message %} {{message}}{% endif %}"
-    example = "feature: this feature eanable customize through config file"
+    example = "feature: this feature enable customize through config file"
     schema = "<type>: <body>"
     bump_pattern = "^(break|new|fix|hotfix)"
     bump_map = {"break" = "MAJOR", "new" = "MINOR", "fix" = "PATCH", "hotfix" = "PATCH"}
@@ -88,16 +88,16 @@ def test_answer(config):
     cz = CustomizeCommitsCz(config)
     answers = {
         "change_type": "feature",
-        "message": "this feature eanable customize through config file",
+        "message": "this feature enaable customize through config file",
         "show_message": True,
     }
     message = cz.message(answers)
-    assert message == "feature: this feature eanable customize through config file"
+    assert message == "feature: this feature enaable customize through config file"
 
     cz = CustomizeCommitsCz(config)
     answers = {
         "change_type": "feature",
-        "message": "this feature eanable customize through config file",
+        "message": "this feature enaable customize through config file",
         "show_message": False,
     }
     message = cz.message(answers)
@@ -106,7 +106,7 @@ def test_answer(config):
 
 def test_example(config):
     cz = CustomizeCommitsCz(config)
-    assert "feature: this feature eanable customize through config file" in cz.example()
+    assert "feature: this feature enable customize through config file" in cz.example()
 
 
 def test_schema(config):


### PR DESCRIPTION
(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)

## Types of changes
Please put an `x` in the box that applies

- [x] **Bugfix**
- [ ] **New feature**
- [x] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [x] **Documentation Update**
- [x] **Other (please describe)**: ci improvement

## Description
* Refactoring
    * unify docstring style to google convetion
    * fix typo in codebase (through [codespell](https://github.com/codespell-project/codespell))
* fix
    * remove trailing space in keep_a_changelog
* doc
    * add pypa/gh-action-pypi-publish as reference
* ci improvement
    * use `pydocstyle` to check docstring style
    * add commit check

## Checklist:
- [x] Add test cases to all the changes you introduce
- [x] Run `./script/lint` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Steps to Test This Pull Request
1. Generate changelog through `cz changelog`

## Expected behavior
The trailing space after each version should no longer exist.

## Related Issue
#161 

## Additional context

