### PR TITLE
feat(changelog): add support for multiline BREAKING paragraph

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,4 +35,4 @@ exclude =
     build,
     dist
 max-line-length = 88
-max-complexity = 11
+max-complexity = 12

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -387,6 +387,30 @@ def test_breaking_change_content_v1(mocker, capsys):
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
+def test_breaking_change_content_v1_multiline(mocker, capsys):
+    commit_message = (
+        "feat(users): email pattern corrected\n\n"
+        "body content\n\n"
+        "BREAKING CHANGE: migrate by renaming user to users.\n"
+        "and then connect the thingy with the other thingy\n\n"
+        "footer content"
+    )
+    create_file_and_commit(commit_message)
+    testargs = ["cz", "changelog", "--dry-run"]
+    mocker.patch.object(sys, "argv", testargs)
+    with pytest.raises(DryRunExit):
+        cli.main()
+    out, _ = capsys.readouterr()
+
+    assert out == (
+        "## Unreleased\n\n### Feat\n\n- **users**: email pattern corrected\n\n"
+        "### BREAKING CHANGE\n\n- migrate by renaming user to users.\n"
+        "and then connect the thingy with the other thingy"
+        "\n\n"
+    )
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
 def test_changelog_config_flag_increment(mocker, changelog_path, config_path):
 
     with open(config_path, "a") as f:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
Support for multiline body, suppose a commit message like this:

```
fix: user issue

BREAKING CHANGE: this should be all picked up by commitizen itself, when
I do a new line like this, it will be included in the end result changelog

not this
```

Commitizen will detect a `fix` and a `BREAKING CHANGE`
both will be added to the changelog


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
1. Create a commit like the example above
2. Run `cz changelog`
3. Observe `cat CHANGELOG.md`

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
Closes #346