### PR TITLE
Feature/271 redux

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -137,6 +137,11 @@ data = {
                         ),
                         "action": "store_true",
                     },
+                    {
+                        "name": ["--annotated-tag", "-at"],
+                        "help": "create annotated tag instead of lightweight one",
+                        "action": "store_true",
+                    },
                 ],
             },
             {

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -32,7 +32,13 @@ class Bump:
             **config.settings,
             **{
                 key: arguments[key]
-                for key in ["tag_format", "prerelease", "increment", "bump_message"]
+                for key in [
+                    "tag_format",
+                    "prerelease",
+                    "increment",
+                    "bump_message",
+                    "annotated_tag",
+                ]
                 if arguments[key] is not None
             },
         }
@@ -183,7 +189,11 @@ class Bump:
         c = git.commit(message, args=self._get_commit_args())
         if c.return_code != 0:
             raise BumpCommitFailedError(f'git.commit error: "{c.err.strip()}"')
-        c = git.tag(new_tag_version)
+        c = git.tag(
+            new_tag_version,
+            annotated=self.bump_settings.get("annotated_tag", False)
+            or bool(self.config.settings.get("annotated_tag", False)),
+        )
         if c.return_code != 0:
             raise BumpTagFailedError(c.err)
         out.success("Done!")

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -45,8 +45,8 @@ class GitTag(GitObject):
         return f"GitTag('{self.name}', '{self.rev}', '{self.date}')"
 
 
-def tag(tag: str):
-    c = cmd.run(f"git tag {tag}")
+def tag(tag: str, annotated: bool = False):
+    c = cmd.run(f"git tag -a {tag} -m {tag}" if annotated else f"git tag {tag}")
     return c
 
 

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -57,30 +57,29 @@ $ cz bump --help
 usage: cz bump [-h] [--dry-run] [--files-only] [--changelog] [--no-verify] [--local-version]
                [--yes] [--tag-format TAG_FORMAT] [--bump-message BUMP_MESSAGE]
                [--prerelease {alpha,beta,rc}]
-               [--increment {MAJOR,MINOR,PATCH}] [--check-consistency]
+               [--increment {MAJOR,MINOR,PATCH}] [--check-consistency] [--annotated-tag]
 
 optional arguments:
   -h, --help            show this help message and exit
   --dry-run             show output to stdout, no commit, no modified files
   --files-only          bump version in the files from the config
   --changelog, -ch      generate the changelog for the newest version
-  --no-verify           this option bypasses the pre-commit and commit-msg
-                        hooks
+  --no-verify           this option bypasses the pre-commit and commit-msg hooks
   --yes                 accept automatically questions done
   --local-version       bump the local portion of the version
   --tag-format TAG_FORMAT
-                        the format used to tag the commit and read it, use it
-                        in existing projects, wrap around simple quotes
+                        the format used to tag the commit and read it, use it in existing projects, wrap
+                        around simple quotes
   --bump-message BUMP_MESSAGE
-                        template used to create the release commit, useful
-                        when working with CI
+                        template used to create the release commit, useful when working with CI
   --prerelease {alpha,beta,rc}, -pr {alpha,beta,rc}
                         choose type of prerelease
   --increment {MAJOR,MINOR,PATCH}
                         manually specify the desired increment
   --check-consistency, -cc
-                        check consistency among versions defined in commitizen
-                        configuration and version_files
+                        check consistency among versions defined in commitizen configuration and
+                        version_files
+  --annotated-tag, -at  create annotated tag instead of lightweight one
 ```
 
 ### `--files-only`
@@ -157,6 +156,10 @@ version = "5.3.5+0.1.0"
 ```
 
 If `--local-version` is used, it will bump only the local version `0.1.0` and keep the public version `5.3.5` intact, bumping to the version `5.3.5+0.2.0`.
+
+### `--annotated-tag`
+
+If `--annotated-tag` is used, commitizen will create annotated tags. Also available via configuration, in `pyproject.toml` or `.cz.toml`.
 
 ## Configuration
 
@@ -254,6 +257,17 @@ defaults to: `false`
 ```toml
 [tool.commitizen]
 update_changelog_on_bump = true
+```
+
+---
+
+### `annotated_tag`
+
+When set to `true` commitizen will create annotated tags.
+
+```toml
+[tool.commitizen]
+annotated_tag = true
 ```
 
 ## Custom bump

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -49,7 +49,37 @@ def test_bump_minor_increment(commit_msg, mocker):
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
     tag_exists = git.tag_exist("0.2.0")
-    assert tag_exists is True
+    cmd_res = cmd.run('git for-each-ref refs/tags --format "%(objecttype):%(refname)"')
+    assert tag_exists is True and "commit:refs/tags/0.2.0\n" in cmd_res.out
+
+
+@pytest.mark.parametrize("commit_msg", ("feat: new file", "feat(user): new file"))
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_minor_increment_annotated(commit_msg, mocker):
+    create_file_and_commit(commit_msg)
+    testargs = ["cz", "bump", "--yes", "--annotated-tag"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    tag_exists = git.tag_exist("0.2.0")
+    cmd_res = cmd.run('git for-each-ref refs/tags --format "%(objecttype):%(refname)"')
+    assert tag_exists is True and "tag:refs/tags/0.2.0\n" in cmd_res.out
+
+
+@pytest.mark.parametrize("commit_msg", ("feat: new file", "feat(user): new file"))
+def test_bump_minor_increment_annotated_config_file(
+    commit_msg, mocker, tmp_commitizen_project
+):
+    tmp_commitizen_cfg_file = tmp_commitizen_project.join("pyproject.toml")
+    tmp_commitizen_cfg_file.write(
+        f"{tmp_commitizen_cfg_file.read()}\n" f"annotated_tag = 1"
+    )
+    create_file_and_commit(commit_msg)
+    testargs = ["cz", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    tag_exists = git.tag_exist("0.2.0")
+    cmd_res = cmd.run('git for-each-ref refs/tags --format "%(objecttype):%(refname)"')
+    assert tag_exists is True and "tag:refs/tags/0.2.0\n" in cmd_res.out
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
As noted in #329 there exists an abandoned PR (#272) for annotated tag support. After reviewing #272 it looks like the only outstanding action was to rebase and revert CHANGELOG entries so they could be generated from CI? 

I can not gain access to the original author's fork, but have simply carried the original work over and rebased and cleared CHANGELOG. 

This is a very useful feature, so adoption seemed valid.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
See original #272 

## Steps to Test This Pull Request
See original #272 


## Additional context
See original #271  
See original #272 
