### PR TITLE
build: use poetry_core to build instead of poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,5 +116,5 @@ known_first_party = ["commitizen", "tests"]
     ]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Changes the build backend from poetry to poetry_core. poetry_core is lighter weight than poetry and all that's required for the build vs project management aspect of poetry.


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
>If your pyproject.toml file still references poetry directly as a build backend, you should update it to reference poetry-core instead.
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
