### PR TITLE
fix: Raise NotAGitProjectError only in git related command

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -13,6 +13,7 @@ from commitizen.exceptions import (
     ExpectedExit,
     NoCommitsFoundError,
     NoPatternMapError,
+    NotAGitProjectError,
     NoVersionSpecifiedError,
 )
 
@@ -21,6 +22,9 @@ class Bump:
     """Show prompt for the user to create a guided commit."""
 
     def __init__(self, config: BaseConfig, arguments: dict):
+        if not git.is_git_project():
+            raise NotAGitProjectError()
+
         self.config: BaseConfig = config
         self.arguments: dict = arguments
         self.bump_settings: dict = {

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -10,6 +10,7 @@ from commitizen.exceptions import (
     NoCommitsFoundError,
     NoPatternMapError,
     NoRevisionError,
+    NotAGitProjectError,
 )
 from commitizen.git import GitTag
 
@@ -22,6 +23,9 @@ class Changelog:
     """Generate a changelog based on the commit history."""
 
     def __init__(self, config: BaseConfig, args):
+        if not git.is_git_project():
+            raise NotAGitProjectError()
+
         self.config: BaseConfig = config
         self.cz = factory.commiter_factory(self.config)
 

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -13,6 +13,7 @@ from commitizen.exceptions import (
     DryRunExit,
     NoAnswersError,
     NoCommitBackupError,
+    NotAGitProjectError,
     NothingToCommitError,
 )
 
@@ -21,6 +22,9 @@ class Commit:
     """Show prompt for the user to create a guided commit."""
 
     def __init__(self, config: BaseConfig, arguments: dict):
+        if not git.is_git_project():
+            raise NotAGitProjectError()
+
         self.config: BaseConfig = config
         self.cz = factory.commiter_factory(self.config)
         self.arguments = arguments

--- a/commitizen/config/__init__.py
+++ b/commitizen/config/__init__.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Optional, Union
 
 from commitizen import defaults, git
-from commitizen.exceptions import NotAGitProjectError
 
 from .base_config import BaseConfig
 from .ini_config import IniConfig
@@ -37,12 +36,13 @@ def read_cfg() -> BaseConfig:
     conf = BaseConfig()
 
     git_project_root = git.find_git_project_root()
-    if not git_project_root:
-        raise NotAGitProjectError()
+    cfg_search_paths = [Path(".")]
+    if git_project_root:
+        cfg_search_paths.append(git_project_root)
 
     cfg_paths = (
         path / Path(filename)
-        for path in [Path("."), git_project_root]
+        for path in cfg_search_paths
         for filename in defaults.config_files
     )
     for filename in cfg_paths:

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -135,3 +135,10 @@ def is_staging_clean() -> bool:
     c = cmd.run("git diff --no-ext-diff --name-only")
     c_cached = cmd.run("git diff --no-ext-diff --cached --name-only")
     return not (bool(c.out) or bool(c_cached.out))
+
+
+def is_git_project() -> bool:
+    c = cmd.run("git rev-parse --is-inside-work-tree")
+    if c.out.strip() == "true":
+        return True
+    return False

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -10,6 +10,7 @@ from commitizen.exceptions import (
     ExpectedExit,
     NoCommitsFoundError,
     NoPatternMapError,
+    NotAGitProjectError,
     NoVersionSpecifiedError,
 )
 from tests.utils import create_file_and_commit
@@ -206,3 +207,13 @@ def test_bump_dry_run(mocker, capsys, tmp_commitizen_project):
 
     tag_exists = git.tag_exist("0.2.0")
     assert tag_exists is False
+
+
+def test_bump_in_non_git_project(tmpdir, config, mocker):
+    testargs = ["cz", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+
+    with tmpdir.as_cwd():
+        with pytest.raises(NotAGitProjectError):
+            with pytest.raises(ExpectedExit):
+                cli.main()

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -6,7 +6,12 @@ import pytest
 
 from commitizen import cli, git
 from commitizen.commands.changelog import Changelog
-from commitizen.exceptions import DryRunExit, NoCommitsFoundError, NoRevisionError
+from commitizen.exceptions import (
+    DryRunExit,
+    NoCommitsFoundError,
+    NoRevisionError,
+    NotAGitProjectError,
+)
 from tests.utils import create_file_and_commit
 
 
@@ -335,3 +340,12 @@ def test_changelog_with_different_tag_name_and_changelog_content(
 
     with pytest.raises(NoRevisionError):
         cli.main()
+
+
+def test_changelog_in_non_git_project(tmpdir, config, mocker):
+    testargs = ["cz", "changelog", "--incremental"]
+    mocker.patch.object(sys, "argv", testargs)
+
+    with tmpdir.as_cwd():
+        with pytest.raises(NotAGitProjectError):
+            cli.main()

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -10,6 +10,7 @@ from commitizen.exceptions import (
     DryRunExit,
     NoAnswersError,
     NoCommitBackupError,
+    NotAGitProjectError,
     NothingToCommitError,
 )
 
@@ -151,3 +152,9 @@ def test_commit_when_no_user_answer(config, mocker, capsys):
     with pytest.raises(NoAnswersError):
         commit_cmd = commands.Commit(config, {})
         commit_cmd()
+
+
+def test_commit_in_non_git_project(tmpdir, config):
+    with tmpdir.as_cwd():
+        with pytest.raises(NotAGitProjectError):
+            commands.Commit(config, {})

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 
 from commitizen import config, defaults, git
-from commitizen.exceptions import NotAGitProjectError
 
 PYPROJECT = """
 [tool.commitizen]
@@ -148,14 +147,6 @@ def test_find_git_project_root(tmpdir):
 
     with tmpdir.as_cwd() as _:
         assert git.find_git_project_root() is None
-
-
-def test_read_cfg_when_not_in_a_git_project(tmpdir):
-    with tmpdir.as_cwd() as _:
-        with pytest.raises(NotAGitProjectError) as excinfo:
-            config.read_cfg()
-
-        assert NotAGitProjectError.message in str(excinfo.value)
 
 
 class TestInilConfig:


### PR DESCRIPTION
Only Running `cz commit`, `cz bump` and `cz changelog` in a non git project will raise NotAGitProjectError
Other commands like `cz --help` will work now

#206

(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)

## Types of changes
Please put an `x` in the box that applies

- [x] **Bugfix**

## Description
**Describe what the change is**

## Checklist:
- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Steps to Test This Pull Request
1. Run `cz --help`, `cz ls`, `cz example`, `cz info`, `cz init`, `cz version`, `cz check`
2. Run `cz commit`, `cz bump`, `cz changelog` 

## Expected behavior
1. After running the first group (i.e. `cz --help `) of commands, no error should be raised.
2. After running the second group (i.e. `cz commit `) of commands, no error should be raised.

## Related Issue
#206 

## Additional context
Add any other context or screenshots about the pull request here.
