### PR TITLE
fix(#271): add annotated_tag option to bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fix
+
+- **#271**: add annotated_tag option to bump
+
 ## v2.4.0 (2020-09-18)
 
 ### Feat
@@ -97,17 +103,17 @@
 ### Fix
 
 - **commands/bump**: use `return_code` in commands used by bump
-- **commands/commit**: use return_code to raise commit error, not stderr
-
-### Refactor
-
-- **cmd**: add return code to Command
 
 ## v1.23.2 (2020-07-25)
 
 ### Fix
 
 - **bump**: add changelog file into stage when running `cz bump --changelog`
+- **commands/commit**: use return_code to raise commit error, not stderr
+
+### Refactor
+
+- **cmd**: add return code to Command
 
 ## v1.23.1 (2020-07-14)
 
@@ -124,16 +130,19 @@
 - **commands/init**: add test case and remove unaccessible code
 - **exception**: move output message related to exception into exception
 - **exception**: implement message handling mechanism for CommitizenException
-- **cli**: do not show traceback if the raised exception is CommitizenException
-- introduce DryRunExit, ExpectedExit, NoCommandFoundError, InvalidCommandArgumentError
-- use custom exception for error handling
-- **error_codes**: remove unused NO_COMMIT_MSG error code
 
 ### Feat
 
 - **cli**: enable displaying all traceback for CommitizenException when --debug flag is used
 
 ## v1.22.3 (2020-06-10)
+
+### Refactor
+
+- **cli**: do not show traceback if the raised exception is CommitizenException
+- introduce DryRunExit, ExpectedExit, NoCommandFoundError, InvalidCommandArgumentError
+- use custom exception for error handling
+- **error_codes**: remove unused NO_COMMIT_MSG error code
 
 ## v1.22.2 (2020-05-29)
 

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -131,6 +131,11 @@ data = {
                         ),
                         "action": "store_true",
                     },
+                    {
+                        "name": ["--annotated-tag", "-at"],
+                        "help": "create annotated tag instead of lightweight one",
+                        "action": "store_true",
+                    },
                 ],
             },
             {

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -31,7 +31,13 @@ class Bump:
             **config.settings,
             **{
                 key: arguments[key]
-                for key in ["tag_format", "prerelease", "increment", "bump_message"]
+                for key in [
+                    "tag_format",
+                    "prerelease",
+                    "increment",
+                    "bump_message",
+                    "annotated_tag",
+                ]
                 if arguments[key] is not None
             },
         }
@@ -157,7 +163,11 @@ class Bump:
         c = git.commit(message, args=self._get_commit_args())
         if c.return_code != 0:
             raise BumpCommitFailedError(f'git.commit error: "{c.err.strip()}"')
-        c = git.tag(new_tag_version)
+        c = git.tag(
+            new_tag_version,
+            annotated=self.bump_settings.get("annotated_tag", False)
+            or bool(self.config.settings.get("annotated_tag", False)),
+        )
         if c.return_code != 0:
             raise BumpTagFailedError(c.err)
         out.success("Done!")

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -45,8 +45,8 @@ class GitTag(GitObject):
         return f"GitTag('{self.name}', '{self.rev}', '{self.date}')"
 
 
