### PR TITLE
fix(commands/bump): Add NoneIncrementExit to avoid git fatal error

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -109,7 +109,6 @@ class Bump:
         if increment is None:
             increment = self.find_increment(commits)
 
-
         # Increment is removed when current and next version
         # are expected to be prereleases.
         if prerelease and current_version_instance.is_prerelease:

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -12,6 +12,7 @@ from commitizen.exceptions import (
     DryRunExit,
     ExpectedExit,
     NoCommitsFoundError,
+    NoneIncrementExit,
     NoPatternMapError,
     NotAGitProjectError,
     NoVersionSpecifiedError,
@@ -108,6 +109,12 @@ class Bump:
         if increment is None:
             increment = self.find_increment(commits)
 
+            # if increment != 'PATCH' and increment != 'MINOR':
+            #    if increment != 'MAJOR':
+            #        import ipdb; ipdb.set_trace()
+
+            # git.tag_exist()
+
         # Increment is removed when current and next version
         # are expected to be prereleases.
         if prerelease and current_version_instance.is_prerelease:
@@ -117,6 +124,7 @@ class Bump:
             current_version, increment, prerelease=prerelease
         )
         new_tag_version = bump.create_tag(new_version, tag_format=tag_format)
+
         message = bump.create_commit_message(
             current_version, new_version, bump_commit_message
         )
@@ -127,6 +135,9 @@ class Bump:
             f"tag to create: {new_tag_version}\n"
             f"increment detected: {increment}\n"
         )
+
+        if increment is None and new_tag_version == current_tag_version:
+            raise NoneIncrementExit()
 
         # Do not perform operations over files or git.
         if dry_run:
@@ -157,6 +168,7 @@ class Bump:
         c = git.commit(message, args=self._get_commit_args())
         if c.return_code != 0:
             raise BumpCommitFailedError(f'git.commit error: "{c.err.strip()}"')
+
         c = git.tag(new_tag_version)
         if c.return_code != 0:
             raise BumpTagFailedError(c.err)

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -109,11 +109,6 @@ class Bump:
         if increment is None:
             increment = self.find_increment(commits)
 
-            # if increment != 'PATCH' and increment != 'MINOR':
-            #    if increment != 'MAJOR':
-            #        import ipdb; ipdb.set_trace()
-
-            # git.tag_exist()
 
         # Increment is removed when current and next version
         # are expected to be prereleases.
@@ -124,7 +119,6 @@ class Bump:
             current_version, increment, prerelease=prerelease
         )
         new_tag_version = bump.create_tag(new_version, tag_format=tag_format)
-
         message = bump.create_commit_message(
             current_version, new_version, bump_commit_message
         )
@@ -168,7 +162,6 @@ class Bump:
         c = git.commit(message, args=self._get_commit_args())
         if c.return_code != 0:
             raise BumpCommitFailedError(f'git.commit error: "{c.err.strip()}"')
-
         c = git.tag(new_tag_version)
         if c.return_code != 0:
             raise BumpTagFailedError(c.err)

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -47,7 +47,7 @@ class Init:
     def _ask_config_path(self) -> str:
         name = questionary.select(
             "Please choose a supported config file: (default: pyproject.toml)",
-            choices=config_files,
+            choices=config_files,  # type: ignore
             default="pyproject.toml",
             style=self.cz.style,
         ).ask()
@@ -79,7 +79,7 @@ class Init:
 
             latest_tag = questionary.select(
                 "Please choose the latest tag: ",
-                choices=get_tag_names(),
+                choices=get_tag_names(),  # type: ignore
                 style=self.cz.style,
             ).ask()
 

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -53,6 +53,10 @@ class DryRunExit(ExpectedExit):
     pass
 
 
+class NoneIncrementExit(ExpectedExit):
+    ...
+
+
 class NoCommitizenFoundException(CommitizenException):
     exit_code = ExitCode.NO_COMMITIZEN_FOUND
 

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -54,7 +54,7 @@ class DryRunExit(ExpectedExit):
 
 
 class NoneIncrementExit(ExpectedExit):
-    ...
+    pass
 
 
 class NoCommitizenFoundException(CommitizenException):

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -123,7 +123,7 @@ def get_latest_tag_name() -> Optional[str]:
     return c.out.strip()
 
 
-def get_tag_names() -> Optional[List[str]]:
+def get_tag_names() -> List[Optional[str]]:
     c = cmd.run("git tag --list")
     if c.err:
         return []

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import pytest
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,3 +1,6 @@
+import inspect
+from typing import List, Optional, Union
+
 import pytest
 
 from commitizen import git
@@ -68,3 +71,9 @@ def test_get_commits_author_and_email():
 
     assert commit.author is not ""
     assert "@" in commit.author_email
+
+
+def test_get_tag_names_has_correct_arrow_annotation():
+    arrow_annotation = inspect.getfullargspec(git.get_tag_names).annotations["return"]
+
+    assert arrow_annotation == List[Optional[str]]


### PR DESCRIPTION
… creating existing tag

raises NoneIncrementExit if `increment is None and new_tag_version == current_tag_version`

closes #280 

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes


## Expected behavior

Not raising git fatal error (please see #280 )


## Steps to Test This Pull Request

1. commit a test, ci, build or doc w/ `cz c`
2. run `cz bump`
3. **no** fatal error will occur


