### PR TITLE
docs: Fix exit code for NoCommitsFoundError

### DIFF
--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -10,7 +10,7 @@ These exit codes can be found in `commitizen/exceptions.py::ExitCode`.
 | DryRunExit | 0 | Exit due to passing `--dry-run` option |
 | NoCommitizenFoundException | 1 | Using a cz (e.g., `cz_jira`) that cannot be found in your system |
 | NotAGitProjectError | 2 | Not in a git project |
-| NoCommitsFoundError | 4 | No commit found |
+| NoCommitsFoundError | 3 | No commit found |
 | NoVersionSpecifiedError | 4 | Version can not be found in configuration file |
 | NoPatternMapError | 5 | bump / changelog pattern or map can not be found in configuration file |
 | BumpCommitFailedError | 6 | Commit error when bumping version |


### PR DESCRIPTION
The source code indicates that the correct exit code is 3. See https://github.com/commitizen-tools/commitizen/blob/master/commitizen/exceptions.py#L10

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

Update the documentation with the correct exit number

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [x] Update the documentation for the changes

The first three entries do not apply to this PR.

## Expected behavior

The documentation shows the correct information.
