### PR TITLE
Add json support for config

### DIFF
--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -6,7 +6,7 @@ from packaging.version import Version
 
 from commitizen import cmd, factory, out
 from commitizen.__version__ import __version__
-from commitizen.config import BaseConfig, TomlConfig
+from commitizen.config import BaseConfig, JsonConfig, TomlConfig
 from commitizen.cz import registry
 from commitizen.defaults import config_files
 from commitizen.exceptions import NoAnswersError
@@ -26,6 +26,8 @@ class Init:
             config_path = self._ask_config_path()
             if "toml" in config_path:
                 self.config = TomlConfig(data="", path=config_path)
+            elif "json" in config_path:
+                self.config = JsonConfig(data="{}", path=config_path)
 
             self.config.init_empty_config_content()
 

--- a/commitizen/config/__init__.py
+++ b/commitizen/config/__init__.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+from typing import Union
 
 from commitizen import defaults, git
 
 from .base_config import BaseConfig
+from .json_config import JsonConfig
 from .toml_config import TomlConfig
 
 
@@ -26,9 +28,12 @@ def read_cfg() -> BaseConfig:
         with open(filename, "r") as f:
             data: str = f.read()
 
-        _conf: TomlConfig
+        _conf: Union[TomlConfig, JsonConfig]
         if "toml" in filename.suffix:
             _conf = TomlConfig(data=data, path=filename)
+
+        if "json" in filename.suffix:
+            _conf = JsonConfig(data=data, path=filename)
 
         if _conf.is_empty_config:
             continue

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -14,7 +14,7 @@ class JsonConfig(BaseConfig):
 
     def init_empty_config_content(self):
         with open(self.path, "a") as json_file:
