### PR TITLE
ci(version): fix poetry project version and version_files config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,9 @@
 version = "2.17.1"
 tag_format = "v$version"
 version_files = [
-  "pyproject.toml:version",
-  "commitizen/__version__.py"
+    "pyproject.toml:[tool.commitizen]\nversion",
+    "pyproject.toml:[tool.poetry]\nname = \"commitizen\"\nversion",
+    "commitizen/__version__.py"
 ]
 
 [tool.black]
@@ -29,7 +30,7 @@ exclude = '''
 
 [tool.poetry]
 name = "commitizen"
-version = "2.17.0"
+version = "2.17.1"
 description = "Python commitizen client tool"
 authors = ["Santiago Fraire <santiwilly@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Description
We didn't clearly specify which version should be updated in `pyproject.toml`. After the fix of #361, we need to clearly specify it.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
Run `cz bump` and bump the version correctly


## Steps to Test This Pull Request
1. Run `cz bump`
2. Check the version in `pyproject.toml` in `poetry` and `commitizen` section

## Additional context
