### PR TITLE
feat: skip merge messages that start with Pull request

### DIFF
--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -100,6 +100,10 @@ class Check:
 
     @staticmethod
     def validate_commit_message(commit_msg: str, pattern: str) -> bool:
-        if commit_msg.startswith("Merge") or commit_msg.startswith("Revert"):
+        if (
+            commit_msg.startswith("Merge")
+            or commit_msg.startswith("Revert")
+            or commit_msg.startswith("Pull request")
+        ):
             return True
         return bool(re.match(pattern, commit_msg))

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -49,7 +49,7 @@ class TomlConfig(BaseConfig):
         name = "cz_conventional_commits"
         ```
         """
-        doc = parse(data)  # type: ignore
+        doc = parse(data)
         try:
             self.settings.update(doc["tool"]["commitizen"])  # type: ignore
         except exceptions.NonExistentKey:


### PR DESCRIPTION
Bitbucket add as default message when a pull request is merged, the message commit that starts with "Pull request". cz check fails with this kind of messages.

Signed-off-by: Angelo Mantellini <manangel@cisco.com>

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Bitbucket add as default message when a pull request is merged, the message commit that starts with "Pull request". cz check fails with this kind of messages.


## Checklist

- [x ] Add test cases to all the changes you introduce
- [x ] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x ] Test the changes on the local machine manually
- [x ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
1. create commit that starts with "Pull request"
2. cz check

