### PR TITLE
build(#325): upgrade isort for black compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ codecov = "^2.0"
 mypy = "^0.770"
 mkdocs = "^1.0"
 mkdocs-material = "^4.1"
-isort = "^4.3.21"
+isort = "^5.7.0"
 freezegun = "^0.3.15"
 pydocstyle = "^5.0.2"
 pre-commit = "^2.6.0"
@@ -76,11 +76,7 @@ cz = "commitizen.cli:main"
 git-cz = "commitizen.cli:main"
 
 [tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-combine_as_imports = true
-line_length = 88
+profile = "black"
 known_first_party = ["commitizen", "tests"]
 
 [tool.coverage]

--- a/scripts/format
+++ b/scripts/format
@@ -7,5 +7,5 @@ fi
 
 set -x
 
-${PREFIX}isort --recursive --apply commitizen tests
+${PREFIX}isort commitizen tests
 ${PREFIX}black commitizen tests

--- a/scripts/test
+++ b/scripts/test
@@ -7,7 +7,7 @@ fi
 
 ${PREFIX}pytest --cov-report term-missing --cov-report=xml:coverage.xml --cov=commitizen tests/
 ${PREFIX}black commitizen tests --check
-${PREFIX}isort --recursive --check-only commitizen tests
+${PREFIX}isort --check-only commitizen tests
 ${PREFIX}flake8 commitizen/ tests/
 ${PREFIX}mypy commitizen/ tests/
 ${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415


### PR DESCRIPTION
Fixes #325. Resolves errors from `./script/test` from `isort` by upgrading to `5.X` and using the new `profile = "black"`

## Checklist

- [X] Add test cases to all the changes you introduce {N/A}
- [X] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [X] Update the documentation for the changes {N/A}

## Steps to Test This Pull Request

```sh
❯ ./scripts/format; ./scripts/test
+ poetry run python -m isort commitizen tests
+ poetry run python -m black commitizen tests
All done! ✨ 🍰 ✨
67 files left unchanged.
========================================== test session starts ===========================================
platform darwin -- Python 3.8.3, pytest-5.4.3, py-1.10.0, pluggy-0.13.1
rootdir: /Users/kyleking/Developer/Pull_Requests/commitizen, inifile: setup.cfg
plugins: mock-2.0.0, cov-2.10.1
collected 310 items                                                                                      

tests/test_bump_create_commit_message.py ...                                                       [  0%]
tests/test_bump_create_tag.py .........                                                            [  3%]
tests/test_bump_find_increment.py .........                                                        [  6%]
tests/test_bump_find_version.py .............................................                      [ 21%]
tests/test_bump_update_version_in_files.py ...                                                     [ 22%]
tests/test_changelog.py ........                                                                   [ 24%]
tests/test_changelog_meta.py ..................                                                    [ 30%]
tests/test_changelog_parser.py .........................                                           [ 38%]
tests/test_cli.py .........                                                                        [ 41%]
tests/test_conf.py ..................                                                              [ 47%]
tests/test_cz_base.py .......                                                                      [ 49%]
tests/test_cz_conventional_commits.py .............                                                [ 53%]
tests/test_cz_customize.py .......................                                                 [ 61%]
tests/test_cz_jira.py .....                                                                        [ 62%]
tests/test_cz_utils.py ..                                                                          [ 63%]
tests/test_factory.py ..                                                                           [ 64%]
tests/test_git.py .......                                                                          [ 66%]
tests/commands/test_bump_command.py ....................................                           [ 78%]
tests/commands/test_changelog_command.py .................                                         [ 83%]
tests/commands/test_check_command.py ....................                                          [ 90%]
tests/commands/test_commit_command.py .........                                                    [ 92%]
tests/commands/test_init_command.py ...............                                                [ 97%]
tests/commands/test_other_commands.py ....                                                         [ 99%]
tests/commands/test_version_command.py ...                                                         [100%]

============================================ warnings summary ============================================
tests/test_conf.py::test_set_key[.cz.yaml]
tests/test_conf.py::test_set_key[cz.yaml]
tests/commands/test_init_command.py::TestPreCommitCases::test_no_existing_pre_commit_conifg[.cz.yaml]
tests/commands/test_init_command.py::TestPreCommitCases::test_empty_pre_commit_config[.cz.yaml]
tests/commands/test_init_command.py::TestPreCommitCases::test_pre_commit_config_without_cz_hook[.cz.yaml]
tests/commands/test_init_command.py::TestPreCommitCases::test_cz_hook_exists_in_pre_commit_config[.cz.yaml]
  /Users/kyleking/Developer/Pull_Requests/commitizen/commitizen/config/yaml_config.py:41: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    parser = yaml.load(yaml_file)

tests/commands/test_init_command.py::TestPreCommitCases::test_no_existing_pre_commit_conifg[.cz.yaml]
  /Users/kyleking/Developer/Pull_Requests/commitizen/tests/commands/test_init_command.py:119: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    assert yaml.load(file) == EXPECTED_DICT_CONFIG

tests/commands/test_init_command.py::TestPreCommitCases::test_empty_pre_commit_config[.cz.yaml]
  /Users/kyleking/Developer/Pull_Requests/commitizen/tests/commands/test_init_command.py:139: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    assert yaml.load(file) == EXPECTED_DICT_CONFIG

tests/commands/test_init_command.py::TestPreCommitCases::test_pre_commit_config_without_cz_hook[.cz.yaml]
  /Users/kyleking/Developer/Pull_Requests/commitizen/tests/commands/test_init_command.py:165: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    assert yaml.load(file) == EXPECTED_DICT_CONFIG

tests/commands/test_init_command.py::TestPreCommitCases::test_cz_hook_exists_in_pre_commit_config[.cz.yaml]
  /Users/kyleking/Developer/Pull_Requests/commitizen/tests/commands/test_init_command.py:187: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    assert yaml.load(file) == EXPECTED_DICT_CONFIG

-- Docs: https://docs.pytest.org/en/latest/warnings.html

---------- coverage: platform darwin, python 3.8.3-final-0 -----------
Name                                                         Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------------
commitizen/__init__.py                                           8      0   100%
commitizen/__main__.py                                           1      1     0%   1
commitizen/__version__.py                                        1      0   100%
commitizen/bump.py                                             103      0   100%
commitizen/changelog.py                                        126      6    95%   54-59, 234
commitizen/changelog_parser.py                                  65      2    97%   117, 125
commitizen/cli.py                                               40      1    98%   257
commitizen/cmd.py                                               13      0   100%
commitizen/commands/__init__.py                                 11      0   100%
commitizen/commands/bump.py                                     90      5    94%   53-61, 131, 185
commitizen/commands/changelog.py                                74      2    97%   19, 85
commitizen/commands/check.py                                    45      0   100%
commitizen/commands/commit.py                                   58      1    98%   91
commitizen/commands/example.py                                   8      0   100%
commitizen/commands/info.py                                      8      0   100%
commitizen/commands/init.py                                     96      8    92%   81-82, 92, 97-98, 109, 147, 154
commitizen/commands/list_cz.py                                   8      0   100%
commitizen/commands/schema.py                                    8      0   100%
commitizen/commands/version.py                                  20      0   100%
commitizen/config/__init__.py                                   30      0   100%
commitizen/config/base_config.py                                19      0   100%
commitizen/config/json_config.py                                26      0   100%
commitizen/config/toml_config.py                                26      0   100%
commitizen/config/yaml_config.py                                26      0   100%
commitizen/cz/__init__.py                                       10      0   100%
commitizen/cz/base.py                                           31      0   100%
commitizen/cz/conventional_commits/__init__.py                   1      0   100%
commitizen/cz/conventional_commits/conventional_commits.py      63      1    98%   197
commitizen/cz/customize/__init__.py                              1      0   100%
commitizen/cz/customize/customize.py                            47      3    94%   3-4, 41
commitizen/cz/exceptions.py                                      4      0   100%
commitizen/cz/jira/__init__.py                                   2      0   100%
commitizen/cz/jira/jira.py                                      22      0   100%
commitizen/cz/utils.py                                           7      0   100%
commitizen/defaults.py                                          13      0   100%
commitizen/exceptions.py                                        85      0   100%
commitizen/factory.py                                           12      0   100%
commitizen/git.py                                               90      4    96%   123, 142-144
commitizen/out.py                                               15      0   100%
------------------------------------------------------------------------------------------
TOTAL                                                         1313     34    97%
Coverage XML written to file coverage.xml

=================================== 310 passed, 10 warnings in 43.82s ====================================
All done! ✨ 🍰 ✨
67 files would be left unchanged.
Success: no issues found in 59 source files
❯ 
```
