### PR TITLE
fix(scripts/test): excluding venv folder from pydocstyle checks

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -10,4 +10,4 @@ ${PREFIX}black commitizen tests --check
 ${PREFIX}isort --check-only commitizen tests
 ${PREFIX}flake8 commitizen/ tests/
 ${PREFIX}mypy commitizen/ tests/
-${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415
+${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415 --match-dir='^(?!venv|[\.]).*'


### PR DESCRIPTION
## Description
Removing the `venv` folder from the scope of `pydocstyle`.
When having the venv set up in the project forlder, `pydocstyle` fails because of some libraries not being complainant. 


## Checklist

- [ ] Add test cases to all the changes you introduce
- [X] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
When running `./scripts/test` with `venv` folder in the project folder, the script should not fail.


## Steps to Test This Pull Request

1. set up venv in project folder
2. run `./scripts/test`
