### PR TITLE
feat(cz_check): cz check can read from a string input

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -195,6 +195,11 @@ data = {
                         "help": "a range of git rev to check. e.g, master..HEAD",
                         "exclusive_group": "group1",
                     },
+                    {
+                        "name": ["-m", "--message"],
+                        "help": "commit message that needs to be checked",
+                        "exclusive_group": "group1",
+                    },
                 ],
             },
             {

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -23,6 +23,7 @@ class Check:
             cwd: Current work directory
         """
         self.commit_msg_file: Optional[str] = arguments.get("commit_msg_file")
+        self.commit_msg: Optional[str] = arguments.get("message")
         self.rev_range: Optional[str] = arguments.get("rev_range")
 
         self._valid_command_argument()
@@ -31,7 +32,9 @@ class Check:
         self.cz = factory.commiter_factory(self.config)
 
     def _valid_command_argument(self):
-        if bool(self.commit_msg_file) is bool(self.rev_range):
+        if not (
+            bool(self.commit_msg_file) ^ bool(self.commit_msg) ^ bool(self.rev_range)
+        ):
             raise InvalidCommandArgumentError(
                 (
                     "One and only one argument is required for check command! "
@@ -77,6 +80,8 @@ class Check:
                 commit_title = commit_file.readline()
                 commit_body = commit_file.read()
             return [git.GitCommit(rev="", title=commit_title, body=commit_body)]
+        elif self.commit_msg:
+            return [git.GitCommit(rev="", title="", body=self.commit_msg)]
 
         # Get commit messages from git log (--rev-range)
         return git.get_commits(end=self.rev_range)

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -226,3 +226,22 @@ def test_check_a_range_of_failed_git_commits(config, mocker):
     with pytest.raises(InvalidCommitMessageError) as excinfo:
         check_cmd()
     assert all([msg in str(excinfo.value) for msg in ill_formated_commits_msgs])
+
+
+def test_check_command_with_valid_message(config, mocker):
+    success_mock = mocker.patch("commitizen.out.success")
+    check_cmd = commands.Check(
+        config=config, arguments={"message": "fix(scope): some commit message"}
+    )
+
+    check_cmd()
+    success_mock.assert_called_once()
+
+
+def test_check_command_with_invalid_message(config, mocker):
+    error_mock = mocker.patch("commitizen.out.error")
+    check_cmd = commands.Check(config=config, arguments={"message": "bad commit"})
+
+    with pytest.raises(InvalidCommitMessageError):
+        check_cmd()
+        error_mock.assert_called_once()


### PR DESCRIPTION
## Description
<!-- Describe what the change is -->
As mentioned in #200 , this PR make `cz check` can read a string input as an argument with "--message"

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
With "-m" or "--message", `cz check` checks string input as commit message.

## Steps to Test This Pull Request
1. `cz check -m COMMIT_MESSAGE`
2. `cz check --message COMMIT_MESSAGE`


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
Refer to issue #200