### PR TITLE
fix(git): use double quotation mark in get_tags

### DIFF
--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -99,9 +99,9 @@ def get_commits(
 def get_tags(dateformat: str = "%Y-%m-%d") -> List[GitTag]:
     inner_delimiter = "---inner_delimiter---"
     formatter = (
-        f"'%(refname:lstrip=2){inner_delimiter}"
+        f'"%(refname:lstrip=2){inner_delimiter}'
         f"%(objectname){inner_delimiter}"
-        f"%(committerdate:format:{dateformat})'"
+        f'%(committerdate:format:{dateformat})"'
     )
     c = cmd.run(f"git tag --format={formatter} --sort=-committerdate")
     if c.err or not c.out:


### PR DESCRIPTION
this bug affects windows users, by adding a single quotation
in front of the tag


<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Types of changes

<!-- Please put an `x` in the box that applies -->

- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Refactoring**
- [ ] **Breaking change** (any change that would cause existing functionality to not work as expected)
- [ ] **Documentation update**
- [ ] **Other (please describe)**

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually

## Related Issue

Closes #240