### PR TITLE
fix: add utf-8 encode when write toml file

### DIFF
--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -27,8 +27,8 @@ class TomlConfig(BaseConfig):
             parser = parse(f.read())
 
         parser["tool"]["commitizen"][key] = value
-        with open(self.path, "w") as f:
-            f.write(parser.as_string())
+        with open(self.path, "wb") as f:
+            f.write(parser.as_string().encode("utf-8"))
         return self
 
     def _parse_setting(self, data: Union[bytes, str]):


### PR DESCRIPTION
## Description
Add utf-8 encode when write toml file.


## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
Write toml file using binary mode.


## Steps to Test This Pull Request
Run `cz init` or `cz bump`.


## Additional context
#355

**Screenshots**
![image](https://user-images.githubusercontent.com/13810485/109296258-fbb8f080-786a-11eb-9db5-def0b0e06b89.png)
