### PR TITLE
style(init): fix typo in init script

### DIFF
--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -32,7 +32,7 @@ class Init:
             values_to_add["version"] = Version(tag).public
             values_to_add["tag_format"] = self._ask_tag_format(tag)
             self._update_config_file(values_to_add)
-            out.write("You can bump the version and create cangelog running:\n")
+            out.write("You can bump the version and create changelog running:\n")
             out.info("cz bump --changelog")
             out.success("The configuration are all set.")
         else:


### PR DESCRIPTION
## Types of changes
Please put an `x` in the box that applies

- [ ] **Bugfix**
- [ ] **New feature**
- [x] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [ ] **Other (please describe)**

## Description
I was trying out the commitizen init command when I noticed a typo in the word. Thought I would help fix this small typo 😀

## Checklist:
- [x] Run `./script/lint` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
