### PR TITLE
fix: version update in a docker-compose.yaml file

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -205,7 +205,7 @@ def _get_line_break_position(text: str) -> int:
 
 def _version_to_regex(version: str):
     clean_regex = version.replace(".", r"\.").replace("+", r"\+")
-    return re.compile(f"\\b{clean_regex}\\b")
+    return re.compile(f"{clean_regex}")
 
 
 def create_tag(version: Union[Version, str], tag_format: Optional[str] = None):

--- a/tests/test_bump_update_version_in_files.py
+++ b/tests/test_bump_update_version_in_files.py
@@ -50,6 +50,15 @@ name = "other-project"
 version = "1.2.3"
 """
 
+DOCKER_COMPOSE = """
+version: "3.3"
+
+services:
+  app:
+    image: my-repo/my-container:v1.2.3
+  command: my-command
+"""
+
 MULTIPLE_VERSIONS_INCREASE_STRING = 'version = "1.2.9"\n' * 30
 MULTIPLE_VERSIONS_REDUCE_STRING = 'version = "1.2.10"\n' * 30
 
@@ -104,8 +113,25 @@ def multiple_versions_reduce_string(tmpdir):
 
 
 @pytest.fixture(scope="function")
-def version_files(commitizen_config_file, python_version_file, version_repeated_file):
-    return [commitizen_config_file, python_version_file, version_repeated_file]
+def docker_compose_file(tmpdir):
+    tmp_file = tmpdir.join("docker-compose.yaml")
+    tmp_file.write(DOCKER_COMPOSE)
+    return str(tmp_file)
+
+
+@pytest.fixture(scope="function")
+def version_files(
+    commitizen_config_file,
+    python_version_file,
+    version_repeated_file,
+    docker_compose_file,
+):
+    return [
+        commitizen_config_file,
+        python_version_file,
+        version_repeated_file,
+        docker_compose_file,
+    ]
 
 
 def test_update_version_in_files(version_files):


### PR DESCRIPTION
## Description
Support updated versions in Docker Compose files.


## Checklist

- [X] Add test cases to all the changes you introduce
- [X] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [-] Update the documentation for the changes

## Expected behavior
A version which is used to build a docker container should be usable to update a docker-compose.yaml file which is used to deploy that docker container. E.g. this is the case in an automated CI/CD setup using Amazon Elasticbeanstalk.


## Steps to Test This Pull Request
1. Create a docker-compose.yaml file where the version is used as tag for a docker file
2. Add docker-compose to the `version_files` config setting
3. Bump version
4. Check if the docker-compose file is updated


## Additional context
Related to issue #371 
