### PR TITLE
feat(#426): system info utility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,11 +28,18 @@ If applicable, add screenshots to help explain your problem.
 
 ## Environment
 <!--
+For older commitizen versions, please include the
+output of the following commands manually:
+
 cz version
 python --version
 python3 -c "import platform; print(platform.system())"
 -->
-
+Add output of the following command to include the following
 - commitizen version:
 - python version:
 - operating system:
+```bash
+cz version --report
+```
+

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -228,6 +228,12 @@ data = {
                 "func": commands.Version,
                 "arguments": [
                     {
+                        "name": ["-r", "--report"],
+                        "help": "get system information for reporting bugs",
+                        "action": "store_true",
+                        "exclusive_group": "group1",
+                    },
+                    {
                         "name": ["-p", "--project"],
                         "help": "get the version of the current project",
                         "action": "store_true",

--- a/commitizen/commands/version.py
+++ b/commitizen/commands/version.py
@@ -1,3 +1,6 @@
+import platform
+import sys
+
 from commitizen import out
 from commitizen.__version__ import __version__
 from commitizen.config import BaseConfig
@@ -9,9 +12,15 @@ class Version:
     def __init__(self, config: BaseConfig, *args):
         self.config: BaseConfig = config
         self.parameter = args[0]
+        self.operating_system = platform.system()
+        self.python_version = sys.version
 
     def __call__(self):
-        if self.parameter.get("project"):
+        if self.parameter.get("report"):
+            out.write(f"Commitizen Version: {__version__}")
+            out.write(f"Python Version: {self.python_version}")
+            out.write(f"Operating System: {self.operating_system}")
+        elif self.parameter.get("project"):
             version = self.config.settings["version"]
             if version:
                 out.write(f"{version}")

--- a/tests/commands/test_version_command.py
+++ b/tests/commands/test_version_command.py
@@ -1,42 +1,72 @@
+import platform
+import sys
+
 from commitizen import commands
 from commitizen.__version__ import __version__
 
 
 def test_version_for_showing_project_version(config, capsys):
     # No version exist
-    commands.Version(config, {"project": True, "commitizen": False, "verbose": False})()
+    commands.Version(
+        config,
+        {"report": False, "project": True, "commitizen": False, "verbose": False},
+    )()
     captured = capsys.readouterr()
     assert "No project information in this project." in captured.err
 
     config.settings["version"] = "v0.0.1"
-    commands.Version(config, {"project": True, "commitizen": False, "verbose": False})()
+    commands.Version(
+        config,
+        {"report": False, "project": True, "commitizen": False, "verbose": False},
+    )()
     captured = capsys.readouterr()
     assert "v0.0.1" in captured.out
 
 
 def test_version_for_showing_commitizen_version(config, capsys):
-    commands.Version(config, {"project": False, "commitizen": True, "verbose": False})()
+    commands.Version(
+        config,
+        {"report": False, "project": False, "commitizen": True, "verbose": False},
+    )()
     captured = capsys.readouterr()
     assert f"{__version__}" in captured.out
 
     # default showing commitizen version
     commands.Version(
-        config, {"project": False, "commitizen": False, "verbose": False}
+        config,
+        {"report": False, "project": False, "commitizen": False, "verbose": False},
     )()
     captured = capsys.readouterr()
     assert f"{__version__}" in captured.out
 
 
 def test_version_for_showing_both_versions(config, capsys):
-    commands.Version(config, {"project": False, "commitizen": False, "verbose": True})()
+    commands.Version(
+        config,
+        {"report": False, "project": False, "commitizen": False, "verbose": True},
+    )()
     captured = capsys.readouterr()
     assert f"Installed Commitizen Version: {__version__}" in captured.out
     assert "No project information in this project." in captured.err
 
     config.settings["version"] = "v0.0.1"
-    commands.Version(config, {"project": False, "commitizen": False, "verbose": True})()
+    commands.Version(
+        config,
+        {"report": False, "project": False, "commitizen": False, "verbose": True},
+    )()
     captured = capsys.readouterr()
     expected_out = (
         f"Installed Commitizen Version: {__version__}\n" f"Project Version: v0.0.1"
     )
     assert expected_out in captured.out
+
+
+def test_version_for_showing_commitizen_system_info(config, capsys):
+    commands.Version(
+        config,
+        {"report": True, "project": False, "commitizen": False, "verbose": False},
+    )()
+    captured = capsys.readouterr()
+    assert f"Commitizen Version: {__version__}" in captured.out
+    assert f"Python Version: {sys.version}" in captured.out
+    assert f"Operating System: {platform.system()}" in captured.out


### PR DESCRIPTION
command to show system info output for bug reports

Issue #426

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
As mentioned in issue #426 , a single line command would be preferable to fetch system information
I added a `--report` flag to the `version` command for doing that.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
System info can be output using a single command which can be attached to bug report


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

```bash 
commitizen version --report
```


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