-def tag(tag: str):
-    c = cmd.run(f"git tag {tag}")
+def tag(tag: str, annotated: bool = False):
+    c = cmd.run(f"git tag -a {tag} -m {tag}" if annotated else f"git tag {tag}")
     return c
 
 

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -54,32 +54,30 @@ Some examples:
 
 ```bash
 $ cz bump --help
-usage: cz bump [-h] [--dry-run] [--files-only] [--changelog] [--no-verify]
-               [--yes] [--tag-format TAG_FORMAT] [--bump-message BUMP_MESSAGE]
-               [--prerelease {alpha,beta,rc}]
-               [--increment {MAJOR,MINOR,PATCH}] [--check-consistency]
+usage: cz bump [-h] [--dry-run] [--files-only] [--changelog] [--no-verify] [--yes]
+               [--tag-format TAG_FORMAT] [--bump-message BUMP_MESSAGE] [--prerelease {alpha,beta,rc}]
+               [--increment {MAJOR,MINOR,PATCH}] [--check-consistency] [--annotated-tag]
 
 optional arguments:
   -h, --help            show this help message and exit
   --dry-run             show output to stdout, no commit, no modified files
   --files-only          bump version in the files from the config
   --changelog, -ch      generate the changelog for the newest version
-  --no-verify           this option bypasses the pre-commit and commit-msg
-                        hooks
+  --no-verify           this option bypasses the pre-commit and commit-msg hooks
   --yes                 accept automatically questions done
   --tag-format TAG_FORMAT
-                        the format used to tag the commit and read it, use it
-                        in existing projects, wrap around simple quotes
+                        the format used to tag the commit and read it, use it in existing projects, wrap
+                        around simple quotes
   --bump-message BUMP_MESSAGE
-                        template used to create the release commit, useful
-                        when working with CI
+                        template used to create the release commit, useful when working with CI
   --prerelease {alpha,beta,rc}, -pr {alpha,beta,rc}
                         choose type of prerelease
   --increment {MAJOR,MINOR,PATCH}
                         manually specify the desired increment
   --check-consistency, -cc
-                        check consistency among versions defined in commitizen
-                        configuration and version_files
+                        check consistency among versions defined in commitizen configuration and
+                        version_files
+  --annotated-tag, -at  create annotated tag instead of lightweight one
 ```
 
 ### `--changelog`
@@ -214,6 +212,15 @@ Some examples
 ```toml
 [tool.commitizen]
 bump_message = "release $current_version → $new_version [skip-ci]"
+```
+
+### `annotated_tag`
+
+Whether to create annotated tags or lightweight ones.
+
+```toml
+[tool.commitizen]
+annotated_tag = true
 ```
 
 ## Custom bump

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -45,7 +45,37 @@ def test_bump_minor_increment(commit_msg, mocker):
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
     tag_exists = git.tag_exist("0.2.0")
-    assert tag_exists is True
+    cmd_res = cmd.run('git for-each-ref refs/tags --format "%(objecttype):%(refname)"')
+    assert tag_exists is True and "commit:refs/tags/0.2.0\n" in cmd_res.out
+
+
+@pytest.mark.parametrize("commit_msg", ("feat: new file", "feat(user): new file"))
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_minor_increment_annotated(commit_msg, mocker):
+    create_file_and_commit(commit_msg)
+    testargs = ["cz", "bump", "--yes", "--annotated-tag"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    tag_exists = git.tag_exist("0.2.0")
+    cmd_res = cmd.run('git for-each-ref refs/tags --format "%(objecttype):%(refname)"')
+    assert tag_exists is True and "tag:refs/tags/0.2.0\n" in cmd_res.out
+
+
+@pytest.mark.parametrize("commit_msg", ("feat: new file", "feat(user): new file"))
+def test_bump_minor_increment_annotated_config_file(
+    commit_msg, mocker, tmp_commitizen_project
+):
+    tmp_commitizen_cfg_file = tmp_commitizen_project.join("pyproject.toml")
+    tmp_commitizen_cfg_file.write(
+        f"{tmp_commitizen_cfg_file.read()}\n" f"annotated_tag = 1"
+    )
+    create_file_and_commit(commit_msg)
+    testargs = ["cz", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    tag_exists = git.tag_exist("0.2.0")
+    cmd_res = cmd.run('git for-each-ref refs/tags --format "%(objecttype):%(refname)"')
+    assert tag_exists is True and "tag:refs/tags/0.2.0\n" in cmd_res.out
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")


### PR DESCRIPTION
    Enable creation of annotated tags when bumping.

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Create annotated tags, when bumping.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
With `annotated_tag` enabled commitizen will create annotated tag instead of lightweight ones.


## Steps to Test This Pull Request
Use `cz bump --annotated_tag` or `annotated_tag = 1` in config file
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
maybe related to https://github.com/commitizen-tools/commitizen/issues/261 ???