### PR TITLE
Feat/addional config ch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,7 +53,7 @@ body:
         - commitizen version: `cz version`
         - python version: `python --version`
         - operating system: `python3 -c "import platform; print(platform.system())"`
-        
+
         ```bash
         cz version --report
         ```

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 default_stages: [push]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v4.1.0
     hooks:
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
-        exclude: "tests/[test_*|data]/*"
+        exclude: "tests/[test_*|data|commands/tests_*]/*"
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
       - id: debug-statements

--- a/commitizen/cz/customize/customize.py
+++ b/commitizen/cz/customize/customize.py
@@ -38,6 +38,18 @@ class CustomizeCommitsCz(BaseCommitizen):
         if custom_change_type_order:
             self.change_type_order = custom_change_type_order
 
+        commit_parser = self.custom_settings.get("commit_parser")
+        if commit_parser:
+            self.commit_parser = commit_parser
+
+        changelog_pattern = self.custom_settings.get("changelog_pattern")
+        if changelog_pattern:
+            self.changelog_pattern = changelog_pattern
+
+        change_type_map = self.custom_settings.get("change_type_map")
+        if change_type_map:
+            self.change_type_map = change_type_map
+
     def questions(self) -> Questions:
         return self.custom_settings.get("questions", [{}])
 

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -1,6 +1,6 @@
 import pathlib
 from collections import OrderedDict
-from typing import Any, Iterable, List, MutableMapping, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Tuple, Union
 
 from typing_extensions import TypedDict
 
@@ -20,6 +20,9 @@ class CzSettings(TypedDict, total=False):
     info_path: Union[str, pathlib.Path]
     info: str
     message_template: str
+    commit_parser: Optional[str]
+    changelog_pattern: Optional[str]
+    change_type_map: Optional[Dict[str, str]]
 
 
 class Settings(TypedDict, total=False):

--- a/docs/auto_check.md
+++ b/docs/auto_check.md
@@ -1,7 +1,7 @@
 # Automatically check message before commit
 
 ## About
-To automatically check a commit message prior to committing, you can use a [git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks). 
+To automatically check a commit message prior to committing, you can use a [git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).
 
 ## How to
 There are two common methods for installing the hook:
@@ -62,4 +62,3 @@ Each time you create a commit, automatically, this hook will analyze it.
 If the commit message is invalid, it'll be rejected.
 
 The commit should follow the given committing rules; otherwise, it won't be accepted.
-

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -26,6 +26,9 @@ info_path = "cz_customize_info.txt"
 info = """
 This is customized info
 """
+commit_parser = "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?"
+changelog_pattern = "^(feature|bug fix)?(!)?"
+change_type_map = {"feature" = "Feat", "bug fix" = "Fix"}
 
 [[tool.commitizen.customize.questions]]
 type = "list"
@@ -66,6 +69,9 @@ The equivalent example for a json config file:
             "change_type_order": ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"],
             "info_path": "cz_customize_info.txt",
             "info": "This is customized info",
