### PR TITLE
fix(bump): raise non zero error code when there's no elegible commit to bump

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -170,7 +170,10 @@ class Bump:
             out.write(information)
 
         if increment is None and new_tag_version == current_tag_version:
-            raise NoneIncrementExit()
+            raise NoneIncrementExit(
+                "[NO_COMMITS_TO_BUMP]\n"
+                "The commits found are not elegible to be bumped"
+            )
 
         # Do not perform operations over files or git.
         if dry_run:

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -54,8 +54,8 @@ class DryRunExit(ExpectedExit):
     pass
 
 
-class NoneIncrementExit(ExpectedExit):
-    pass
+class NoneIncrementExit(CommitizenException):
+    exit_code = ExitCode.NO_COMMITS_FOUND
 
 
 class NoCommitizenFoundException(CommitizenException):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
See error in https://github.com/commitizen-tools/commitizen-action/issues/18

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] ~Update the documentation for the changes~

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
An error code should be returned when the bump can not succeed

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
Clone this repo https://github.com/now8-org/app

and run `cz bump`

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->

1. Is there a reason why we weren't rising an error code in this situation? 🤔 
2. Am I missing any use case?
