### PR TITLE
ci(github-actions): set force to true for Homebrew bump formula

### DIFF
--- a/.github/workflows/homebrewpublish.yaml
+++ b/.github/workflows/homebrewpublish.yaml
@@ -29,3 +29,4 @@ jobs:
         token: ${{secrets.PERSONAL_ACCESS_TOKEN}}
         formula: commitizen
         tag: v${{ env.project_version }}
+        force: true


### PR DESCRIPTION

## Description
fix homebrew publishing error as reported https://github.com/commitizen-tools/commitizen/issues/438#issuecomment-937606468
this solution is suggested by our failed workflow https://github.com/commitizen-tools/commitizen/runs/3845350057?check_suite_focus=true

```
commitizen 2.20.0 https://github.com/Homebrew/homebrew-core/pull/86905
Duplicate PRs should not be opened. Use --force to override this error.
/usr/local/Homebrew/Library/Homebrew/utils.rb:322:in `safe_system': Failure while executing; `/usr/local/bin/brew bump-formula-pr --no-audit --no-browse --message=\[\`action-homebrew-bump-formula\`\]\(https://github.com/dawidd6/action-homebrew-bump-formula\) --version=2.20.0 --url=https://files.pythonhosted.org/packages/8f/0c/97a94ded248305222b1c5c86c0c58d81c7822e1fa705e92870e9ad643635/commitizen-2.20.0.tar.gz commitizen` exited with 1. (ErrorDuringExecution)
	from /Users/runner/work/_actions/dawidd6/action-homebrew-bump-formula/v3/main.rb:27:in `brew'
	from /Users/runner/work/_actions/dawidd6/action-homebrew-bump-formula/v3/main.rb:112:in `<module:Homebrew>'
	from /Users/runner/work/_actions/dawidd6/action-homebrew-bump-formula/v3/main.rb:18:in `<main>'
```

according to [Homebrew bump formula](https://github.com/marketplace/actions/homebrew-bump-formula#usage), this shouldn't break anything


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
succeeded on homebrew publishing


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
