### PR TITLE
feat(#319): add optional change_type_order

### DIFF
--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -130,14 +130,21 @@ def generate_tree_from_commits(
 
 
 def order_changelog_tree(tree: Iterable, change_type_order: List[str]) -> Iterable:
+    if len(set(change_type_order)) != len(change_type_order):
+        raise RuntimeError(
+            f"Change types contain duplicates types ({change_type_order})"
+        )
+
     sorted_tree = []
     for entry in tree:
-        entry_change_types = sorted(entry["changes"].keys())
-        ordered_change_types = []
-        for ct in change_type_order + entry_change_types:
-            if ct in entry_change_types and ct not in ordered_change_types:
-                ordered_change_types.append(ct)
-        changes = [(ct, entry["changes"][ct]) for ct in ordered_change_types]
+        ordered_change_types = change_type_order + sorted(
+            set(entry["changes"].keys()) - set(change_type_order)
+        )
+        changes = [
+            (ct, entry["changes"][ct])
+            for ct in ordered_change_types
+            if ct in entry["changes"]
+        ]
         sorted_tree.append({**entry, **{"changes": OrderedDict(changes)}})
     return sorted_tree
 

--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -34,6 +34,7 @@ from typing import Callable, Dict, Iterable, List, Optional
 from jinja2 import Environment, PackageLoader
 
 from commitizen import defaults
+from commitizen.exceptions import InvalidConfigurationError
 from commitizen.git import GitCommit, GitTag
 
 CATEGORIES = [
@@ -131,7 +132,7 @@ def generate_tree_from_commits(
 
 def order_changelog_tree(tree: Iterable, change_type_order: List[str]) -> Iterable:
     if len(set(change_type_order)) != len(change_type_order):
-        raise RuntimeError(
+        raise InvalidConfigurationError(
             f"Change types contain duplicates types ({change_type_order})"
         )
 

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -43,6 +43,9 @@ class Changelog:
         self.change_type_map = (
             self.config.settings.get("change_type_map") or self.cz.change_type_map
         )
+        self.change_type_order = (
+            self.config.settings.get("change_type_order") or self.cz.change_type_order
+        )
 
     def _find_incremental_rev(self, latest_version: str, tags: List[GitTag]) -> str:
         """Try to find the 'start_rev'.
@@ -109,6 +112,8 @@ class Changelog:
             change_type_map=change_type_map,
             changelog_message_builder_hook=changelog_message_builder_hook,
         )
+        if self.change_type_order:
+            tree = changelog.order_changelog_tree(tree, self.change_type_order)
         changelog_out = changelog.render_changelog(tree)
         changelog_out = changelog_out.lstrip("\n")
 

--- a/commitizen/cz/base.py
+++ b/commitizen/cz/base.py
@@ -29,6 +29,7 @@ class BaseCommitizen(metaclass=ABCMeta):
     commit_parser: Optional[str] = r"(?P<message>.*)"
     changelog_pattern: Optional[str] = r".*"
     change_type_map: Optional[Dict[str, str]] = None
+    change_type_order: Optional[List[str]] = None
 
     # Executed per message parsed by the commitizen
     changelog_message_builder_hook: Optional[

--- a/commitizen/cz/customize/customize.py
+++ b/commitizen/cz/customize/customize.py
@@ -16,6 +16,7 @@ __all__ = ["CustomizeCommitsCz"]
 class CustomizeCommitsCz(BaseCommitizen):
     bump_pattern = defaults.bump_pattern
     bump_map = defaults.bump_map
+    change_type_order = defaults.change_type_order
 
     def __init__(self, config: BaseConfig):
         super(CustomizeCommitsCz, self).__init__(config)
@@ -31,6 +32,10 @@ class CustomizeCommitsCz(BaseCommitizen):
         custom_bump_map = self.custom_settings.get("bump_map")
         if custom_bump_map:
             self.bump_map = custom_bump_map
+
+        custom_change_type_order = self.custom_settings.get("change_type_order")
+        if custom_change_type_order:
+            self.change_type_order = custom_change_type_order
 
     def questions(self) -> List[Dict[str, Any]]:
         return self.custom_settings.get("questions")

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -40,5 +40,7 @@ bump_map = OrderedDict(
 )
 bump_message = "bump: version $current_version → $new_version"
 
+change_type_order = ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"]
+
 commit_parser = r"^(?P<change_type>feat|fix|refactor|perf|BREAKING CHANGE)(?:\((?P<scope>[^()\r\n]*)\)|\()?(?P<breaking>!)?:\s(?P<message>.*)?"  # noqa
 version_parser = r"(?P<version>([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?)"

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -23,6 +23,7 @@ class ExitCode(enum.IntEnum):
     NO_REVISION = 16
     CURRENT_VERSION_NOT_FOUND = 17
     INVALID_COMMAND_ARGUMENT = 18
+    INVALID_CONFIGURATION = 19
 
 
 class CommitizenException(Exception):
@@ -137,3 +138,7 @@ class NoCommandFoundError(CommitizenException):
 
 class InvalidCommandArgumentError(CommitizenException):
     exit_code = ExitCode.INVALID_COMMAND_ARGUMENT
+
+
+class InvalidConfigurationError(CommitizenException):
+    exit_code = ExitCode.INVALID_CONFIGURATION

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -23,6 +23,7 @@ schema = "<type>: <body>"
 schema_pattern = "(feature|bug fix):(\\s.*)"
 bump_pattern = "^(break|new|fix|hotfix)"
 bump_map = {"break" = "MAJOR", "new" = "MINOR", "fix" = "PATCH", "hotfix" = "PATCH"}
+change_type_order = ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"]
 info_path = "cz_customize_info.txt"
 info = """
 This is customized info
@@ -51,7 +52,7 @@ The equivalent example for a json config file:
 ```json
 {
     "commitizen": {
-	"name": "cz_customize",
+    "name": "cz_customize",
         "customize": {
             "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
             "example": "feature: this feature enable customize through config file",
@@ -64,7 +65,8 @@ The equivalent example for a json config file:
                 "fix": "PATCH",
                 "hotfix": "PATCH"
             },
-	    "info_path": "cz_customize_info.txt",
+            "change_type_order": ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"],
+            "info_path": "cz_customize_info.txt",
             "info": "This is customized info",
             "questions": [
                 {
@@ -114,6 +116,7 @@ commitizen:
       new: MINOR
       fix: PATCH
       hotfix: PATCH
+    change_type_order: ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"]
     info_path: cz_customize_info.txt
     info: This is customized info
     questions:
@@ -146,6 +149,7 @@ commitizen:
 | `info`             | `str`  | `None`  | (OPTIONAL) Explanation of the commit rules. Used by `cz info`.                                                                                                                                                                                                         |
 | `bump_map`         | `dict` | `None`  | (OPTIONAL) Dictionary mapping the extracted information to a `SemVer` increment type (`MAJOR`, `MINOR`, `PATCH`)                                                                                                                                                       |
 | `bump_pattern`     | `str`  | `None`  | (OPTIONAL) Regex to extract information from commit (subject and body)                                                                                                                                                                                                 |
+| `change_type_order`| `str`  | `None`  | (OPTIONAL) List of strings used to order the Changelog. All other types will be sorted alphabetically. Default is `["BREAKING CHANGE", "feat", "fix", "refactor", "perf"]`                                                                                             |
 
 #### Detailed `questions` content
 
@@ -298,7 +302,7 @@ You can customize it of course, and this are the variables you need to add to yo
 | Parameter                        | Type                                                                     | Required | Description                                                                                                                                                                                                         |
 | -------------------------------- | ------------------------------------------------------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `commit_parser`                  | `str`                                                                    | NO       | Regex which should provide the variables explained in the [changelog description][changelog-des]                                                                                                                    |
-| `changelog_pattern`              | `str`                                                                    | NO       | Regex to validate the commits, this is useful to skip commits that don't meet your rulling standards like a Merge. Usually the same as bump_pattern                                                                 |
+| `changelog_pattern`              | `str`                                                                    | NO       | Regex to validate the commits, this is useful to skip commits that don't meet your ruling standards like a Merge. Usually the same as bump_pattern                                                                  |
 | `change_type_map`                | `dict`                                                                   | NO       | Convert the title of the change type that will appear in the changelog, if a value is not found, the original will be provided                                                                                      |
 | `changelog_message_builder_hook` | `method: (dict, git.GitCommit) -> dict`                                  | NO       | Customize with extra information your message output, like adding links, this function is executed per parsed commit. Each GitCommit contains the following attrs: `rev`, `title`, `body`, `author`, `author_email` |
 | `changelog_hook`                 | `method: (full_changelog: str, partial_changelog: Optional[str]) -> str` | NO       | Receives the whole and partial (if used incremental) changelog. Useful to send slack messages or notify a compliance department. Must return the full_changelog                                                     |

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -66,7 +66,7 @@ The equivalent example for a json config file:
                 "hotfix": "PATCH"
             },
             "change_type_order": ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"],
-    "info_path": "cz_customize_info.txt",
+	    "info_path": "cz_customize_info.txt",
             "info": "This is customized info",
             "questions": [
                 {

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -52,7 +52,7 @@ The equivalent example for a json config file:
 ```json
 {
     "commitizen": {
-    "name": "cz_customize",
+	"name": "cz_customize",
         "customize": {
             "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
             "example": "feature: this feature enable customize through config file",
@@ -66,7 +66,7 @@ The equivalent example for a json config file:
                 "hotfix": "PATCH"
             },
             "change_type_order": ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"],
-            "info_path": "cz_customize_info.txt",
+    "info_path": "cz_customize_info.txt",
             "info": "This is customized info",
             "questions": [
                 {

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -26,3 +26,4 @@ These exit codes can be found in `commitizen/exceptions.py::ExitCode`.
 | NoRevisionError | 16 | No revision found |
 | CurrentVersionNotFoundError | 17 | current version cannot be found in *version_files* |
 | InvalidCommandArgumentError | 18 | The argument provide to command is invalid (e.g. `cz check -commit-msg-file filename --rev-range master..`) |
+| InvalidConfigurationError | 19 | An error was found in the Commitizen Configuration, such as duplicates in `change_type_order` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,6 @@ freezegun = "^0.3.15"
 pydocstyle = "^5.0.2"
 pre-commit = "^2.6.0"
 
-# FIXME: Remove for submission (testing issues/319-only)
-pytest-watch = "*"
-
 [tool.poetry.scripts]
 cz = "commitizen.cli:main"
 git-cz = "commitizen.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ freezegun = "^0.3.15"
 pydocstyle = "^5.0.2"
 pre-commit = "^2.6.0"
 
+# FIXME: Remove for submission (testing issues/319-only)
+pytest-watch = "*"
+
 [tool.poetry.scripts]
 cz = "commitizen.cli:main"
 git-cz = "commitizen.cli:main"
@@ -81,6 +84,7 @@ include_trailing_comma = true
 force_grid_wrap = 0
 combine_as_imports = true
 line_length = 88
+known_first_party = ["commitizen", "tests"]
 
 [tool.coverage]
     [tool.coverage.report]

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -249,6 +249,7 @@ def test_changelog_hook(mocker, config):
     create_file_and_commit("refactor: is in changelog")
     create_file_and_commit("Merge into master")
 
+    config.settings["change_type_order"] = ["Refactor", "Feat"]
     changelog = Changelog(
         config, {"unreleased_version": None, "incremental": True, "dry_run": False}
     )

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,6 +1,7 @@
 import pytest
 
 from commitizen import changelog, defaults, git
+from commitizen.exceptions import InvalidConfigurationError
 
 COMMITS_DATA = [
     {
@@ -833,10 +834,10 @@ def test_order_changelog_tree(change_type_order, expected_reordering):
 
 def test_order_changelog_tree_raises():
     change_type_order = ["BREAKING CHANGE", "feat", "refactor", "feat"]
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(InvalidConfigurationError) as excinfo:
         changelog.order_changelog_tree(COMMITS_TREE, change_type_order)
 
-    assert " duplicate" in str(excinfo)
+    assert "Change types contain duplicates types" in str(excinfo)
 
 
 def test_render_changelog(gitcommits, tags, changelog_content):

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -509,6 +509,283 @@ def test_get_commit_tag_is_None(gitcommits, tags):
     assert current_key is None
 
 
+COMMITS_TREE = (
+    {
+        "version": "v1.2.0",
+        "date": "2019-04-19",
+        "changes": {
+            "feat": [
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "custom cz plugins now support bumping version",
+                }
+            ]
+        },
+    },
+    {
+        "version": "v1.1.1",
+        "date": "2019-04-18",
+        "changes": {
+            "refactor": [
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "changed stdout statements",
+                },
+                {
+                    "scope": "schema",
+                    "breaking": None,
+                    "message": "command logic removed from commitizen base",
+                },
+                {
+                    "scope": "info",
+                    "breaking": None,
+                    "message": "command logic removed from commitizen base",
+                },
+                {
+                    "scope": "example",
+                    "breaking": None,
+                    "message": "command logic removed from commitizen base",
+                },
+                {
+                    "scope": "commit",
+                    "breaking": None,
+                    "message": "moved most of the commit logic to the commit command",
+                },
+            ],
+            "fix": [
+                {
+                    "scope": "bump",
+                    "breaking": None,
+                    "message": "commit message now fits better with semver",
+                },
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "conventional commit 'breaking change' in body instead of title",
+                },
+            ],
+        },
+    },
+    {
+        "version": "v1.1.0",
+        "date": "2019-04-14",
+        "changes": {
+            "feat": [
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "new working bump command",
+                },
+                {"scope": None, "breaking": None, "message": "create version tag"},
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "update given files with new version",
+                },
+                {
+                    "scope": "config",
+                    "breaking": None,
+                    "message": "new set key, used to set version to cfg",
+                },
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "support for pyproject.toml",
+                },
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "first semantic version bump implementation",
+                },
+            ],
+            "fix": [
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "removed all from commit",
+                },
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "fix config file not working",
+                },
+            ],
+            "refactor": [
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "added commands folder, better integration with decli",
+                }
+            ],
+        },
+    },
+    {
+        "version": "v1.0.0",
+        "date": "2019-03-01",
+        "changes": {
+            "refactor": [
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "removed delegator, added decli and many tests",
+                }
+            ],
+            "BREAKING CHANGE": [
+                {"scope": None, "breaking": None, "message": "API is stable"}
+            ],
+        },
+    },
+    {"version": "1.0.0b2", "date": "2019-01-18", "changes": {}},
+    {
+        "version": "v1.0.0b1",
+        "date": "2019-01-17",
+        "changes": {
+            "feat": [
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "py3 only, tests and conventional commits 1.0",
+                }
+            ]
+        },
+    },
+    {
+        "version": "v0.9.11",
+        "date": "2018-12-17",
+        "changes": {
+            "fix": [
+                {
+                    "scope": "config",
+                    "breaking": None,
+                    "message": "load config reads in order without failing if there is no commitizen section",
+                }
+            ]
+        },
+    },
+    {
+        "version": "v0.9.10",
+        "date": "2018-09-22",
+        "changes": {
+            "fix": [
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "parse scope (this is my punishment for not having tests)",
+                }
+            ]
+        },
+    },
+    {
+        "version": "v0.9.9",
+        "date": "2018-09-22",
+        "changes": {
+            "fix": [{"scope": None, "breaking": None, "message": "parse scope empty"}]
+        },
+    },
+    {
+        "version": "v0.9.8",
+        "date": "2018-09-22",
+        "changes": {
+            "fix": [
+                {
+                    "scope": "scope",
+                    "breaking": None,
+                    "message": "parse correctly again",
+                }
+            ]
+        },
+    },
+    {
+        "version": "v0.9.7",
+        "date": "2018-09-22",
+        "changes": {
+            "fix": [{"scope": "scope", "breaking": None, "message": "parse correctly"}]
+        },
+    },
+    {
+        "version": "v0.9.6",
+        "date": "2018-09-19",
+        "changes": {
+            "refactor": [
+                {
+                    "scope": "conventionalCommit",
+                    "breaking": None,
+                    "message": "moved filters to questions instead of message",
+                }
+            ],
+            "fix": [
+                {
+                    "scope": "manifest",
+                    "breaking": None,
+                    "message": "included missing files",
+                }
+            ],
+        },
+    },
+    {
+        "version": "v0.9.5",
+        "date": "2018-08-24",
+        "changes": {
+            "fix": [
+                {
+                    "scope": "config",
+                    "breaking": None,
+                    "message": "home path for python versions between 3.0 and 3.5",
+                }
+            ]
+        },
+    },
+    {
+        "version": "v0.9.4",
+        "date": "2018-08-02",
+        "changes": {
+            "feat": [{"scope": "cli", "breaking": None, "message": "added version"}]
+        },
+    },
+    {
+        "version": "v0.9.3",
+        "date": "2018-07-28",
+        "changes": {
+            "feat": [
+                {
+                    "scope": "committer",
+                    "breaking": None,
+                    "message": "conventional commit is a bit more intelligent now",
+                }
+            ]
+        },
+    },
+    {
+        "version": "v0.9.2",
+        "date": "2017-11-11",
+        "changes": {
+            "refactor": [
+                {
+                    "scope": None,
+                    "breaking": None,
+                    "message": "renamed conventional_changelog to conventional_commits, not backward compatible",
+                }
+            ]
+        },
+    },
+    {
+        "version": "v0.9.1",
+        "date": "2017-11-11",
+        "changes": {
+            "fix": [
+                {
+                    "scope": "setup.py",
+                    "breaking": None,
+                    "message": "future is now required for every python version",
+                }
+            ]
+        },
+    },
+)
+
+
 def test_generate_tree_from_commits(gitcommits, tags):
     parser = defaults.commit_parser
     changelog_pattern = defaults.bump_pattern