+            "commit_parser": "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?",
+            "changelog_pattern": "^(feature|bug fix)?(!)?",
+            "change_type_map": {"feature": "Feat", "bug fix": "Fix"},
             "questions": [
                 {
                     "type": "list",
@@ -109,6 +115,11 @@ commitizen:
     schema: "<type>: <body>"
     schema_pattern: "(feature|bug fix):(\\s.*)"
     bump_pattern: "^(break|new|fix|hotfix)"
+    commit_parser: "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?",
+    changelog_pattern: "^(feature|bug fix)?(!)?",
+    change_type_map:
+      feature: Feat
+      bug fix: Fix
     bump_map:
       break: MAJOR
       new: MINOR
@@ -148,8 +159,12 @@ commitizen:
 | `bump_map`          | `dict` | `None`  | (OPTIONAL) Dictionary mapping the extracted information to a `SemVer` increment type (`MAJOR`, `MINOR`, `PATCH`)                                                                                                                 |
 | `bump_pattern`      | `str`  | `None`  | (OPTIONAL) Regex to extract information from commit (subject and body)                                                                                                                                                           |
 | `change_type_order` | `str`  | `None`  | (OPTIONAL) List of strings used to order the Changelog. All other types will be sorted alphabetically. Default is `["BREAKING CHANGE", "feat", "fix", "refactor", "perf"]`                                                       |
+| `commit_parser`     | `str`  | `None`  | (OPTIONAL) Regex to extract information used in creating changelog. [See more][changelog-spec]                                                                                                                                   |
+| `changelog_pattern` | `str`  | `None`  | (OPTIONAL) Regex to understand which commits to include in the changelog                                                                                                                                                         |
+| `change_type_map`   | `dict` | `None`  | (OPTIONAL) Dictionary mapping the type of the commit to a changelog entry                                                                                                                                                        |
 
 [jinja2]: https://jinja.palletsprojects.com/en/2.10.x/
+[changelog-spec]: https://commitizen-tools.github.io/commitizen/changelog/
 
 #### Detailed `questions` content
 

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -3,13 +3,43 @@ import os
 import pytest
 
 from commitizen import defaults
-from commitizen.config import BaseConfig
+from commitizen.config import BaseConfig, JsonConfig
 
 
 @pytest.fixture()
 def config():
     _config = BaseConfig()
     _config.settings.update({"name": defaults.DEFAULT_SETTINGS["name"]})
+    return _config
+
+
+@pytest.fixture()
+def config_customize():
+    json_string = r"""{
+      "commitizen": {
+        "name": "cz_customize",
+        "version": "3.0.0",
+        "changelog_incremental": "true",
+        "customize": {
+          "message_template": "{{prefix}}({{scope}}): {{subject}}\n\n{{body}}{% if is_breaking_change %}\nBREAKING CHANGE: {{footer}}{% endif %}",
+          "schema": "<type>(<scope>): <subject>\n<BLANK LINE>\n<body>\n<BLANK LINE>\n(BREAKING CHANGE: <footer>)",
+          "schema_pattern": "(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)(\\(\\S+\\))?!?:(\\s.*)",
+          "change_type_map": {
+            "feat": "Feat",
+            "fix": "Fix",
+            "refactor": "Refactor",
+            "perf": "Perf"
+          },
+          "change_type_order": ["Refactor", "Feat"],
+          "commit_parser": "^(?P<change_type>feat|fix|refactor|perf|BREAKING CHANGE)(?:\\((?P<scope>[^()\\r\\n]*)\\)|\\()?(?P<breaking>!)?:\\s(?P<message>.*)?",
+          "changelog_pattern": "^(BREAKING[\\-\\ ]CHANGE|feat|fix|refactor|perf)(\\(.+\\))?(!)?",
+          "questions": [
+
+          ]
+        }
+      }
+    }"""
+    _config = JsonConfig(data=json_string, path="not_exist.json")
     return _config
 
 

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -264,6 +264,28 @@ def test_changelog_hook(mocker, config):
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
+def test_changelog_hook_customize(mocker, config_customize):
+    changelog_hook_mock = mocker.Mock()
+    changelog_hook_mock.return_value = "cool changelog hook"
+
+    create_file_and_commit("feat: new file")
+    create_file_and_commit("refactor: is in changelog")
+    create_file_and_commit("Merge into master")
+
+    changelog = Changelog(
+        config_customize,
+        {"unreleased_version": None, "incremental": True, "dry_run": False},
+    )
+    mocker.patch.object(changelog.cz, "changelog_hook", changelog_hook_mock)
+    changelog()
+    full_changelog = (
+        "## Unreleased\n\n### Refactor\n\n- is in changelog\n\n### Feat\n\n- new file\n"
+    )
+
+    changelog_hook_mock.assert_called_with(full_changelog, full_changelog)
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
 def test_changelog_multiple_incremental_do_not_add_new_lines(
     mocker, capsys, changelog_path
 ):

--- a/tests/test_cz_customize.py
+++ b/tests/test_cz_customize.py
@@ -10,6 +10,9 @@ TOML_STR = r"""
     example = "feature: this feature enable customize through config file"
     schema = "<type>: <body>"
     schema_pattern = "(feature|bug fix):(\\s.*)"
+    commit_parser = "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?"
+    changelog_pattern = "^(feature|bug fix)?(!)?"
+    change_type_map = {"feature" = "Feat", "bug fix" = "Fix"}
 
     bump_pattern = "^(break|new|fix|hotfix)"
     bump_map = {"break" = "MAJOR", "new" = "MINOR", "fix" = "PATCH", "hotfix" = "PATCH"}
@@ -57,6 +60,9 @@ JSON_STR = r"""
                     "fix": "PATCH",
                     "hotfix": "PATCH"
                 },
+                "commit_parser": "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?",
+                "changelog_pattern": "^(feature|bug fix)?(!)?",
+                "change_type_map": {"feature": "Feat", "bug fix": "Fix"},
                 "change_type_order": ["perf", "BREAKING CHANGE", "feat", "fix", "refactor"],
                 "info": "This is a customized cz.",
                 "questions": [
@@ -363,3 +369,18 @@ def test_info_with_info_path(tmpdir, config_info):
 def test_info_without_info(config_without_info):
     cz = CustomizeCommitsCz(config_without_info)
     assert cz.info() is None
+
+
+def test_commit_parser(config):
+    cz = CustomizeCommitsCz(config)
+    assert cz.commit_parser == "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?"
+
+
+def test_changelog_pattern(config):
+    cz = CustomizeCommitsCz(config)
+    assert cz.changelog_pattern == "^(feature|bug fix)?(!)?"
+
+
+def test_change_type_map(config):
+    cz = CustomizeCommitsCz(config)
+    assert cz.change_type_map == {"feature": "Feat", "bug fix": "Fix"}


### PR DESCRIPTION
## Description
Adding commit_parser, changelog_pattern, change_type_map as customizable fields in customize.py

I noticed that when customizing the tool, the changelog was not properly created, given the impossibility to specify a commit_parser. While adding the feature, I also added the possibility to specify a regex for changelog_pattern and the mapping contained in change_type_map.


## Checklist

- [X] Add test cases to all the changes you introduce
- [X] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [X] Update the documentation for the changes

## Expected behavior
When creating a changelog with a user-defined regex, the changelog should have the correct entries.

![image](https://user-images.githubusercontent.com/15369570/136054212-6753bab4-1a39-4004-ab52-f94f2c38c5f3.png)

## Steps to Test This Pull Request

1. define a custom setup
2. check that the changelog is created correctly using the defined regex

