### PR TITLE
feat(cz_check): Update to show all ill-formatted commits

### DIFF
--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -50,14 +50,17 @@ class Check:
             raise NoCommitsFoundError(f"No commit found with range: '{self.rev_range}'")
 
         pattern = self.cz.schema_pattern()
+        ill_formated_commits = []
         for commit_msg in commit_msgs:
             if not Check.validate_commit_message(commit_msg, pattern):
-                raise InvalidCommitMessageError(
-                    "commit validation: failed!\n"
-                    "please enter a commit message in the commitizen format.\n"
-                    f"commit: {commit_msg}\n"
-                    f"pattern: {pattern}"
-                )
+                ill_formated_commits.append(f"commit: {commit_msg}\n")
+        if ill_formated_commits != []:
+            raise InvalidCommitMessageError(
+                "commit validation: failed!\n"
+                "please enter a commit message in the commitizen format.\n"
+                f"{''.join(ill_formated_commits)}\n"
+                f"pattern: {pattern}"
+            )
         out.success("Commit validation: successful!")
 
     def _get_commit_messages(self):

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -76,13 +76,7 @@ class Check:
             with open(self.commit_msg_file, "r") as commit_file:
                 commit_title = commit_file.readline()
                 commit_body = commit_file.read()
-            return [
-                git.GitCommit(
-                    rev="",
-                    title=commit_title,
-                    body=commit_body,
-                )
-            ]
+            return [git.GitCommit(rev="", title=commit_title, body=commit_body)]
 
         # Get commit messages from git log (--rev-range)
         return git.get_commits(end=self.rev_range)

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -57,7 +57,7 @@ class Check:
         ]
         displayed_msgs_content = "\n".join(
             [
-                f"commit {commit.rev}: {commit.message}"
+                f'commit "{commit.rev}": "{commit.message}"'
                 for commit in ill_formated_commits
             ]
         )

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -53,11 +53,11 @@ class Check:
         ill_formated_commits = [
             commit
             for commit in commits
-            if not Check.validate_commit_message(commit["msg"], pattern)
+            if not Check.validate_commit_message(commit.message, pattern)
         ]
-        displayed_msgs_content = "".join(
+        displayed_msgs_content = "\n".join(
             [
-                f"commit {commit['rev'] or ''}: {commit['msg']}\n"
+                f"commit {commit.rev}: {commit.message}"
                 for commit in ill_formated_commits
             ]
         )
@@ -74,14 +74,18 @@ class Check:
         # Get commit message from file (--commit-msg-file)
         if self.commit_msg_file:
             with open(self.commit_msg_file, "r") as commit_file:
-                commit_msg = commit_file.read()
-            return [{"rev": None, "msg": commit_msg}]
+                commit_title = commit_file.readline()
+                commit_body = commit_file.read()
+            return [
+                git.GitCommit(
+                    rev="",
+                    title=commit_title,
+                    body=commit_body,
+                )
+            ]
 
         # Get commit messages from git log (--rev-range)
-        return [
-            {"rev": commit.rev[:8], "msg": commit.message}
-            for commit in git.get_commits(end=self.rev_range)
-        ]
+        return git.get_commits(end=self.rev_range)
 
     @staticmethod
     def validate_commit_message(commit_msg: str, pattern: str) -> bool:

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -211,13 +211,10 @@ def test_check_command_with_empty_range(config, mocker):
 
 def test_check_a_range_of_failed_git_commits(config, mocker):
     ill_formated_commits_msgs = [
-            "First commit does not follow rule",
-            "Second commit does not follow rule",
-            (
-                "Third commit does not follow rule\n"
-                "Ill-formatted commit with body"
-            )
-        ]
+        "First commit does not follow rule",
+        "Second commit does not follow rule",
+        ("Third commit does not follow rule\n" "Ill-formatted commit with body"),
+    ]
     mocker.patch(
         "commitizen.git.get_commits",
         return_value=_build_fake_git_commits(ill_formated_commits_msgs),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Update `cz check --rev-range` to show all ill-formatted commits when running batch checking

## Checklist

(Not sure if I need to add test case and update the docs)
- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
All ill-formatted commits should be displayed when running `cz check --rev-range`

## Steps to Test This Pull Request
1. Go to any repo containing ill-formatted commits
2. Run `cz check --rev-range HEAD~10..HEAD` to check if all ill-formatted commits in the range is displayed (`HEAD~10..HEAD` could be replaced with any valid argument)


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
Solve Issue #175 