@@ -516,285 +793,7 @@ def test_generate_tree_from_commits(gitcommits, tags):
         gitcommits, tags, parser, changelog_pattern
     )
 
-    assert tuple(tree) == (
-        {
-            "version": "v1.2.0",
-            "date": "2019-04-19",
-            "changes": {
-                "feat": [
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "custom cz plugins now support bumping version",
-                    }
-                ]
-            },
-        },
-        {
-            "version": "v1.1.1",
-            "date": "2019-04-18",
-            "changes": {
-                "refactor": [
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "changed stdout statements",
-                    },
-                    {
-                        "scope": "schema",
-                        "breaking": None,
-                        "message": "command logic removed from commitizen base",
-                    },
-                    {
-                        "scope": "info",
-                        "breaking": None,
-                        "message": "command logic removed from commitizen base",
-                    },
-                    {
-                        "scope": "example",
-                        "breaking": None,
-                        "message": "command logic removed from commitizen base",
-                    },
-                    {
-                        "scope": "commit",
-                        "breaking": None,
-                        "message": "moved most of the commit logic to the commit command",
-                    },
-                ],
-                "fix": [
-                    {
-                        "scope": "bump",
-                        "breaking": None,
-                        "message": "commit message now fits better with semver",
-                    },
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "conventional commit 'breaking change' in body instead of title",
-                    },
-                ],
-            },
-        },
-        {
-            "version": "v1.1.0",
-            "date": "2019-04-14",
-            "changes": {
-                "feat": [
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "new working bump command",
-                    },
-                    {"scope": None, "breaking": None, "message": "create version tag"},
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "update given files with new version",
-                    },
-                    {
-                        "scope": "config",
-                        "breaking": None,
-                        "message": "new set key, used to set version to cfg",
-                    },
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "support for pyproject.toml",
-                    },
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "first semantic version bump implementation",
-                    },
-                ],
-                "fix": [
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "removed all from commit",
-                    },
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "fix config file not working",
-                    },
-                ],
-                "refactor": [
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "added commands folder, better integration with decli",
-                    }
-                ],
-            },
-        },
-        {
-            "version": "v1.0.0",
-            "date": "2019-03-01",
-            "changes": {
-                "refactor": [
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "removed delegator, added decli and many tests",
-                    }
-                ],
-                "BREAKING CHANGE": [
-                    {"scope": None, "breaking": None, "message": "API is stable"}
-                ],
-            },
-        },
-        {"version": "1.0.0b2", "date": "2019-01-18", "changes": {}},
-        {
-            "version": "v1.0.0b1",
-            "date": "2019-01-17",
-            "changes": {
-                "feat": [
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "py3 only, tests and conventional commits 1.0",
-                    }
-                ]
-            },
-        },
-        {
-            "version": "v0.9.11",
-            "date": "2018-12-17",
-            "changes": {
-                "fix": [
-                    {
-                        "scope": "config",
-                        "breaking": None,
-                        "message": "load config reads in order without failing if there is no commitizen section",
-                    }
-                ]
-            },
-        },
-        {
-            "version": "v0.9.10",
-            "date": "2018-09-22",
-            "changes": {
-                "fix": [
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "parse scope (this is my punishment for not having tests)",
-                    }
-                ]
-            },
-        },
-        {
-            "version": "v0.9.9",
-            "date": "2018-09-22",
-            "changes": {
-                "fix": [
-                    {"scope": None, "breaking": None, "message": "parse scope empty"}
-                ]
-            },
-        },
-        {
-            "version": "v0.9.8",
-            "date": "2018-09-22",
-            "changes": {
-                "fix": [
-                    {
-                        "scope": "scope",
-                        "breaking": None,
-                        "message": "parse correctly again",
-                    }
-                ]
-            },
-        },
-        {
-            "version": "v0.9.7",
-            "date": "2018-09-22",
-            "changes": {
-                "fix": [
-                    {"scope": "scope", "breaking": None, "message": "parse correctly"}
-                ]
-            },
-        },
-        {
-            "version": "v0.9.6",
-            "date": "2018-09-19",
-            "changes": {
-                "refactor": [
-                    {
-                        "scope": "conventionalCommit",
-                        "breaking": None,
-                        "message": "moved filters to questions instead of message",
-                    }
-                ],
-                "fix": [
-                    {
-                        "scope": "manifest",
-                        "breaking": None,
-                        "message": "included missing files",
-                    }
-                ],
-            },
-        },
-        {
-            "version": "v0.9.5",
-            "date": "2018-08-24",
-            "changes": {
-                "fix": [
-                    {
-                        "scope": "config",
-                        "breaking": None,
-                        "message": "home path for python versions between 3.0 and 3.5",
-                    }
-                ]
-            },
-        },
-        {
-            "version": "v0.9.4",
-            "date": "2018-08-02",
-            "changes": {
-                "feat": [{"scope": "cli", "breaking": None, "message": "added version"}]
-            },
-        },
-        {
-            "version": "v0.9.3",
-            "date": "2018-07-28",
-            "changes": {
-                "feat": [
-                    {
-                        "scope": "committer",
-                        "breaking": None,
-                        "message": "conventional commit is a bit more intelligent now",
-                    }
-                ]
-            },
-        },
-        {
-            "version": "v0.9.2",
-            "date": "2017-11-11",
-            "changes": {
-                "refactor": [
-                    {
-                        "scope": None,
-                        "breaking": None,
-                        "message": "renamed conventional_changelog to conventional_commits, not backward compatible",
-                    }
-                ]
-            },
-        },
-        {
-            "version": "v0.9.1",
-            "date": "2017-11-11",
-            "changes": {
-                "fix": [
-                    {
-                        "scope": "setup.py",
-                        "breaking": None,
-                        "message": "future is now required for every python version",
-                    }
-                ]
-            },
-        },
-    )
+    assert tuple(tree) == COMMITS_TREE
 
 
 def test_render_changelog(gitcommits, tags, changelog_content):

