### PR TITLE
Add ability to create changelog on bump

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -37,7 +37,9 @@ class Bump:
             },
         }
         self.cz = factory.commiter_factory(self.config)
-        self.changelog = arguments["changelog"]
+        self.changelog = arguments["changelog"] or self.config.settings.get(
+            "update_changelog_on_bump"
+        )
         self.no_verify = arguments["no_verify"]
         self.check_consistency = arguments["check_consistency"]
 

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -13,6 +13,7 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
     "changelog_file": "CHANGELOG.md",
     "changelog_incremental": False,
     "changelog_start_rev": None,
+    "update_changelog_on_bump": False,
 }
 
 MAJOR = "MAJOR"

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -216,6 +216,19 @@ Some examples
 bump_message = "release $current_version → $new_version [skip-ci]"
 ```
 
+---
+
+### `update_changelog_on_bump`
+
+When set to `true` the changelog is always updated incrementally when running `cz bump`, so the user does not have to provide the `--changelog` flag every time.
+
+defaults to: `false`
+
+```toml
+[tool.commitizen]
+update_changelog_on_bump = true
+```
+
 ## Custom bump
 
 Read the [customizing section](./customization.md).

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from commitizen import defaults
@@ -9,3 +11,13 @@ def config():
     _config = BaseConfig()
     _config.settings.update({"name": defaults.name})
     return _config
+
+
+@pytest.fixture()
+def changelog_path() -> str:
+    return os.path.join(os.getcwd(), "CHANGELOG.md")
+
+
+@pytest.fixture()
+def config_path() -> str:
+    return os.path.join(os.getcwd(), "pyproject.toml")

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -301,3 +301,36 @@ def test_none_increment_should_not_call_git_tag(mocker, tmp_commitizen_project):
 
     # restore pop stashed
     git.tag = stashed_git_tag
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_with_changelog_arg(mocker, changelog_path):
+    create_file_and_commit("feat(user): new file")
+    testargs = ["cz", "bump", "--yes", "--changelog"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    tag_exists = git.tag_exist("0.2.0")
+    assert tag_exists is True
+
+    with open(changelog_path, "r") as f:
+        out = f.read()
+    assert out.startswith("#")
+    assert "0.2.0" in out
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_with_changelog_config(mocker, changelog_path, config_path):
+    create_file_and_commit("feat(user): new file")
+    with open(config_path, "a") as fp:
+        fp.write("update_changelog_on_bump = true\n")
+
+    testargs = ["cz", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    tag_exists = git.tag_exist("0.2.0")
+    assert tag_exists is True
+
+    with open(changelog_path, "r") as f:
+        out = f.read()
+    assert out.startswith("#")
+    assert "0.2.0" in out

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from datetime import date
 
@@ -13,16 +12,6 @@ from commitizen.exceptions import (
     NotAGitProjectError,
 )
 from tests.utils import create_file_and_commit
-
-
-@pytest.fixture()
-def changelog_path() -> str:
-    return os.path.join(os.getcwd(), "CHANGELOG.md")
-
-
-@pytest.fixture()
-def config_path() -> str:
-    return os.path.join(os.getcwd(), "pyproject.toml")
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -34,6 +34,7 @@ _settings = {
     "changelog_file": "CHANGELOG.md",
     "changelog_incremental": False,
     "changelog_start_rev": None,
+    "update_changelog_on_bump": False,
 }
 
 _new_settings = {
@@ -46,6 +47,7 @@ _new_settings = {
     "changelog_file": "CHANGELOG.md",
     "changelog_incremental": False,
     "changelog_start_rev": None,
+    "update_changelog_on_bump": False,
 }
 
 _read_settings = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
As described in #290, this adds the ability to set `update_changelog_on_bump = true` in the config file, and Commitizen will automatically update the changelog when running `cz bump`, even if the `--changelog` flag is not added.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
When setting `update_changelog_on_bump = true` `cz bump` will always update the changelog. When running `cz bump --no-changelog` that setting is overridden and the changelog is _not_ updated.


## Steps to Test This Pull Request

1. add `update_changelog_on_bump = true` to `pyproject.toml`/`.cz.toml`
2. add changes and commit them as feat/fix
3. run `cz bump`
4. have changelog updated _and_ version bumped


## Additional context

#290 

---

Let me know if you want any changes to be done to wording or implementation.
