### PR TITLE
Fix git message parsing

### DIFF
--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -122,7 +122,6 @@ class Init:
             # .pre-commit-config does not exist
             config_data["repos"] = [cz_hook_config]
         else:
-            # breakpoint()
             with open(pre_commit_config_filename) as config_file:
                 yaml_data = yaml.safe_load(config_file)
                 if yaml_data:

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -79,8 +79,7 @@ def get_commits(
         return []
 
     git_commits = []
-    for rev_and_commit in c.out.split(delimiter):
-        rev_and_commit = rev_and_commit.strip()
+    for rev_and_commit in c.out.split(f"\n{delimiter}\n"):
         if not rev_and_commit:
             continue
         rev, title, author, author_email, *body_list = rev_and_commit.split("\n")

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -73,6 +73,33 @@ def test_get_commits_author_and_email():
     assert "@" in commit.author_email
 
 
+def test_get_commits_without_email(mocker):
+    raw_commit = (
+        "a515bb8f71c403f6f7d1c17b9d8ebf2ce3959395\n"
+        "\n"
+        "user name\n"
+        "\n"
+        "----------commit-delimiter----------\n"
+        "12d3b4bdaa996ea7067a07660bb5df4772297bdd\n"
+        "feat(users): add username\n"
+        "user name\n"
+        "\n"
+        "----------commit-delimiter----------\n"
+    )
+    mocker.patch("commitizen.cmd.run", return_value=FakeCommand(out=raw_commit))
+
+    commits = git.get_commits()
+
+    assert commits[0].author == "user name"
+    assert commits[1].author == "user name"
+
+    assert commits[0].author_email == ""
+    assert commits[1].author_email == ""
+
+    assert commits[0].title == ""
+    assert commits[1].title == "feat(users): add username"
+
+
 def test_get_tag_names_has_correct_arrow_annotation():
     arrow_annotation = inspect.getfullargspec(git.get_tag_names).annotations["return"]
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import pytest
 
-from commitizen import git
+from commitizen import cmd, git
 from tests.utils import FakeCommand, create_file_and_commit
 
 
@@ -104,3 +104,14 @@ def test_get_tag_names_has_correct_arrow_annotation():
     arrow_annotation = inspect.getfullargspec(git.get_tag_names).annotations["return"]
 
     assert arrow_annotation == List[Optional[str]]
+
+
+def test_get_latest_tag_name(tmp_commitizen_project):
+    with tmp_commitizen_project.as_cwd():
+        tag_name = git.get_latest_tag_name()
+        assert tag_name is None
+
+        create_file_and_commit("feat(test): test")
+        cmd.run("git tag 1.0")
+        tag_name = git.get_latest_tag_name()
+        assert tag_name == "1.0"


### PR DESCRIPTION
## Description
originally, we use "----------commit-delimiter----------" to split git command result and strip them which should be "\n----------commit-delimiter----------\n" instead.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
Proceed as usual if users do not provide their email or commit message in their commit history


## Steps to Test This Pull Request
1. Create an empty project
2. `git init`
3. `touch test-file`
4. `git commit --author="Name <>" -m "whatever"`
5. `touch another-test-file`
6. `git commit --author="Name <>" -m "" --allow-empty`

## Additional context
#340 
