### PR TITLE
ci(github-action): use personal access token

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Use personal access token instead of github token, in order to trigger new events (like pthonpublish)

