### PR TITLE
docs: remove duplicated file name

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -3,7 +3,7 @@ We have two different ways to do so.
 
 ## 1. Customize in configuration file
 
-**This is only supported when configuring through `toml` or `json` (e.g., `pyproject.toml`, `.cz.toml`, `.cz.toml`, `.cz.json`, and `cz.json`)**
+**This is only supported when configuring through `toml` or `json` (e.g., `pyproject.toml`, `.cz.toml`, `.cz.json`, and `cz.json`)**
 
 The basic steps are:
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
`.cz.toml` is specified twice and gets confusing.

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [x] Update the documentation for the changes
