### PR TITLE
Safely ignore modules named `cz_` that are not plugins

### DIFF
--- a/commitizen/cz/__init__.py
+++ b/commitizen/cz/__init__.py
@@ -1,7 +1,6 @@
 import importlib
 import pkgutil
 import warnings
-from pathlib import Path
 from typing import Dict, Iterable, Type
 
 from commitizen.cz.base import BaseCommitizen
@@ -10,7 +9,7 @@ from commitizen.cz.customize import CustomizeCommitsCz
 from commitizen.cz.jira import JiraSmartCz
 
 
-def discover_plugins(path: Iterable[Path] = None) -> Dict[str, Type[BaseCommitizen]]:
+def discover_plugins(path: Iterable[str] = None) -> Dict[str, Type[BaseCommitizen]]:
     """Discover commitizen plugins on the path
 
     Args:

--- a/commitizen/cz/__init__.py
+++ b/commitizen/cz/__init__.py
@@ -23,7 +23,7 @@ def discover_plugins(path: Iterable[str] = None) -> Dict[str, Type[BaseCommitize
     for finder, name, ispkg in pkgutil.iter_modules(path):
         try:
             if name.startswith("cz_"):
-                plugins[name] = importlib.import_module(name).discover_this
+                plugins[name] = importlib.import_module(name).discover_this  # type: ignore
         except AttributeError as e:
             warnings.warn(UserWarning(e.args[0]))
             continue

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -38,7 +38,7 @@ def test_discover_plugins(module_content, plugin_name, expected_plugins, tmp_pat
 
     sys.path.append(tmp_path.as_posix())
     with pytest.warns(UserWarning) as record:
-        discovered_plugins = discover_plugins([tmp_path])
+        discovered_plugins = discover_plugins([tmp_path.as_posix()])
     sys.path.pop()
 
     assert (


### PR DESCRIPTION
When a package starting with a plugin name is found, but it is not a plugin, it becomes safely ignored.

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
When a packages has a name that matches a plugin, but it is not a plugin, it is safely ignored and reported to the user.

Background: The company where I work, and where I use `commitizen` for releasing package versions, is called CZ. And because we are not very imaginative, we use to call the packages that we develop for internal use something like `cz_`.

This collides with the way that `commitizen` discover plugins, and the discovery process raises an exception when a package starts with the name `cz_` is found but is not implemented as a plugin.

This MR proposes a way to ignore those packages that collide in name but are not plugins. This proposal tries to be as agnostic as possible, not very Pythonic, but I am open to suggestions.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
When the CLI searches for plugins, those packages that have a name `cz_` but lack the `discover_this` attribute, will be ignored and the user will get a warning

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
1. Create a package with a name starting with `cz_`. It can be located under a `src` folder
2. Install `commitizen`
3. Run `commitizen changelog --help`. Without this patch, an exception will be risen.

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->