### PR TITLE
fix(cli): handle argparse different behavior after python 3.9

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -286,8 +286,13 @@ def main():
     # This is for the command required constraint in 2.0
     try:
         args = parser.parse_args()
-    except TypeError:
-        raise NoCommandFoundError()
+    except (TypeError, SystemExit) as e:
+        # https://github.com/commitizen-tools/commitizen/issues/429
+        # argparse raises TypeError when non exist command is provided on Python < 3.9
+        # but raise SystemExit with exit code == 2 on Python 3.9
+        if isinstance(e, TypeError) or (isinstance(e, SystemExit) and e.code == 2):
+            raise NoCommandFoundError()
+        raise e
 
     if args.name:
         conf.update({"name": args.name})


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
argparse raises TypeError when non exist command is provided on Python < 3.9
but raise SystemExit with exit code == 2 on Python 3.9
this error does not break anything obviously from the user perspective, but will break our existing test

#429

This issue is caused by https://bugs.python.org/issue29298. The new checking is the correct one, but we'll need to keep the old one for backward compatibility. This fix was first introduced on [3.9.7](https://github.com/python/cpython/tree/v3.9.7) 👉 see [argparse.py#L730-L731](https://github.com/python/cpython/blob/v3.9.7/Lib/argparse.py#L730-L731)


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
detailed on #429 


## Steps to Test This Pull Request
detailed on #429

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
