### PR TITLE
fix: correct indentation for json config for better readability

### DIFF
--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -27,7 +27,7 @@ class JsonConfig(BaseConfig):
 
         parser["commitizen"][key] = value
         with open(self.path, "w") as f:
-            json.dump(parser, f)
+            json.dump(parser, f, indent=2)
         return self
 
     def _parse_setting(self, data: Union[bytes, str]):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Output the json config as multi line instead of single-line.
This is much more readable.


## Checklist

- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

Output should look like this:
```json
{
  "commitizen": {
    "name": "cz_conventional_commits",
    "version": "0.0.1",
    "tag_format": "$version"
  }
}
```
