### PR TITLE
feat(cz_check): cz check can read commit message from pipe

### DIFF
--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 from typing import Dict, Optional
 
 from commitizen import factory, git, out
@@ -32,9 +33,12 @@ class Check:
         self.cz = factory.commiter_factory(self.config)
 
     def _valid_command_argument(self):
-        if not (
-            bool(self.commit_msg_file) ^ bool(self.commit_msg) ^ bool(self.rev_range)
-        ):
+        sources = (
+            bool(self.commit_msg_file) + bool(self.commit_msg) + bool(self.rev_range)
+        )
+        if sources == 0 and not os.isatty(0):
+            self.commit_msg: Optional[str] = sys.stdin.read()
+        elif sources != 1:
             raise InvalidCommandArgumentError(
                 (
                     "One and only one argument is required for check command! "


### PR DESCRIPTION
## Description
As mentioned in #200, this PR makes `cz check` can read message from pipe. In this mode, "--message" option is used.


## Checklist
- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
String input from pipe can be read by `cz check`


## Steps to Test This Pull Request
1. `echo COMMIT_MESSAGE | cz check`
2. `cat COMMIT_FILE | cz check`


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
#200 