--- a/tests/test_cz_customize.py
+++ b/tests/test_cz_customize.py
@@ -13,6 +13,7 @@ TOML_STR = r"""
 
     bump_pattern = "^(break|new|fix|hotfix)"
     bump_map = {"break" = "MAJOR", "new" = "MINOR", "fix" = "PATCH", "hotfix" = "PATCH"}
+    change_type_order = ["perf", "BREAKING CHANGE", "feat", "fix", "refactor"]
     info = "This is a customized cz."
 
     [[tool.commitizen.customize.questions]]
@@ -56,6 +57,7 @@ JSON_STR = r"""
                     "fix": "PATCH",
                     "hotfix": "PATCH"
                 },
+                "change_type_order": ["perf", "BREAKING CHANGE", "feat", "fix", "refactor"],
                 "info": "This is a customized cz.",
                 "questions": [
                     {
@@ -107,6 +109,7 @@ commitizen:
       new: MINOR
       fix: PATCH
       hotfix: PATCH
+    change_type_order: ["perf", "BREAKING CHANGE", "feat", "fix", "refactor"]
     info: This is a customized cz.
     questions:
     - type: list
@@ -272,6 +275,17 @@ def test_bump_map(config):
         "fix": "PATCH",
         "hotfix": "PATCH",
     }
+
+
+def test_change_type_order(config):
+    cz = CustomizeCommitsCz(config)
+    assert cz.change_type_order == [
+        "perf",
+        "BREAKING CHANGE",
+        "feat",
+        "fix",
+        "refactor",
+    ]
 
 
 def test_questions(config):


### PR DESCRIPTION
## Description

Implements proposed feature in #319. The default change type order is `["BREAKING CHANGE", "feat", "fix", "refactor", "perf"]` (in descending order of importance) followed by any other change types in alphabetical order. In the configuration file, a user can override this setting to specify their own order and cover custom change types of interest.

## Checklist

- [X] Add test cases to all the changes you introduce
- [X] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [X] Update the documentation for the changes

## Expected behavior

The `CHANGELOG` should be ordered in the user-specified order rather than FIFO

## Steps to Test This Pull Request

Run the standard pytest suite and see the two new test cases

## Additional context

Fixes #319

Example use: https://github.com/KyleKing/calcipy/commit/4a480a8ca91350c1a4c190a672af1e9d397a6eb2
