### PR TITLE
fix(changelog): generating changelog after a pre-release

### DIFF
--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -43,4 +43,4 @@ bump_message = "bump: version $current_version → $new_version"
 change_type_order = ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"]
 
 commit_parser = r"^(?P<change_type>feat|fix|refactor|perf|BREAKING CHANGE)(?:\((?P<scope>[^()\r\n]*)\)|\()?(?P<breaking>!)?:\s(?P<message>.*)?"  # noqa
-version_parser = r"(?P<version>([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?)"
+version_parser = r"(?P<version>([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?(\w+)?)"

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 [![Supported versions](https://img.shields.io/pypi/pyversions/commitizen.svg?style=flat-square)](https://pypi.org/project/commitizen/)
 [![homebrew](https://img.shields.io/homebrew/v/commitizen?color=teal&style=flat-square)](https://formulae.brew.sh/formula/commitizen)
 [![Codecov](https://img.shields.io/codecov/c/github/commitizen-tools/commitizen.svg?style=flat-square)](https://codecov.io/gh/commitizen-tools/commitizen)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?style=flat-square&logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 
 ![Using commitizen cli](images/demo.gif)
 

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -480,3 +480,36 @@ def test_changelog_incremental_keep_a_changelog_sample_with_annotated_tag(
         out = f.read()
 
     file_regression.check(out, extension=".md")
+
+
+@pytest.mark.parametrize("test_input", ["rc", "alpha", "beta"])
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_changelog_incremental_with_release_candidate_version(
+    mocker, capsys, changelog_path, file_regression, test_input
+):
+    """Fix #357"""
+    with open(changelog_path, "w") as f:
+        f.write(KEEP_A_CHANGELOG)
+    create_file_and_commit("irrelevant commit")
+    git.tag("1.0.0", annotated=True)
+
+    create_file_and_commit("feat: add new output")
+    create_file_and_commit("fix: output glitch")
+
+    testargs = ["cz", "bump", "--changelog", "--prerelease", test_input, "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    create_file_and_commit("fix: mama gotta work")
+    create_file_and_commit("feat: add more stuff")
+    create_file_and_commit("Merge into master")
+
+    testargs = ["cz", "changelog", "--incremental"]
+
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    with open(changelog_path, "r") as f:
+        out = f.read()
+
+    file_regression.check(out, extension=".md")

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_release_candidate_version_alpha_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_release_candidate_version_alpha_.md
@@ -1,0 +1,40 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Feat
+
+- add more stuff
+
+### Fix
+
+- mama gotta work
+
+## 0.2.0a0 (2021-06-11)
+
+### Fix
+
+- output glitch
+
+### Feat
+
+- add new output
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_release_candidate_version_beta_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_release_candidate_version_beta_.md
@@ -1,0 +1,40 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Feat
+
+- add more stuff
+
+### Fix
+
+- mama gotta work
+
+## 0.2.0b0 (2021-06-11)
+
+### Fix
+
+- output glitch
+
+### Feat
+
+- add new output
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_release_candidate_version_rc_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_release_candidate_version_rc_.md
@@ -1,0 +1,40 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Feat
+
+- add more stuff
+
+### Fix
+
+- mama gotta work
+
+## 0.2.0rc0 (2021-06-11)
+
+### Fix
+
+- output glitch
+
+### Feat
+
+- add new output
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).


### PR DESCRIPTION
Closes #357

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Trying to create an incremental changelog after a prerelease failed.
This happened because of the version regex when parsing the changelog.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
You'll see the changelog created

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

```
# step1 init everything, not exactly relevant to the bug
git init
cz init
git add .
git commit -m "chore: add config"
git tag 0.0.1

# step2 add a dummy feature and make a pre-release
git commit -m "feat: first feat" --allow-empty
cz bump --prerelease rc --changelog

# step3 add another feature and try to do incremental changelog
git commit -m "feat: second feat" --allow-empty
cz changelog --incremental
```
