### PR TITLE
fix: fix multiple versions bumps when version changes the string size

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -152,24 +152,15 @@ def update_version_in_files(
     for location in files:
         filepath, *regexes = location.split(":")
         regex = regexes[0] if regexes else None
-        current_version_found = False
 
         with open(filepath, "r") as f:
             version_file = f.read()
 
         if regex:
-            for match in re.finditer(regex, version_file, re.MULTILINE):
-                left = version_file[: match.end()]
-                right = version_file[match.end() :]
-                line_break = _get_line_break_position(right)
-                middle = right[:line_break]
-                current_version_found = current_version in middle
-                right = right[line_break:]
-                version_file = (
-                    left + middle.replace(current_version, new_version) + right
-                )
-
-        if not regex:
+            current_version_found, version_file = _bump_with_regex(
+                version_file, current_version, new_version, regex
+            )
+        else:
             current_version_regex = _version_to_regex(current_version)
             current_version_found = bool(current_version_regex.search(version_file))
             version_file = current_version_regex.sub(new_version, version_file)
@@ -184,6 +175,27 @@ def update_version_in_files(
         # Write the file out again
         with open(filepath, "w") as file:
             file.write("".join(version_file))
+
+
+def _bump_with_regex(version_file_contents, current_version, new_version, regex):
+    current_version_found = False
+    # Bumping versions that change the string length move the offset on the file contents as finditer keeps a
+    # reference to the initial string that was used and calling search many times would lead in infinite loops
+    # e.g.: 1.1.9 -> 1.1.20
+    offset = 0
+    for match in re.finditer(regex, version_file_contents, re.MULTILINE):
+        left = version_file_contents[: match.end() + offset]
+        right = version_file_contents[match.end() + offset :]
+        line_break = _get_line_break_position(right)
+        middle = right[:line_break]
+        current_version_found_in_block = current_version in middle
+        offset += len(new_version) - len(current_version)
+        current_version_found |= current_version_found_in_block
+        right = right[line_break:]
+        version_file_contents = (
+            left + middle.replace(current_version, new_version) + right
+        )
+    return current_version_found, version_file_contents
 
 
 def _get_line_break_position(text: str) -> int:

--- a/tests/test_bump_update_version_in_files.py
+++ b/tests/test_bump_update_version_in_files.py
@@ -50,6 +50,9 @@ name = "other-project"
 version = "1.2.3"
 """
 
+MULTIPLE_VERSIONS_INCREASE_STRING = 'version = "1.2.9"\n' * 30
+MULTIPLE_VERSIONS_REDUCE_STRING = 'version = "1.2.10"\n' * 30
+
 
 @pytest.fixture(scope="function")
 def commitizen_config_file(tmpdir):
@@ -83,6 +86,20 @@ def random_location_version_file(tmpdir):
 def version_repeated_file(tmpdir):
     tmp_file = tmpdir.join("package.json")
     tmp_file.write(REPEATED_VERSION_NUMBER)
+    return str(tmp_file)
+
+
+@pytest.fixture(scope="function")
+def multiple_versions_increase_string(tmpdir):
+    tmp_file = tmpdir.join("anyfile")
+    tmp_file.write(MULTIPLE_VERSIONS_INCREASE_STRING)
+    return str(tmp_file)
+
+
+@pytest.fixture(scope="function")
+def multiple_versions_reduce_string(tmpdir):
+    tmp_file = tmpdir.join("anyfile")
+    tmp_file.write(MULTIPLE_VERSIONS_REDUCE_STRING)
     return str(tmp_file)
 
 
@@ -136,6 +153,32 @@ def test_duplicates_are_change_with_no_regex(random_location_version_file):
         data = f.read()
         assert len(re.findall(old_version, data)) == 0
         assert len(re.findall(new_version, data)) == 3
+
+
+def test_version_bump_increase_string_length(multiple_versions_increase_string):
+    old_version = "1.2.9"
+    new_version = "1.2.10"
+    version_bump_change_string_size(
+        multiple_versions_increase_string, old_version, new_version
+    )
+
+
+def test_version_bump_reduce_string_length(multiple_versions_reduce_string):
+    old_version = "1.2.10"
+    new_version = "2.0.0"
+    version_bump_change_string_size(
+        multiple_versions_reduce_string, old_version, new_version
+    )
+
+
+def version_bump_change_string_size(filename, old_version, new_version):
+    location = f"{filename}:version"
+
+    bump.update_version_in_files(old_version, new_version, [location])
+    with open(filename, "r") as f:
+        data = f.read()
+        assert len(re.findall(old_version, data)) == 0
+        assert len(re.findall(new_version, data)) == 30
 
 
 def test_file_version_inconsistent_error(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
As I've commented [here](https://github.com/commitizen-tools/commitizen/pull/372#discussion_r615275718) the bug fix that fixes my bug also introduces a new one.
If you have a file that has many `version = 1.0.9` and you bump to `1.1.10` every time you bump the version, the file increases 1 byte, and `re.findall` keeps a reference to the old string making every iteration point to a character back like (version, versio, versi, vers, and etc) to the point where it would move to previous likes and the check that makes sure that the current version is found on the current line fails.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
All versions should be bumped no matter the size of the file and occurrences of a regex


## Steps to Test This Pull Request
1 - Have a file with at least 8 `version = 1.0.9` lines
2 - Bump version to `1.1.10` using `file:version` as the regex

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
#372 
#361 
