### PR TITLE
WIP: Fix/issue 251

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -139,12 +139,12 @@ data = {
                 "func": commands.Undo,
                 "arguments": [
                     {
-                        "name": ["--bump"],
+                        "name": ["--bump", "-b"],
                         "action": "store_true",
                         "help": "revert bump",
                     },
                     {
-                        "name": "--commit",
+                        "name": ["--commit", "-c"],
                         "action": "store_true",
                         "help": "revert latest commit, equal to git reset HEAD~",
                     },

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -134,6 +134,23 @@ data = {
                 ],
             },
             {
+                "name": "undo",
+                "help": "revert bump or commit",
+                "func": commands.Undo,
+                "arguments": [
+                    {
+                        "name": ["--bump"],
+                        "action": "store_true",
+                        "help": "revert bump",
+                    },
+                    {
+                        "name": "--commit",
+                        "action": "store_true",
+                        "help": "revert latest commit, equal to git reset HEAD~",
+                    },
+                ],
+            },
+            {
                 "name": ["changelog", "ch"],
                 "help": (
                     "generate changelog (note that it will overwrite existing file)"

--- a/commitizen/commands/__init__.py
+++ b/commitizen/commands/__init__.py
@@ -6,8 +6,8 @@ from .example import Example
 from .info import Info
 from .init import Init
 from .list_cz import ListCz
-from .undo import Undo
 from .schema import Schema
+from .undo import Undo
 from .version import Version
 
 __all__ = (
@@ -18,8 +18,8 @@ __all__ = (
     "Example",
     "Info",
     "ListCz",
-    "Undo",
     "Schema",
+    "Undo",
     "Version",
     "Init",
 )

--- a/commitizen/commands/__init__.py
+++ b/commitizen/commands/__init__.py
@@ -6,6 +6,7 @@ from .example import Example
 from .info import Info
 from .init import Init
 from .list_cz import ListCz
+from .undo import Undo
 from .schema import Schema
 from .version import Version
 
@@ -17,6 +18,7 @@ __all__ = (
     "Example",
     "Info",
     "ListCz",
+    "Undo",
     "Schema",
     "Version",
     "Init",

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -47,7 +47,7 @@ class Init:
     def _ask_config_path(self) -> str:
         name = questionary.select(
             "Please choose a supported config file: (default: pyproject.toml)",
-            choices=config_files,
+            choices=config_files,  # type: ignore
             default="pyproject.toml",
             style=self.cz.style,
         ).ask()
@@ -79,7 +79,7 @@ class Init:
 
             latest_tag = questionary.select(
                 "Please choose the latest tag: ",
-                choices=get_tag_names(),
+                choices=get_tag_names(),  # type: ignore
                 style=self.cz.style,
             ).ask()
 

--- a/commitizen/commands/undo.py
+++ b/commitizen/commands/undo.py
@@ -1,0 +1,51 @@
+from commitizen import factory, out, cmd, git
+from commitizen.config import BaseConfig
+from commitizen.exceptions import (
+    InvalidCommandArgumentError
+)
+
+
+class Undo:
+    """  """
+
+    def __init__(self, config: BaseConfig, arguments: dict):
+        self.config: BaseConfig = config
+        self.cz = factory.commiter_factory(self.config)
+        self.arguments = arguments
+
+    def _get_bump_command(self):
+        latest_tag = git.get_tags()[0]
+        latest_commit = git.get_commits()[0]
+
+        if latest_tag.rev != latest_commit.rev:
+            raise InvalidCommandArgumentError(
+                "The revision of the latest tag is not equal to the latest commit, use git undo --commit instead\n\n"
+                f"Latest Tag: {latest_tag.name}, {latest_tag.rev}, {latest_tag.date}\n"
+                f"Latest Commit: {latest_commit.title}, {latest_commit.rev}"
+            )
+
+        created_tag = git.get_latest_tag_name()
+        command = f"git tag --delete {created_tag} && git reset HEAD~ && git reset --hard HEAD"
+
+        return command
+
+    def __call__(self):
+        bump: bool = self.arguments.get("bump")
+        commit: bool = self.arguments.get("commit")
+
+        if bump:
+            command = self._get_bump_command()
+        elif commit:
+            command = "git reset HEAD~"
+        else:
+            raise InvalidCommandArgumentError(
+                (
+                    "One and only one argument is required for check command! "
+                    "See 'cz undo -h' for more information"
+                )
+            )
+
+        c = cmd.run(command)
+        if c.err:
+            return None
+        return c.out.strip()

--- a/commitizen/commands/undo.py
+++ b/commitizen/commands/undo.py
@@ -31,7 +31,9 @@ class Undo:
 
         out.info("Reverting version bump, running:")
         out.info(f"{command}")
-        out.info(f"The tag can be removed from a remote by running `git push origin :{created_tag.name}`")
+        out.info(
+            f"The tag can be removed from a remote by running `git push origin :{created_tag.name}`"
+        )
 
         return command
 

--- a/commitizen/commands/undo.py
+++ b/commitizen/commands/undo.py
@@ -4,7 +4,7 @@ from commitizen.exceptions import InvalidCommandArgumentError
 
 
 class Undo:
-    """  """
+    """Reset the latest git commit or git tag."""
 
     def __init__(self, config: BaseConfig, arguments: dict):
         self.config: BaseConfig = config
@@ -13,7 +13,10 @@ class Undo:
 
     def _get_bump_command(self):
         created_tag = git.get_latest_tag()
-        created_commit = git.get_commits()[0]
+        commits = git.get_commits()
+
+        if created_tag and commits:
+            created_commit = commits[0]
 
         if created_tag.rev != created_commit.rev:
             raise InvalidCommandArgumentError(

--- a/commitizen/commands/undo.py
+++ b/commitizen/commands/undo.py
@@ -1,8 +1,6 @@
-from commitizen import factory, out, cmd, git
+from commitizen import cmd, factory, git, out
 from commitizen.config import BaseConfig
-from commitizen.exceptions import (
-    InvalidCommandArgumentError
-)
+from commitizen.exceptions import InvalidCommandArgumentError
 
 
 class Undo:
@@ -14,17 +12,16 @@ class Undo:
         self.arguments = arguments
 
     def _get_bump_command(self):
-        latest_tag = git.get_tags()[0]
-        latest_commit = git.get_commits()[0]
+        created_tag = git.get_tags()[0]
+        created_commit = git.get_commits()[0]
 
-        if latest_tag.rev != latest_commit.rev:
+        if created_tag.rev != created_commit.rev:
             raise InvalidCommandArgumentError(
                 "The revision of the latest tag is not equal to the latest commit, use git undo --commit instead\n\n"
-                f"Latest Tag: {latest_tag.name}, {latest_tag.rev}, {latest_tag.date}\n"
-                f"Latest Commit: {latest_commit.title}, {latest_commit.rev}"
+                f"Latest Tag: {created_tag.name}, {created_tag.rev}, {created_tag.date}\n"
+                f"Latest Commit: {created_commit.title}, {created_commit.rev}"
             )
 
-        created_tag = git.get_latest_tag_name()
         command = f"git tag --delete {created_tag} && git reset HEAD~ && git reset --hard HEAD"
 
         return command

--- a/commitizen/commands/undo.py
+++ b/commitizen/commands/undo.py
@@ -29,6 +29,10 @@ class Undo:
 
         command = f"git tag --delete {created_tag.name} && git reset HEAD~ && git reset --hard HEAD"
 
+        out.info("Reverting version bump, running:")
+        out.info(f"{command}")
+        out.info(f"The tag can be removed from a remote by running `git push origin :{created_tag.name}`")
+
         return command
 
     def __call__(self):

--- a/commitizen/commands/undo.py
+++ b/commitizen/commands/undo.py
@@ -17,6 +17,8 @@ class Undo:
 
         if created_tag and commits:
             created_commit = commits[0]
+        else:
+            raise InvalidCommandArgumentError("There is no tag or commit to undo")
 
         if created_tag.rev != created_commit.rev:
             raise InvalidCommandArgumentError(

--- a/commitizen/commands/undo.py
+++ b/commitizen/commands/undo.py
@@ -12,7 +12,7 @@ class Undo:
         self.arguments = arguments
 
     def _get_bump_command(self):
-        created_tag = git.get_tags()[0]
+        created_tag = git.get_latest_tag()
         created_commit = git.get_commits()[0]
 
         if created_tag.rev != created_commit.rev:
@@ -22,7 +22,7 @@ class Undo:
                 f"Latest Commit: {created_commit.title}, {created_commit.rev}"
             )
 
-        command = f"git tag --delete {created_tag} && git reset HEAD~ && git reset --hard HEAD"
+        command = f"git tag --delete {created_tag.name} && git reset HEAD~ && git reset --hard HEAD"
 
         return command
 
@@ -44,5 +44,7 @@ class Undo:
 
         c = cmd.run(command)
         if c.err:
-            return None
-        return c.out.strip()
+            out.error(c.err)
+
+        out.write(c.out)
+        out.success("Undo successful!")

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -138,7 +138,7 @@ def get_latest_tag() -> Optional[GitTag]:
     return tags[latest_tag_index]
 
 
-def get_tag_names() -> Optional[List[str]]:
+def get_tag_names() -> List[Optional[str]]:
     c = cmd.run("git tag --list")
     if c.err:
         return []

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -123,9 +123,12 @@ def get_latest_tag_name() -> Optional[str]:
     return c.out.strip()
 
 
-def get_latest_tag() -> GitTag:
-    latest_tag_name = get_latest_tag_name()
+def get_latest_tag() -> Optional[GitTag]:
     tags = get_tags()
+    latest_tag_name = get_latest_tag_name()
+
+    if not tags or not latest_tag_name:
+        return None
 
     if tags[0].name == latest_tag_name:
         return tags[0]

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -123,6 +123,18 @@ def get_latest_tag_name() -> Optional[str]:
     return c.out.strip()
 
 
+def get_latest_tag() -> GitTag:
+    latest_tag_name = get_latest_tag_name()
+    tags = get_tags()
+
+    if tags[0].name == latest_tag_name:
+        return tags[0]
+
+    tag_names = [tag.name for tag in tags]
+    latest_tag_index = tag_names.index(latest_tag_name)
+    return tags[latest_tag_index]
+
+
 def get_tag_names() -> Optional[List[str]]:
     c = cmd.run("git tag --list")
     if c.err:

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ versions](https://img.shields.io/pypi/pyversions/commitizen.svg?style=flat-squar
 
 ---
 
-**Documentation**: https://commitizen-tools.github.io/
+**Documentation**: https://commitizen-tools.github.io/commitizen/
 
 ---
 
@@ -105,7 +105,7 @@ Read more about the `check` command [here](https://commitizen-tools.github.io/co
 ```bash
 $ cz --help
 usage: cz [-h] [--debug] [-n NAME] [--version]
-          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
+          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version,undo}
           ...
 
 Commitizen is a cli tool to generate conventional commits.
@@ -119,7 +119,7 @@ optional arguments:
   --version             get the version of the installed commitizen
 
 commands:
-  {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
+  {init,commit,c,ls,example,info,schema,bump,undo,changelog,ch,check,version}
     init                init commitizen configuration
     commit (c)          create new commit
     ls                  show available commitizens
@@ -127,6 +127,7 @@ commands:
     info                show information about the cz
     schema              show commit schema
     bump                bump semantic version based on the git log
+    undo                revert the latest bump or commit
     changelog (ch)      generate changelog (note that it will overwrite
                         existing file)
     check               validates that a commit message matches the commitizen

--- a/tests/commands/test_undo_command.py
+++ b/tests/commands/test_undo_command.py
@@ -54,7 +54,7 @@ def test_undo_bump(config, mocker):
     _execute_command(mocker, ["cz", "bump", "--prerelease", "alpha"])
     _undo_bump(mocker, 1)
 
-    # # PRERELEASE BUMP CREATES VERSION WITHOUT PRERELEASE
+    # PRERELEASE BUMP CREATES VERSION WITHOUT PRERELEASE
     create_file_and_commit("feat: location")
     _execute_command(mocker, ["cz", "bump", "--prerelease", "alpha"])
     _execute_command(mocker, ["cz", "bump"])

--- a/tests/commands/test_undo_command.py
+++ b/tests/commands/test_undo_command.py
@@ -1,0 +1,6 @@
+from commitizen import factory, out, cmd, git
+from commitizen.config import BaseConfig
+from commitizen.exceptions import (
+    InvalidCommandArgumentError
+)
+

--- a/tests/commands/test_undo_command.py
+++ b/tests/commands/test_undo_command.py
@@ -2,8 +2,7 @@ import sys
 
 import pytest
 
-from commitizen import cli, cmd, commands, git
-from commitizen.exceptions import InvalidCommandArgumentError
+from commitizen import cli, git
 from tests.utils import create_file_and_commit
 
 
@@ -29,14 +28,9 @@ def _execute_command(mocker, testargs):
 
 def _undo_bump(mocker, tag_num: int = 0):
     testargs = ["cz", "undo", "--bump"]
-    tags = git.get_tags()
-    print(tags)
     _execute_command(mocker, testargs)
 
     tags = git.get_tags()
-    print(tags)
-    print(git.get_commits())
-
     assert len(tags) == tag_num
 
 

--- a/tests/commands/test_undo_command.py
+++ b/tests/commands/test_undo_command.py
@@ -1,6 +1,74 @@
-from commitizen import factory, out, cmd, git
-from commitizen.config import BaseConfig
-from commitizen.exceptions import (
-    InvalidCommandArgumentError
-)
+import sys
 
+import pytest
+
+from commitizen import cli, cmd, commands, git
+from commitizen.exceptions import InvalidCommandArgumentError
+from tests.utils import create_file_and_commit
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_undo_commit(config, mocker):
+    create_file_and_commit("feat: new file")
+    # We can not revert the first commit, thus we commit twice.
+    create_file_and_commit("feat: extra file")
+
+    testargs = ["cz", "undo", "--commit"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    commits = git.get_commits()
+
+    assert len(commits) == 1
+
+
+def _execute_command(mocker, testargs):
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+
+def _undo_bump(mocker, tag_num: int = 0):
+    testargs = ["cz", "undo", "--bump"]
+    tags = git.get_tags()
+    print(tags)
+    _execute_command(mocker, testargs)
+
+    tags = git.get_tags()
+    print(tags)
+    print(git.get_commits())
+
+    assert len(tags) == tag_num
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_undo_bump(config, mocker):
+    # MINOR
+    create_file_and_commit("feat: new file")
+    _execute_command(mocker, ["cz", "bump", "--yes"])
+    _undo_bump(mocker)
+
+    # PATCH
+    create_file_and_commit("feat: new file")
+    _execute_command(mocker, ["cz", "bump", "--yes"])
+
+    create_file_and_commit("fix: username exception")
+    _execute_command(mocker, ["cz", "bump"])
+    _undo_bump(mocker, 1)
+
+    # PRERELEASE
+    create_file_and_commit("feat: location")
+    _execute_command(mocker, ["cz", "bump", "--prerelease", "alpha"])
+    _undo_bump(mocker, 1)
+
+    # # PRERELEASE BUMP CREATES VERSION WITHOUT PRERELEASE
+    create_file_and_commit("feat: location")
+    _execute_command(mocker, ["cz", "bump", "--prerelease", "alpha"])
+    _execute_command(mocker, ["cz", "bump"])
+    _undo_bump(mocker, 2)
+
+    # MAJOR
+    create_file_and_commit(
+        "feat: new user interface\n\nBREAKING CHANGE: age is no longer supported"
+    )
+    _execute_command(mocker, ["cz", "bump"])
+    _undo_bump(mocker, 2)


### PR DESCRIPTION
## Description
Follow the discussion of #251, I add the following command. 
```
$ cz undo -h
$ cz undo --bump
$ cz undo --commit
```
## Checklist
- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes
## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
`cz undo --bump`: delete the latest tag and the related commit
`cz undo --commit`: reset the latest commit
## Steps to Test This Pull Request
`cz undo --bump`
1. run `cz bump`
2. run `cz undo --bump`
`cz undo --commit`
1. run `cz commit`
2. run `cz undo --commit`
## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
If I execute the following statements first,  the `git.get_tags()` would get the tags order by `[0.3.0a0, 0.3.0, ...]`.
![image](https://user-images.githubusercontent.com/7900936/95214168-32da2700-0822-11eb-9cc4-c03820c203a8.png)
![image](https://user-images.githubusercontent.com/7900936/95213387-581a6580-0821-11eb-9cdc-4bf248f62d83.png)
![image](https://user-images.githubusercontent.com/7900936/95213732-b47d8500-0821-11eb-9756-2fbfe30748c2.png)
So I implement another function `git.get_latest_tag()`