### PR TITLE
fix(bump): add changelog file into stage when running `cz bump --changelog

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 import questionary
 from packaging.version import Version
 
-from commitizen import bump, factory, git, out
+from commitizen import bump, cmd, factory, git, out
 from commitizen.commands.changelog import Changelog
 from commitizen.config import BaseConfig
 from commitizen.exceptions import (
@@ -142,7 +142,7 @@ class Bump:
             raise ExpectedExit()
 
         if self.changelog:
-            changelog = Changelog(
+            changelog_cmd = Changelog(
                 self.config,
                 {
                     "unreleased_version": new_tag_version,
@@ -150,7 +150,8 @@ class Bump:
                     "dry_run": dry_run,
                 },
             )
-            changelog()
+            changelog_cmd()
+            c = cmd.run(f"git add {changelog_cmd.file_name}")
 
         self.config.set_key("version", new_version.public)
         c = git.commit(message, args=self._get_commit_args())


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Types of changes

<!-- Please put an `x` in the box that applies -->

- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation update**
- [ ] **Other (please describe)**

## Description

<!-- Describe what the change is -->

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Steps to Test This Pull Request

<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

```sh
mkdir bump_test
cd bump_test
git init
cz init
touch some_file.txt
git add .
git commit -m "feat: added some_file"
cz bump --changelog
```

## Expected behavior

<!-- A clear and concise description of what you expected to happen -->

The `CHANGELOG.md` is added to git repo.

## Related Issue
#221 
<!-- If applicable, reference to the issue related to this pull request. -->

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
