### PR TITLE
fix(commands/init): fix toml config format error

### DIFF
--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -1,7 +1,8 @@
+import os
 from pathlib import Path
 from typing import Union
 
-from tomlkit import exceptions, parse
+from tomlkit import exceptions, parse, table
 
 from .base_config import BaseConfig
 
@@ -14,8 +15,17 @@ class TomlConfig(BaseConfig):
         self.add_path(path)
 
     def init_empty_config_content(self):
-        with open(self.path, "a") as toml_file:
-            toml_file.write("[tool.commitizen]")
+        if os.path.isfile(self.path):
+            with open(self.path, "rb") as input_toml_file:
+                parser = parse(input_toml_file.read())
+        else:
+            parser = parse("")
+
+        with open(self.path, "wb") as output_toml_file:
+            if parser.get("tool") is None:
+                parser["tool"] = table()
+            parser["tool"]["commitizen"] = table()
+            output_toml_file.write(parser.as_string().encode("utf-8"))
 
     def set_key(self, key, value):
         """Set or update a key in the conf.

--- a/tests/commands/test_init_command.py
+++ b/tests/commands/test_init_command.py
@@ -25,6 +25,7 @@ cz_hook_config = {
 }
 
 expected_config = (
+    "[tool]\n"
     "[tool.commitizen]\n"
     'name = "cz_conventional_commits"\n'
     'version = "0.0.1"\n'

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -132,7 +132,7 @@ class TestTomlConfig:
         toml_config.init_empty_config_content()
 
         with open(path, "r") as toml_file:
-            assert toml_file.read() == "[tool.commitizen]"
+            assert toml_file.read() == "[tool]\n[tool.commitizen]\n"
 
     def test_init_empty_config_content_with_existing_content(self, tmpdir):
         existing_content = "[tool.black]\n" "line-length = 88\n"
@@ -143,7 +143,7 @@ class TestTomlConfig:
         toml_config.init_empty_config_content()
 
         with open(path, "r") as toml_file:
-            assert toml_file.read() == existing_content + "[tool.commitizen]"
+            assert toml_file.read() == existing_content + "\n[tool.commitizen]\n"
 
 
 class TestJsonConfig:


### PR DESCRIPTION
## Description
fix(commands/init): fix toml config format error

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
Run `cz init` without encountering error

## Steps to Test This Pull Request
1. Run `cz init` with [this `pyproject.toml`](https://github.com/py-plato/plato/blob/v0.1.0/pyproject.toml)

## Additional context
#367
