### PR TITLE
Add changelog argument options

### DIFF
--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -29,11 +29,15 @@ class Changelog:
         self.config: BaseConfig = config
         self.cz = factory.commiter_factory(self.config)
 
-        self.start_rev = args.get("start_rev")
+        self.start_rev = args.get("start_rev") or self.config.settings.get(
+            "changelog_start_rev"
+        )
         self.file_name = args.get("file_name") or self.config.settings.get(
             "changelog_file"
         )
-        self.incremental = args["incremental"]
+        self.incremental = args["incremental"] or self.config.settings.get(
+            "changelog_incremental"
+        )
         self.dry_run = args["dry_run"]
         self.unreleased_version = args["unreleased_version"]
         self.change_type_map = (

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -11,6 +11,8 @@ DEFAULT_SETTINGS: Dict[str, Any] = {
     "tag_format": None,  # example v$version
     "bump_message": None,  # bumped v$current_version to $new_version
     "changelog_file": "CHANGELOG.md",
+    "changelog_incremental": False,
+    "changelog_start_rev": None,
 }
 
 MAJOR = "MAJOR"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -114,6 +114,8 @@ cz changelog --file-name="CHANGES.md"
 
 ### `incremental`
 
+This flag can be set in the `toml` file with the key `changelog_incremental` under `tools.commitizen`
+
 Benefits:
 
 - Build from latest version found in changelog, this is useful if you have a different changelog and want to use commitizen
@@ -122,6 +124,28 @@ Benefits:
 
 ```bash
 cz changelog --incremental
+```
+
+```toml
+[tools.commitizen]
+# ...
+changelog_incremental = true
+```
+
+### `start-rev`
+
+This value can be set in the `toml` file with the key `changelog_start_rev` under `tools.commitizen`
+
+Start from a given git rev to generate the changelog. Commits before that rev will not be considered. This is especially useful for long-running projects adopting conventional commits, where old commit messages might fail to be parsed for changelog generation.
+
+```bash
+cz changelog --start-rev="v0.2.0"
+```
+
+```toml
+[tools.commitizen]
+# ...
+changelog_start_rev = "v0.2.0"
 ```
 
 ## Hooks

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -32,6 +32,8 @@ _settings = {
     "version_files": ["commitizen/__version__.py", "pyproject.toml"],
     "style": [["pointer", "reverse"], ["question", "underline"]],
     "changelog_file": "CHANGELOG.md",
+    "changelog_incremental": False,
+    "changelog_start_rev": None,
 }
 
 _new_settings = {
@@ -42,6 +44,8 @@ _new_settings = {
     "version_files": ["commitizen/__version__.py", "pyproject.toml"],
     "style": [["pointer", "reverse"], ["question", "underline"]],
     "changelog_file": "CHANGELOG.md",
+    "changelog_incremental": False,
+    "changelog_start_rev": None,
 }
 
 _read_settings = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
As described in #291, this adds config options for the changelog arguments `--incremental` and `--start-rev` to commitizen.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
* With `changelog_incremental = true` in the config file, commitizen will only ever attempt incremental changelog updates.
* With `changelog_start_rev = <rev>` in the config file, commitizen will always update the changelog starting from the given rev.

## Steps to Test This Pull Request

**changelog_incremental**

1. Add `changelog_incremental = true` to `pyproject.toml`/`.cz.toml`
2. add e.g. a custom preamble to the changelog
2. add changes and commit them as feat/fix
3. run `cz changelog`
4. have changelog updated and the preamble kept intact

**changelog_start_rev**
1. add changes and commit them as feat/fix
1. add changes and commit them as feat/fix and note rev
1. Add `changelog_start_rev = <rev>` to `pyproject.toml`/`.cz.toml` where <rev> is the noted rev from the second commit
1. run `cz changelog` and see the first commit not being added as an entry to changelog

## Additional context

#291 