-            json.dump({"commitizen": ""}, json_file)
+            json.dump({"commitizen": {}}, json_file)
 
     def set_key(self, key, value):
         """Set or update a key in the conf.

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+from typing import Union
+
+from .base_config import BaseConfig
+
+
+class JsonConfig(BaseConfig):
+    def __init__(self, *, data: str, path: Union[Path, str]):
+        super(JsonConfig, self).__init__()
+        self.is_empty_config = False
+        self._parse_setting(data)
+        self.add_path(path)
+
+    def init_empty_config_content(self):
+        with open(self.path, "a") as json_file:
+            json.dump({"commitizen": ""}, json_file)
+
+    def set_key(self, key, value):
+        """Set or update a key in the conf.
+
+        For now only strings are supported.
+        We use to update the version number.
+        """
+        with open(self.path, "r") as f:
+            parser = json.load(f)
+
+        parser["commitizen"][key] = value
+        with open(self.path, "w") as f:
+            json.dump(parser, f)
+        return self
+
+    def _parse_setting(self, data: str):
+        """We expect to have a section in .cz.json looking like
+
+        ```
+        {
+            "commitizen": {
+                "name": "cz_conventional_commits"
+            }
+        }
+        ```
+        """
+        doc = json.loads(data)
+        try:
+            self.settings.update(doc["commitizen"])
+        except KeyError:
+            self.is_empty_config = True

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from typing import Any, Dict, List
 
 name: str = "cz_conventional_commits"
-config_files: List[str] = ["pyproject.toml", ".cz.toml"]
+config_files: List[str] = ["pyproject.toml", ".cz.toml", ".cz.json", "cz.json"]
 
 DEFAULT_SETTINGS: Dict[str, Any] = {
     "name": "cz_conventional_commits",

--- a/docs/config.md
+++ b/docs/config.md
@@ -28,6 +28,65 @@ style = [
 
 `.cz.toml` is recommended for **other languages** projects (js, go, etc).
 
+## .cz.json or cz.json
+
+JSON may be a more commong configuration format for non-python projects, so Commitizen supports JSON config files, now.
+
+```json
+{
+    "commitizen": {
+        "name": "cz_conventional_commits",
+        "version": "0.1.0",
+        "version_files": [
+	    "src/__version__.py",
+	    "pyproject.toml:version"
+        ],
+        "style": [
+            [
+                "qmark",
+                "fg:#ff9d00 bold"
+            ],
+            [
+                "question",
+                "bold"
+            ],
+            [
+                "answer",
+                "fg:#ff9d00 bold"
+            ],
+            [
+                "pointer",
+                "fg:#ff9d00 bold"
+            ],
+            [
+                "highlighted",
+                "fg:#ff9d00 bold"
+            ],
+            [
+                "selected",
+                "fg:#cc5454"
+            ],
+            [
+                "separator",
+                "fg:#cc5454"
+            ],
+            [
+                "instruction",
+                ""
+            ],
+            [
+                "text",
+                ""
+            ],
+            [
+                "disabled",
+                "fg:#858585 italic"
+            ]
+        ]
+    }
+}
+```
+
 ## Settings
 
 | Variable | Type | Default | Description |

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -3,7 +3,7 @@ We have two different ways to do so.
 
 ## 1. Customize in configuration file
 
-**This is only supported when configuring through `toml` (e.g., `pyproject.toml`, `.cz`, and `.cz.toml`)**
+**This is only supported when configuring through `toml` or `json` (e.g., `pyproject.toml`, `.cz.toml`, `.cz.toml`, `.cz.json`, and `cz.json`)**
 
 The basic steps are:
 
@@ -44,6 +44,58 @@ message = "Body."
 type = "confirm"
 name = "show_message"
 message = "Do you want to add body message in commit?"
+```
+
+The equivalent example for a json config file:
+
+```json
+{
+    "commitizen": {
+	"name": "cz_customize",
+        "customize": {
+            "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
+            "example": "feature: this feature enable customize through config file",
+            "schema": "<type>: <body>",
+            "schema_pattern": "(feature|bug fix):(\\s.*)",
+            "bump_pattern": "^(break|new|fix|hotfix)",
+            "bump_map": {
+                "break": "MAJOR",
+                "new": "MINOR",
+                "fix": "PATCH",
+                "hotfix": "PATCH"
+            },
+	    "info_path": "cz_customize_info.txt",
+            "info": "This is customized info",
+            "questions": [
+                {
+                    "type": "list",
+                    "name": "change_type",
+                    "choices": [
+                        {
+                            "value": "feature",
+                            "name": "feature: A new feature."
+                        },
+                        {
+                            "value": "bug fix",
+                            "name": "bug fix: A bug fix."
+                        }
+                    ],
+                    "message": "Select the type of change you are committing"
+                },
+                {
+                    "type": "input",
+                    "name": "message",
+                    "message": "Body."
+                },
+                {
+                    "type": "confirm",
+                    "name": "show_message",
+                    "message": "Do you want to add body message in commit?"
+                }
+            ]
+        }
+    }
+}
 ```
 
 ### Customize configuration

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -149,4 +149,4 @@ class TestJsonConfig:
         json_config.init_empty_config_content()
 
         with open(path, "r") as json_file:
-            assert json.load(json_file) == {"commitizen": ""}
+            assert json.load(json_file) == {"commitizen": {}}

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 
@@ -23,6 +24,14 @@ line-length = 88
 target-version = ['py36', 'py37', 'py38']
 """
 
+JSON_CONFIG = {
+    "commitizen": {
+        "name": "cz_jira",
+        "version": "1.0.0",
+        "version_files": ["commitizen/__version__.py", "pyproject.toml"],
+        "style": [["pointer", "reverse"], ["question", "underline"]],
+    }
+}
 
 _settings = {
     "name": "cz_jira",
@@ -66,6 +75,8 @@ def config_files_manager(request, tmpdir):
         with open(filename, "w") as f:
             if "toml" in filename:
                 f.write(PYPROJECT)
+            if "json" in filename:
+                json.dump(JSON_CONFIG, f)
         yield
 
 
@@ -129,3 +140,13 @@ class TestTomlConfig:
 
         with open(path, "r") as toml_file:
             assert toml_file.read() == existing_content + "[tool.commitizen]"
+
+
+class TestJsonConfig:
+    def test_init_empty_config_content(self, tmpdir):
+        path = tmpdir.mkdir("commitizen").join(".cz.json")
+        json_config = config.JsonConfig(data="{}", path=path)
+        json_config.init_empty_config_content()
+
+        with open(path, "r") as json_file:
+            assert json.load(json_file) == {"commitizen": ""}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
As mentioned in #120 , this PR add json support for configuration

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

Replace a TOML config file with a JSON config file with no side effects, (of course, passing the same arguments).

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

 1. Run the tests
 2. Activate the virtual environment provided by the project/Poetry
 3. Since the json files are supported for configuration, try to add a new file called .cz.json to customize Commitizen.

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->

Related to #120 