### PR TITLE
feat: allow files-only to set config version and create changelog

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -148,8 +148,6 @@ class Bump:
             version_files,
             check_consistency=self.check_consistency,
         )
-        if is_files_only:
-            raise ExpectedExit()
 
         if self.changelog:
             changelog_cmd = Changelog(
@@ -164,6 +162,10 @@ class Bump:
             c = cmd.run(f"git add {changelog_cmd.file_name}")
 
         self.config.set_key("version", str(new_version))
+
+        if is_files_only:
+            raise ExpectedExit()
+
         c = git.commit(message, args=self._get_commit_args())
         if c.return_code != 0:
             raise BumpCommitFailedError(f'git.commit error: "{c.err.strip()}"')

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -83,6 +83,14 @@ optional arguments:
                         configuration and version_files
 ```
 
+### `--files-only`
+
+Bumps the version in the files defined in `version_files` without creating a commit and tag on the git repository,
+
+```bash
+cz bump --files-only
+```
+
 ### `--changelog`
 
 Generate a **changelog** along with the new version and tag when bumping.

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -242,6 +242,9 @@ def test_bump_files_only(mocker, tmp_commitizen_project):
     with open(tmp_version_file, "r") as f:
         assert "0.3.0" in f.read()
 
+    with open(tmp_commitizen_cfg_file, "r") as f:
+        assert "0.3.0" in f.read()
+
 
 def test_bump_local_version(mocker, tmp_commitizen_project):
     tmp_version_file = tmp_commitizen_project.join("__version__.py")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
This PR allows the command `bump` with the flag `--files-only` to update the version in the configuration file and to create the changelog if the flag was passed. 

The current behavior exits the program before those 2 actions happen. 

## Checklist

- NA Add test cases to all the changes you introduce
- [X] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [X] Update the documentation for the changes

## Expected behavior
The version in the configuration file will be updated and the changelog will be created (if flag passed) when using `bump --files-only`, changing the current behavior. 


## Steps to Test This Pull Request
1. run `cz bump --files-only --changelog`
2. check if the version was updated file `pyproject.toml` or `.cz.toml`. 
3. check if the changelog was actually created.


## Additional context
Related issue: #298 
