### PR TITLE
Provide shell completion for cz

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -3,6 +3,7 @@ import logging
 import sys
 from functools import partial
 
+import argcomplete
 from decli import cli
 
 from commitizen import commands, config
@@ -265,6 +266,7 @@ def main():
     conf = config.read_cfg()
     parser = cli(data)
 
+    argcomplete.autocomplete(parser)
     # Show help if no arg provided
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)

--- a/docs/README.md
+++ b/docs/README.md
@@ -144,6 +144,32 @@ commands:
                         current project (default: installed commitizen)
 ```
 
+## Setting up bash completion
+
+When using bash as your shell (limited support for zsh, fish, and tcsh is available), Commitizen can use [argcomplete](https://kislyuk.github.io/argcomplete/) for auto-completion. For this argcomplete needs to be enabled.
+
+argcomplete is installed when you install Commitizen since it's a dependency.
+
+If Commitizen is installed globally, global activation can be executed:
+
+```bash
+sudo activate-global-python-argcomplete
+```
+
+For permanent (but not global) Commitizen activation, use:
+
+```bash
+register-python-argcomplete cz >> ~/.bashrc
+```
+
+For one-time activation of argcomplete for Commitizen only, use:
+
+```bash
+eval "$(register-python-argcomplete cz)"
+```
+
+For further information on activation, please visit the [argcomplete website](https://kislyuk.github.io/argcomplete/).
+
 ## Third-Party Commitizen Templates
 
 See [Third-Party Commitizen Templates](third-party-commitizen.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ packaging = ">=19,<21"
 tomlkit = "^0.5.3"
 jinja2 = "^2.10.3"
 pyyaml = ">=3.08"
+argcomplete = "^1.12.1"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.2"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
-import sys
 import subprocess
+import sys
 
 import pytest
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import sys
+import subprocess
 
 import pytest
 
@@ -78,3 +79,16 @@ def test_commitizen_debug_excepthook(capsys):
     assert excinfo.type == SystemExit
     assert excinfo.value.code == NotAGitProjectError.exit_code
     assert "NotAGitProjectError" in str(excinfo.traceback[0])
+
+
+def test_argcomplete_activation():
+    """
+    This function is testing the one-time activation of argcomplete for
+    commitizen only.
+
+    Equivalent to run:
+    $ eval "$(register-python-argcomplete pytest)"
+    """
+    output = subprocess.run(["register-python-argcomplete", "cz"])
+
+    assert output.returncode == 0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
As mentioned in #137 , this PR add auto-completion to cz using argcomplete

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
If the proper [activation](https://kislyuk.github.io/argcomplete/) is set, the auto-completion can performed just by pressing the 
tab key.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ... Activate the virtual environment provided by the project/Poetry
2. ...Run 
3. ... -->
1. Run the tests
2. Activate the virtual environment provided by the project/Poetry
3. Activate the auto-completion. For one-time activation of argcomplete for Commitizen only, use: 
**$ eval "$(register-python-argcomplete cz)"**
4. Type incomplete commands and flags from Commitizen and just pres the tab key.
 
## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
Related to #137 