### PR TITLE
fix: prevent prerelase from creating a bump when there are no commits

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -112,6 +112,19 @@ class Bump:
         if increment is None:
             increment = self.find_increment(commits)
 
+        # It may happen that there are commits, but they are not elegible
+        # for an increment, this generates a problem when using prerelease (#281)
+        if (
+            prerelease
+            and increment is None
+            and not current_version_instance.is_prerelease
+        ):
+            raise NoCommitsFoundError(
+                "[NO_COMMITS_FOUND]\n"
+                "No commits found to generate a pre-release.\n"
+                "To avoid this error, manually specify the type of increment with `--increment`"
+            )
+
         # Increment is removed when current and next version
         # are expected to be prereleases.
         if prerelease and current_version_instance.is_prerelease:
@@ -123,6 +136,7 @@ class Bump:
             prerelease=prerelease,
             is_local_version=is_local_version,
         )
+
         new_tag_version = bump.create_tag(new_version, tag_format=tag_format)
         message = bump.create_commit_message(
             current_version, new_version, bump_commit_message


### PR DESCRIPTION
Closes #281

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually

## Steps to Test This Pull Request
Described in the issue

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->

This issue can only be triggered if there are commits but they are not elegible for an increment.
- let's say tag exists `0.1.0`
- a new commit is created "ci: update job name"
- `cz bumo -pr alpha` is executed
- commitizen will find commits, but no increment, thus triggering the bug that happens afterwards.
