### PR TITLE
docs: removing customization file contradiction

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -3,8 +3,6 @@ We have two different ways to do so.
 
 ## 1. Customize in configuration file
 
-**This is only supported when configuring through `toml` or `json` (e.g., `pyproject.toml`, `.cz.toml`, `.cz.json`, and `cz.json`)**
-
 The basic steps are:
 
 1. Define your custom committing or bumping rules in the configuration file.


### PR DESCRIPTION
## Description
Customising via the configuration file is clearly possible when using yaml files since you show an example for this. This PR updates the doc to remove the warning that states this is not possible. Given that yaml was the only missing file type in the original warning it seems safe to remove it completely.

## Checklist

- [n/a] Add test cases to all the changes you introduce
- [n/a] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [n/a] Test the changes on the local machine manually
- [*] Update the documentation for the changes

## Expected behavior
N/A - Docs updated only


## Steps to Test This Pull Request
N/A - Docs updated only

## Additional context
N/A - Docs updated only
