### PR TITLE
Runtime dependency on setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ termcolor = "^1.1"
 packaging = ">=19,<21"
 tomlkit = "^0.5.3"
 jinja2 = "^2.10.3"
+setuptools = ">=47.3.1"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.2"


### PR DESCRIPTION
Imported here: https://github.com/commitizen-tools/commitizen/blob/b8fc1eeaf5a915d8d0f7179dc303ec2f3835b79f/commitizen/changelog.py#L33

## Types of changes
Please put an `x` in the box that applies

- [x] **Bugfix**


Without it in  a pristine python environment: 

```shell
cz --help
Traceback (most recent call last):
  File "/nix/store/8wvn1d6hfdcribcinn21rzlkvjvzab2p-python3.8-commitizen-1.23.0/bin/.cz-wrapped", line 6, in <module>
    from commitizen.cli import main
  File "/nix/store/k4h5dy9yqdm8gisdmbhzg75m06p1fb9z-python3-3.8.3-env/lib/python3.8/site-packages/commitizen/cli.py", line 9, in <module>
    from commitizen import commands, config
  File "/nix/store/k4h5dy9yqdm8gisdmbhzg75m06p1fb9z-python3-3.8.3-env/lib/python3.8/site-packages/commitizen/commands/__init__.py", line 1, in <module>
    from .bump import Bump
  File "/nix/store/k4h5dy9yqdm8gisdmbhzg75m06p1fb9z-python3-3.8.3-env/lib/python3.8/site-packages/commitizen/commands/bump.py", line 7, in <module>
    from commitizen.commands.changelog import Changelog
  File "/nix/store/k4h5dy9yqdm8gisdmbhzg75m06p1fb9z-python3-3.8.3-env/lib/python3.8/site-packages/commitizen/commands/changelog.py", line 6, in <module>
    from commitizen import changelog, factory, git, out
  File "/nix/store/k4h5dy9yqdm8gisdmbhzg75m06p1fb9z-python3-3.8.3-env/lib/python3.8/site-packages/commitizen/changelog.py", line 33, in <module>
    import pkg_resources
```
