### PR TITLE
fix(commit): attach user info to backup for permission denied issue

### DIFF
--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -28,7 +28,10 @@ class Commit:
         self.config: BaseConfig = config
         self.cz = factory.commiter_factory(self.config)
         self.arguments = arguments
-        self.temp_file: str = os.path.join(tempfile.gettempdir(), "cz.commit.backup")
+        self.temp_file: str = os.path.join(
+            tempfile.gettempdir(),
+            "cz.commit{user}.backup".format(user=os.environ.get("USER", "")),
+        )
 
     def read_backup_message(self) -> str:
         # Check the commit backup file exists


### PR DESCRIPTION
For multi user situation, it may get fail

```
Permission denied: '/tmp/cz.commit.backup'
``` 

The reason is another user has already created a temp file with the same name.
So if one user create temp_file should attatch with `$USER`  info to resolve permission issue

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

attach user info to temp-file name when $USER is possible


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

create `/tmp/cz.committom.backup`


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->