### PR TITLE
Fix conventional commits schema pattern

### DIFF
--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -178,8 +178,8 @@ class ConventionalCommitsCz(BaseCommitizen):
 
     def schema_pattern(self) -> str:
         PATTERN = (
-            r"(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)!?"
-            r"(\(\S+\))?:(\s.*)"
+            r"(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)"
+            r"(\(\S+\))?!?:(\s.*)"
         )
         return PATTERN
 

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -125,11 +125,7 @@ def test_check_conventional_commit_succeeds(mocker, capsys):
 
 
 @pytest.mark.parametrize(
-    "commit_msg",
-    (
-        "feat!(lang): removed polish language",
-        "no conventional commit",
-    ),
+    "commit_msg", ("feat!(lang): removed polish language", "no conventional commit",),
 )
 def test_check_no_conventional_commit(commit_msg, config, mocker, tmpdir):
     with pytest.raises(InvalidCommitMessageError):

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -124,12 +124,19 @@ def test_check_conventional_commit_succeeds(mocker, capsys):
     assert "Commit validation: successful!" in out
 
 
-def test_check_no_conventional_commit(config, mocker, tmpdir):
+@pytest.mark.parametrize(
+    "commit_msg",
+    (
+        "feat!(lang): removed polish language",
+        "no conventional commit",
+    ),
+)
+def test_check_no_conventional_commit(commit_msg, config, mocker, tmpdir):
     with pytest.raises(InvalidCommitMessageError):
         error_mock = mocker.patch("commitizen.out.error")
 
         tempfile = tmpdir.join("temp_commit_file")
-        tempfile.write("no conventional commit")
+        tempfile.write(commit_msg)
 
         check_cmd = commands.Check(
             config=config, arguments={"commit_msg_file": tempfile}
@@ -141,6 +148,7 @@ def test_check_no_conventional_commit(config, mocker, tmpdir):
 @pytest.mark.parametrize(
     "commit_msg",
     (
+        "feat(lang)!: removed polish language",
         "feat(lang): added polish language",
         "feat: add polish language",
         "bump: 0.0.1 -> 1.0.0",

--- a/tests/test_cz_conventional_commits.py
+++ b/tests/test_cz_conventional_commits.py
@@ -132,21 +132,13 @@ def test_info(config):
     assert isinstance(info, str)
 
 
-@pytest.mark.parametrize(("commit_message", "expected_message"),
+@pytest.mark.parametrize(
+    ("commit_message", "expected_message"),
     [
-        (
-            "test(test_scope): this is test msg",
-            "this is test msg",
-        ),
-        (
-            "test(test_scope)!: this is test msg",
-            "this is test msg",
-        ),
-        (
-            "test!(test_scope): this is test msg",
-            "",
-        ),
-    ]
+        ("test(test_scope): this is test msg", "this is test msg",),
+        ("test(test_scope)!: this is test msg", "this is test msg",),
+        ("test!(test_scope): this is test msg", "",),
+    ],
 )
 def test_process_commit(commit_message, expected_message, config):
     conventional_commits = ConventionalCommitsCz(config)

--- a/tests/test_cz_conventional_commits.py
+++ b/tests/test_cz_conventional_commits.py
@@ -132,7 +132,23 @@ def test_info(config):
     assert isinstance(info, str)
 
 
-def test_process_commit(config):
+@pytest.mark.parametrize(("commit_message", "expected_message"),
+    [
+        (
+            "test(test_scope): this is test msg",
+            "this is test msg",
+        ),
+        (
+            "test(test_scope)!: this is test msg",
+            "this is test msg",
+        ),
+        (
+            "test!(test_scope): this is test msg",
+            "",
+        ),
+    ]
+)
+def test_process_commit(commit_message, expected_message, config):
     conventional_commits = ConventionalCommitsCz(config)
-    message = conventional_commits.process_commit("test(test_scope): this is test msg")
-    assert message == "this is test msg"
+    message = conventional_commits.process_commit(commit_message)
+    assert message == expected_message


### PR DESCRIPTION
## Description
Adjust schema_pattern in cz_conventional_commits to match the conventional_commits spec


## Checklist

- [X] Add test cases to all the changes you introduce
- [X] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
- `cz -n cz_conventional_commits check -m "feat!(scope): message"` to fail validation
- `cz -n cz_conventional_commits check -m "feat(scope)!: message"` to pass validation


## Steps to Test This Pull Request
1. Check out this branch
2. Run commands as described in "Expected behaviour"


## Additional context
#381
