### PR TITLE
Remove typing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ termcolor = "^1.1"
 packaging = ">=19,<21"
 tomlkit = "^0.5.3"
 jinja2 = "^2.10.3"
-typing = "^3.7.4"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.2"


### PR DESCRIPTION
## Types of changes

- [ ] **Bugfix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation Update**
- [x] **Other (please describe)**

## Description
Remove the `typing` dependency. The typing module is included in stdlib since Python 3.5.

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [x] Run `./script/lint` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes