### PR TITLE
fix(changelog): annotated tags not generating proper changelog

### DIFF
--- a/tests/commands/test_changelog_command/test_changelog_incremental_keep_a_changelog_sample_with_annotated_tag.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_keep_a_changelog_sample_with_annotated_tag.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Feat
+
+- add more stuff
+- add new output
+
+### Fix
+
+- mama gotta work
+- output glitch
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -19,9 +19,9 @@ def test_git_object_eq():
 
 def test_get_tags(mocker):
     tag_str = (
-        "v1.0.0---inner_delimiter---333---inner_delimiter---2020-01-20\n"
-        "v0.5.0---inner_delimiter---222---inner_delimiter---2020-01-17\n"
-        "v0.0.1---inner_delimiter---111---inner_delimiter---2020-01-17\n"
+        "v1.0.0---inner_delimiter---333---inner_delimiter---2020-01-20---inner_delimiter---\n"
+        "v0.5.0---inner_delimiter---222---inner_delimiter---2020-01-17---inner_delimiter---\n"
+        "v0.0.1---inner_delimiter---111---inner_delimiter---2020-01-17---inner_delimiter---\n"
     )
     mocker.patch("commitizen.cmd.run", return_value=FakeCommand(out=tag_str))
 


### PR DESCRIPTION
Closes #378

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
Both annotated and not annotated tags should work.


## Steps to Test This Pull Request

```
git clone https://github.com/Trim21/transmission-rpc.git

cd transmission-rpc

pip install -U commitizen

cz changelog

git tag -l
```


## Additional context
Now both annotated and not annotated are detected. If there's no `object` from an annotated, it means we have a lightweight tag.

Please also @Trim21 let me know if this patch works for you
