### PR TITLE
doc: inverse major and minor

### DIFF
--- a/docs/bump.md
+++ b/docs/bump.md
@@ -199,7 +199,7 @@ In your `pyproject.toml` or `.cz.toml`
 
 ```toml
 [tool.commitizen]
-tag_format = "v$minor.$major.$patch$prerelease"
+tag_format = "v$major.$minor.$patch$prerelease"
 ```
 
 The variables must be preceded by a `$` sign.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
I think it was a typo. In the example, the major and minor keyword were set in a strange order. I changed it to stay consistent with PEP


## Checklist

- [ ] `N/A` Add test cases to all the changes you introduce
- [ ] `N/A` Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [ ] `N/A` Test the changes on the local machine manually
- [x] Update the documentation for the changes
