### PR TITLE
feat: Support versions on random positions

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -154,7 +154,9 @@ def update_version_in_files(
         regex = regexes[0] if regexes else None
         current_version_found = False
 
-        version_file = open(filepath, "r").read()
+        with open(filepath, "r") as f:
+            version_file = f.read()
+
         match = regex and re.search(regex, version_file, re.MULTILINE)
         if match:
             left = version_file[: match.end()]
@@ -167,7 +169,7 @@ def update_version_in_files(
 
         if not regex:
             current_version_regex = _version_to_regex(current_version)
-            current_version_found = current_version_regex.search(version_file) and True
+            current_version_found = bool(current_version_regex.search(version_file))
             version_file = current_version_regex.sub(new_version, version_file)
 
         if check_consistency and not current_version_found:


### PR DESCRIPTION
First thanks for this quite good project!

## Description
This is a rather confusing logic but I decided to send this PR as a way to start the conversation.
I am trying to use commitizen to bump rust projects and its default way works fine when bumping the version inside a `Cargo.toml` as usually, your own package's version is on the top. But if you have a lock file, rust also bumps the version there. This PR was done in a way to bump the version only after something is matched, in the example, I used the project name so the versions_file could have something like `Cargo.lock:version:project-name` where it only bumps version if the project name was found before it.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
Bumping versions on `Cargo.lock` or any other file, should bump only the intended line.

## Steps to Test This Pull Request
Try to bump any Cargo.lock file or any file that can have your own version, randomly placed in it.
