### PR TITLE
Support Python 3.10 in CI/local testing

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   python-check:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ typing-extensions = "^4.0.1"
 [tool.poetry.dev-dependencies]
 ipython = "^7.2"
 # test
-pytest = "^5.0"
+pytest = "^6.2.5"
 pytest-cov = "^2.6"
 pytest-mock = "^2.0"
 codecov = "^2.0"

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -13,11 +13,11 @@ def config():
     return _config
 
 
-@pytest.fixture()  # type: ignore
+@pytest.fixture()
 def changelog_path() -> str:
     return os.path.join(os.getcwd(), "CHANGELOG.md")
 
 
-@pytest.fixture()  # type: ignore
+@pytest.fixture()
 def config_path() -> str:
     return os.path.join(os.getcwd(), "pyproject.toml")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Adds CI support for Python 3.10 and bump pytest to a version which is compatible with 3.10.
<!-- Describe what the change is -->


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
pytest 6.2.5+ is needed for Python 3.10: https://docs.pytest.org/en/6.2.x/changelog.html#pytest-6-2-5-2021-08-29