### PR TITLE
ci(github-actions): add back 3.7 runner to pythonpackage

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   python-check:
     strategy:
       matrix:
-        python-version: [3.6, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6.1"
+python = "^3.6.2"
 questionary = "^1.4.0"
 decli = "^0.5.2"
 colorama = "^0.4.1"
@@ -57,7 +57,7 @@ argcomplete = "^1.12.1"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.2"
-black = "^19.3b0"
+black = "^21.12b0"
 pytest = "^5.0"
 flake8 = "^3.6"
 pytest-cov = "^2.6"

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -125,7 +125,11 @@ def test_check_conventional_commit_succeeds(mocker, capsys):
 
 
 @pytest.mark.parametrize(
-    "commit_msg", ("feat!(lang): removed polish language", "no conventional commit",),
+    "commit_msg",
+    (
+        "feat!(lang): removed polish language",
+        "no conventional commit",
+    ),
 )
 def test_check_no_conventional_commit(commit_msg, config, mocker, tmpdir):
     with pytest.raises(InvalidCommitMessageError):

--- a/tests/test_bump_find_version.py
+++ b/tests/test_bump_find_version.py
@@ -82,16 +82,20 @@ def test_generate_version(test_input, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input,expected", itertools.chain(local_versions),
+    "test_input,expected",
+    itertools.chain(local_versions),
 )
 def test_generate_version_local(test_input, expected):
     current_version = test_input[0]
     increment = test_input[1]
     prerelease = test_input[2]
     is_local_version = True
-    assert generate_version(
-        current_version,
-        increment=increment,
-        prerelease=prerelease,
-        is_local_version=is_local_version,
-    ) == Version(expected)
+    assert (
+        generate_version(
+            current_version,
+            increment=increment,
+            prerelease=prerelease,
+            is_local_version=is_local_version,
+        )
+        == Version(expected)
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,7 +73,10 @@ def test_commitizen_excepthook(capsys):
 def test_commitizen_debug_excepthook(capsys):
     with pytest.raises(SystemExit) as excinfo:
         cli.commitizen_excepthook(
-            NotAGitProjectError, NotAGitProjectError(), "", debug=True,
+            NotAGitProjectError,
+            NotAGitProjectError(),
+            "",
+            debug=True,
         )
 
     assert excinfo.type == SystemExit

--- a/tests/test_cz_conventional_commits.py
+++ b/tests/test_cz_conventional_commits.py
@@ -144,9 +144,18 @@ def test_info(config):
 @pytest.mark.parametrize(
     ("commit_message", "expected_message"),
     [
-        ("test(test_scope): this is test msg", "this is test msg",),
-        ("test(test_scope)!: this is test msg", "this is test msg",),
-        ("test!(test_scope): this is test msg", "",),
+        (
+            "test(test_scope): this is test msg",
+            "this is test msg",
+        ),
+        (
+            "test(test_scope)!: this is test msg",
+            "this is test msg",
+        ),
+        (
+            "test!(test_scope): this is test msg",
+            "",
+        ),
     ],
 )
 def test_process_commit(commit_message, expected_message, config):


### PR DESCRIPTION
## Description
* style: format the code through the latest black
* build(poetry): update black version for python 3.9 and upgrade least support python version to python 3.6.2
* ci(github-actions):
    * upgrade setup-python to v2
    * add back 3.7 runner to pythonpackage

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
3.7 runner added when running checkings


## Steps to Test This Pull Request
send a pull request


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
