### PR TITLE
fix: read commit_msg_file with utf-8

### DIFF
--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -80,7 +80,7 @@ class Check:
     def _get_commits(self):
         # Get commit message from file (--commit-msg-file)
         if self.commit_msg_file:
-            with open(self.commit_msg_file, "r") as commit_file:
+            with open(self.commit_msg_file, "r", encoding="utf-8") as commit_file:
                 commit_title = commit_file.readline()
                 commit_body = commit_file.read()
             return [git.GitCommit(rev="", title=commit_title, body=commit_body)]


### PR DESCRIPTION
## Description

Encoding error will happen if commit-msg-file contains some language-specific chars (e.g. GBK?) in PyCharm

```text
File "c:\users\administrator\.cache\pre-commit\repofeq0u_vr\py_env-python3\lib\site-packages\commitizen\commands\check.py", 
line 64, in _get_commit_messages commit_msg = commit_file.read() 
UnicodeDecodeError: 'gbk' codec can't decode byte 0x8c in position 76: illegal multibyte sequence [INFO] Restored changes from C:\Users\Administrator\.cache\pre-commit\patch1609311833.
```

and this problem causes by:

```python
with open(self.commit_msg_file, "r") as commit_file:
```

## How to fix it

Just add `encoding='utf-8'`

## How to test it

Put some GBK text in `commit-msg-file` (e.g. 这是一段GBK文本).
I will add a test case if it is required.
