### PR TITLE
Fix typo in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -177,7 +177,7 @@ See [Third-Party Commitizen Templates](third-party-commitizen.md).
 ### Why are `revert` and `chore` valid types in the check pattern of cz conventional_commits but not types we can select?
 
 `revert` and `chore` are added to the "pattern" in `cz check` in order to prevent backward errors, but officially they are not part of conventional commits, we are using the latest [types from Angular](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type) (they used to but were removed).
-However, you can create a customized `cz` with those extra types. (See [Customization](https://commitizen-tools.github.io/commitizen/customization/)
+However, you can create a customized `cz` with those extra types. (See [Customization](https://commitizen-tools.github.io/commitizen/customization/))
 
 See more discussion in issue [#142](https://github.com/commitizen-tools/commitizen/issues/142) and [#36](https://github.com/commitizen-tools/commitizen/issues/36)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Added a missing `)`.
<!-- Describe what the change is -->
