### PR TITLE
First take at `ConventionalCommitsAppenderCz`

### DIFF
--- a/commitizen/cz/__init__.py
+++ b/commitizen/cz/__init__.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable, Type
 
 from commitizen.cz.base import BaseCommitizen
 from commitizen.cz.conventional_commits import ConventionalCommitsCz
+from commitizen.cz.conventional_commits_appender.conventional_commits_appender import ConventionalCommitsAppenderCz
 from commitizen.cz.customize import CustomizeCommitsCz
 from commitizen.cz.jira import JiraSmartCz
 
@@ -32,6 +33,7 @@ def discover_plugins(path: Iterable[str] = None) -> Dict[str, Type[BaseCommitize
 
 registry: Dict[str, Type[BaseCommitizen]] = {
     "cz_conventional_commits": ConventionalCommitsCz,
+    "cz_conventional_commits_appender": ConventionalCommitsAppenderCz,
     "cz_jira": JiraSmartCz,
     "cz_customize": CustomizeCommitsCz,
 }

--- a/commitizen/cz/conventional_commits_appender/__init__.py
+++ b/commitizen/cz/conventional_commits_appender/__init__.py
@@ -1,0 +1,1 @@
+from .conventional_commits_appender import ConventionalCommitsCz  # noqa

--- a/commitizen/cz/conventional_commits_appender/conventional_commits_appender.py
+++ b/commitizen/cz/conventional_commits_appender/conventional_commits_appender.py
@@ -1,0 +1,112 @@
+import os
+import re
+
+from commitizen import out
+
+from commitizen.config import BaseConfig
+from commitizen.cz import ConventionalCommitsCz
+from commitizen.cz.utils import required_validator
+from commitizen.defaults import Questions
+
+__all__ = ["ConventionalCommitsAppenderCz"]
+
+
+def parse_scope(text):
+    if not text:
+        return ""
+
+    scope = text.strip().split()
+    if len(scope) == 1:
+        return scope[0]
+
+    return "-".join(scope)
+
+
+def parse_subject(text):
+    if isinstance(text, str):
+        text = text.strip(".").strip()
+
+    return required_validator(text, msg="Subject is required.")
+
+
+class ConventionalCommitsAppenderCz(ConventionalCommitsCz):
+    APPENDER_CZ_LOCAL = "ConventionalCommitsAppenderCz_LOCAL"
+
+    DEFAULT_CONFIG = {
+        "prefix": {
+            "choices": [
+            ]
+        },
+        "schema_allow_locally": {
+            "patterns": [
+            ]
+        }
+    }
+
+    def __init__(self, config: BaseConfig):
+        super().__init__(config)
+        self.appender_config = dict(config.settings.get(self.__class__.__name__, self.DEFAULT_CONFIG))
+        self.q_list = None
+
+        self.questions()
+
+        if self.is_local_run():
+            os.environ[self.APPENDER_CZ_LOCAL] = "True"
+
+    def is_local_run(self):
+        import os
+        return not os.environ.get('CI', False)
+
+    def append_questions(self):
+        for element in self.q_list:
+            if element["name"] != "prefix":
+                continue
+
+            element["choices"].extend(self.appender_config["prefix"]["choices"])
+
+    def questions(self) -> Questions:
+        questions: Questions = super().questions()
+        self.q_list = questions
+        self.append_questions()
+        return questions
+
+    def schema_pattern(self, local=False) -> str:
+        prefix_choices = [x for x in self.q_list if x["name"] == "prefix"]
+        assert len(prefix_choices) == 1
+        prefix_choices = prefix_choices[0]["choices"]
+
+        PATTERN = (
+            fr"({'|'.join([x['value'] for x in prefix_choices])})"
+            r"(\(\S+\))?!?:(\s.*)"
+        )
+
+        if local:
+            schema_allow_locally = self.appender_config["schema_allow_locally"]["patterns"]
+            PATTERN = fr"(^{'|'.join(schema_allow_locally)}|{PATTERN})"
+
+        return PATTERN
+
+    def info(self) -> str:
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        filepath = os.path.join(dir_path, "conventional_commits_appender_info.txt")
+        content = ''
+        with open(filepath, "r") as f:
+            content += f.read()
+        filepath = os.path.join(dir_path, "..", "conventional_commits", "conventional_commits_info.txt")
+        with open(filepath, "r") as f:
+            content += f.read()
+        return content
+
+    def process_commit(self, commit: str, local=False) -> str:
+        pat = re.compile(self.schema_pattern())
+        m = re.match(pat, commit)
+        if m is None:
+            if os.environ.get('CI', None) and not local:
+                return self.process_commit(commit, True)
+
+            return ""
+
+        if os.environ.get('CI', None) and local:
+            out.warning("Title line is only allowed locally!\nIt will be rejected upstream.")
+
+        return m.group(3).strip()

--- a/commitizen/cz/conventional_commits_appender/conventional_commits_appender_info.txt
+++ b/commitizen/cz/conventional_commits_appender/conventional_commits_appender_info.txt
@@ -1,0 +1,5 @@
+This is exactly the same as `conventional_commits`, with the exception that
+it will read the first `.conventional_commit_appender_rc` file it encounters,
+and append its patterns to the conventional_commits' ones.
+
+=== Below is the rest of the `conventional_commits_info.txt` ===

--- a/commitizen/out.py
+++ b/commitizen/out.py
@@ -18,6 +18,11 @@ def error(value: str) -> None:
     line(message, file=sys.stderr)
 
 
+def warning(value: str) -> None:
+    message = colored(value, "yellow")
+    line(message)
+
+
 def success(value: str) -> None:
     message = colored(value, "green")
     line(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ exclude = '''
 
 [tool.poetry]
 name = "commitizen"
-version = "2.20.5"
+version = "2.20.6"
 description = "Python commitizen client tool"
 authors = ["Santiago Fraire <santiwilly@gmail.com>"]
 license = "MIT"

--- a/tests/data/sample_conventional_commits_appender.toml
+++ b/tests/data/sample_conventional_commits_appender.toml
@@ -1,0 +1,21 @@
+[tool.commitizen]
+name = "cz_conventional_commits_appender"
+version = "2.20.4"
+tag_format = "v$version"
+version_files = [
+  "pyproject.toml:version",
+  "commitizen/__version__.py"
+]
+    [tool.commitizen.ConventionalCommitsAppenderCz]
+        [tool.commitizen.ConventionalCommitsAppenderCz.prefix]
+            [[tool.commitizen.ConventionalCommitsAppenderCz.prefix.choices]]
+            value = "impr"
+            name = "improvement: An improvement (but not as big as a feature). Correlates with MINOR in SemVer"
+            key = "i"
+
+        [tool.commitizen.ConventionalCommitsAppenderCz.schema_allow_locally]
+            patterns = [
+                "fixup!",
+                "squash!",
+                "a",
+            ]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

I would like to have `ConventionalCommitsCz`, but also be able to extend it locally, as per project requirements/wishes - also to fit local workflows (i.e. use `fixup!`, `squash!`, or throwaway commits without the extra pain of disabling the local commit hooks)

As indicated by the PR, this is just a RFC: I would like to get the project's insight on how this could be achieved, since these changes touch on internal committizen parts that you might not necessarily want changed.
Also, I failed to find a tutorial on how to create my own plugin.
Finally, I've never used `poetry` before; and therefore everything is broken/unknown to me.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
