### PR TITLE
docs(config.md,customization.md): Fix indentation (replace tabs (\t) with eight spaces)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -38,8 +38,8 @@ JSON might be a more common configuration format for non-python projects, so Com
         "name": "cz_conventional_commits",
         "version": "0.1.0",
         "version_files": [
-	    "src/__version__.py",
-	    "pyproject.toml:version"
+            "src/__version__.py",
+            "pyproject.toml:version"
         ],
         "style": [
             [

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -50,7 +50,7 @@ The equivalent example for a json config file:
 ```json
 {
     "commitizen": {
-	"name": "cz_customize",
+        "name": "cz_customize",
         "customize": {
             "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
             "example": "feature: this feature enable customize through config file",
@@ -64,7 +64,7 @@ The equivalent example for a json config file:
                 "hotfix": "PATCH"
             },
             "change_type_order": ["BREAKING CHANGE", "feat", "fix", "refactor", "perf"],
-	    "info_path": "cz_customize_info.txt",
+            "info_path": "cz_customize_info.txt",
             "info": "This is customized info",
             "questions": [
                 {


### PR DESCRIPTION
## Description
Fix indentation on pages Configuration and Customization in online documentation.
Now it has mixed indentation (spaces&tabs) in some places. I replaced all tabs to eight spaces.


## Checklist

- [ X ] Update the documentation for the changes

## Expected behavior
Indentation for json in Configuration and Customization sections of docs contains only tabs or only spaces.


## Additional context
Old behaviour (unexpected change of:
![image](https://user-images.githubusercontent.com/43097289/151220055-2bcbf93f-9588-4a0c-8a78-88b97fd02d11.png)
