### PR TITLE
feat(#173): support CalVer tag formatting

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -124,7 +124,7 @@ class Bump:
         if increment is None:
             increment = self.find_increment(commits)
 
-        # It may happen that there are commits, but they are not elegible
+        # It may happen that there are commits, but they are not eligible
         # for an increment, this generates a problem when using prerelease (#281)
         if (
             prerelease
@@ -147,6 +147,7 @@ class Bump:
             increment,
             prerelease=prerelease,
             is_local_version=is_local_version,
+            tag_format=tag_format,
         )
 
         new_tag_version = bump.create_tag(new_version, tag_format=tag_format)

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -51,8 +51,7 @@ class Init:
     def _ask_config_path(self) -> str:
         name = questionary.select(
             "Please choose a supported config file: (default: pyproject.toml)",
-            # Incompatible type "List[str]"; expected "List[Union[str, Choice, Dict[str, Any]]]"
-            choices=config_files,  # type: ignore
+            choices=config_files,
             default="pyproject.toml",
             style=self.cz.style,
         ).ask()

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -51,7 +51,8 @@ class Init:
     def _ask_config_path(self) -> str:
         name = questionary.select(
             "Please choose a supported config file: (default: pyproject.toml)",
-            choices=config_files,
+            # Incompatible type "List[str]"; expected "List[Union[str, Choice, Dict[str, Any]]]"
+            choices=config_files,  # type: ignore
             default="pyproject.toml",
             style=self.cz.style,
         ).ask()

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -183,26 +183,28 @@ cz bump --changelog --changelog-to-stdout > body.md
 
 ### `tag_format`
 
-It is used to read the format from the git tags, and also to generate the tags.
+The `tag_format` is used to parse the format from the git tags and to generate new tags.
 
-Commitizen supports 2 types of formats, a simple and a more complex.
+Commitizen defaults to the standard Semver format (`$version`) or can be customized using a predefined set of variables.
 
 ```bash
 cz bump --tag-format="v$version"
 ```
 
 ```bash
-cz bump --tag-format="v$minor.$major.$patch$prerelease"
+cz bump --tag-format="v$major.$minor.$patch$prerelease"
 ```
 
 In your `pyproject.toml` or `.cz.toml`
 
 ```toml
 [tool.commitizen]
-tag_format = "v$minor.$major.$patch$prerelease"
+tag_format = "v$major.$minor.$patch$prerelease"
 ```
 
-The variables must be preceded by a `$` sign.
+#### Standard SemVer Variables
+
+The SemVer variables must be preceded by a `$` sign.
 
 Supported variables:
 
@@ -213,6 +215,34 @@ Supported variables:
 | `$minor`      | MINOR increment                            |
 | `$patch`      | PATCH increment                            |
 | `$prerelease` | Prerelase (alpha, beta, release candidate) |
+
+#### CalVer Variables
+
+Commitizen also supports [CalVer](https://calver.org/) in any combination with or without SemVer; however, using standard CalVer formats is recommended for interoperability with other tools. Common CalVer `tag_format`'s include `%Y.%m` or `%y.%m.%d`.
+
+If a unique build number is desired, this could either be implemented by incrementing the string in the configuration file with whatever build tool is used (i.e. `%Y.%m.123` to `%Y.%m.124`) or by mapping all commit types to one SemVer component through the `bump_map` configuration and a `tag_format` of `"%Y.%m.$major`.
+
+```bash
+cz bump --tag-format="%y.%-m.%-d$prerelease"
+cz bump --tag-format="%Y.%m.$major.$prerelease"
+cz bump --tag-format="%Y.%m.$version"
+```
+
+```toml
+[tool.commitizen]
+tag_format = "%Y.%m.%d$prerelease"
+```
+
+The full `strftime` formatting options are supported. Below are the most common for CalVer. For a full list, see: [https://strftime.org/](https://strftime.org/)
+
+| Code  | Description                                                | Example       |
+| ----- | ---------------------------------------------------------- | ------------- |
+| `%y`  | Year without century as a zero-padded decimal number.      | 08 (for 2008) |
+| `%Y`  | Year with century as a decimal number.                     | 2008          |
+| `$m`  | Month as a zero-padded decimal number.                     | 01 (for Jan)  |
+| `$-m` | Month as a decimal number. (Platform specific)             | 1 (for Jan)   |
+| `$d`  | Day of the month as a zero-padded decimal number.          | 05            |
+| `$-d` | Day of the month as a decimal number. (Platform specific)  | 5             |
 
 ---
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -170,7 +170,7 @@ commitizen:
 When the [`use_shortcuts`](https://commitizen-tools.github.io/commitizen/config/#settings) config option is enabled, commitizen can show and use keyboard shortcuts to select items from lists directly.
 For example, when using the `cz_conventional_commits` commitizen template, shortcut keys are shown when selecting the commit type. Unless otherwise defined, keyboard shortcuts will be numbered automatically.
 To specify keyboard shortcuts for your custom choices, provide the shortcut using the `key` parameter in dictionary form for each choice you would like to customize.
- 
+
 ## 2. Customize through customizing a class
 
 The basic steps are:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ pytest-regressions = "^2.2.0"
 pytest-freezegun = "^0.4.2"
 types-PyYAML = "^5.4.3"
 types-termcolor = "^0.1.1"
+types-freezegun = "^1.1.0"
 
 [tool.poetry.scripts]
 cz = "commitizen.cli:main"

--- a/tests/test_bump_create_tag.py
+++ b/tests/test_bump_create_tag.py
@@ -1,4 +1,5 @@
 import pytest
+from freezegun import freeze_time
 from packaging.version import Version
 
 from commitizen import bump
@@ -13,9 +14,16 @@ conversion = [
     (("1.2.3+1.0.0", "v$version"), "v1.2.3+1.0.0"),
     (("1.2.3+1.0.0", "v$version-local"), "v1.2.3+1.0.0-local"),
     (("1.2.3+1.0.0", "ver$major.$minor.$patch"), "ver1.2.3"),
+    (("1.2.3a1", "%y.%m.%d$prerelease"), "21.05.06a1"),
+    (("1.2.3a1", "%Y.%-m.%-d$prerelease"), "2021.5.6a1"),
+    (("1.2.3a1", "%y.%-m.$major.$minor"), "21.5.1.2"),
+    (("2021.01.31a1", "%Y.%-m.%-d$prerelease"), "2021.5.6a1"),
+    (("21.04.02", "%y.%m.%d"), "21.05.06"),
+    (("21.4.2.1.2", "%y.%-m.%-d.$major.$minor"), "21.5.6.1.2"),
 ]
 
 
+@freeze_time("2021-5-6")
 @pytest.mark.parametrize("test_input,expected", conversion)
 def test_create_tag(test_input, expected):
     version, format = test_input

--- a/tests/test_bump_find_version.py
+++ b/tests/test_bump_find_version.py
@@ -95,3 +95,23 @@ def test_generate_version_local(test_input, expected):
         prerelease=prerelease,
         is_local_version=is_local_version,
     ) == Version(expected)
+
+
+@pytest.mark.parametrize(
+    "current_version,increment,tag_format,expected,",
+    (
+        ("0.1.1", "MINOR", "v$version", "0.2.0"),
+        ("21.05.06", "PATCH", "%y.%m.%d", "21.05.06"),
+        ("21.5.6.1.2", "MAJOR", "%y.%-m.%-d.$major.$minor", "21.5.6.2.0"),
+    ),
+)
+def test_generate_version_with_formats(
+    current_version, increment, tag_format, expected
+):
+    assert generate_version(
+        current_version,
+        increment=increment,
+        prerelease=None,
+        is_local_version=False,
+        tag_format=tag_format,
+    ) == Version(expected)


### PR DESCRIPTION
Closes: #173 

## Description

Adds flexible support for CalVer using `strftime`

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior / Steps to Test This Pull Request

Include `strftime` code in `tag_format` (i.e. `cz bump --tag-format="%Y.%M.$version"`)

---

FYI: there are type tests failing unrelated to this PR. All of `pytest`, formatting, and other tests pass locally except for `mypy`

```
commitizen/config/toml_config.py:52: error: Argument 1 to "parse" has incompatible type "Union[bytes, str]"; expected "str"
commitizen/config/toml_config.py:54: error: Value of type "Union[Item, Container]" is not indexable
commitizen/config/toml_config.py:54: error: Argument 1 to "update" of "dict" has incompatible type "Union[Any, Item, Container]"; expected "Mapping[str, Any]"
Found 3 errors in 1 file (checked 59 source files)
```