### PR TITLE
Make cz schema pattern more precise

### DIFF
--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -82,20 +82,18 @@ class Check:
         out.success("Commit validation: successful!")
 
     def _get_commits(self):
+        msg = None
         # Get commit message from file (--commit-msg-file)
         if self.commit_msg_file is not None:
             # Enter this branch if commit_msg_file is "".
             with open(self.commit_msg_file, "r", encoding="utf-8") as commit_file:
                 msg = commit_file.read()
+        # Get commit message from command line (--message)
+        elif self.commit_msg:
+            msg = self.commit_msg
+        if msg is not None:
             msg = self._filter_comments(msg)
-            msg = msg.lstrip("\n")
-            commit_title = msg.split("\n")[0]
-            commit_body = "\n".join(msg.split("\n")[1:])
-            return [git.GitCommit(rev="", title=commit_title, body=commit_body)]
-        elif self.commit_msg is not None:
-            # Enter this branch if commit_msg is "".
-            self.commit_msg = self._filter_comments(self.commit_msg)
-            return [git.GitCommit(rev="", title="", body=self.commit_msg)]
+            return [git.GitCommit(rev="", title="", body=msg)]
 
         # Get commit messages from git log (--rev-range)
         return git.get_commits(end=self.rev_range)

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -89,7 +89,7 @@ class Check:
             with open(self.commit_msg_file, "r", encoding="utf-8") as commit_file:
                 msg = commit_file.read()
         # Get commit message from command line (--message)
-        elif self.commit_msg:
+        elif self.commit_msg is not None:
             msg = self.commit_msg
         if msg is not None:
             msg = self._filter_comments(msg)

--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -191,8 +191,11 @@ class ConventionalCommitsCz(BaseCommitizen):
 
     def schema_pattern(self) -> str:
         PATTERN = (
-            r"(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)"
-            r"(\(\S+\))?!?:(\s.*)"
+            r"(?s)"  # To explictly make . match new line
+            r"(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)"  # type
+            r"(\(\S+\))?!?:"  # scope
+            r"( [^\n\r]+)"  # subject
+            r"((\n\n.*)|(\s*))?$"
         )
         return PATTERN
 

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -17,20 +17,20 @@ COMMIT_LOG = [
     "refactor(git): remove unnecessary dot between git range",
     "bump: version 1.16.3 → 1.16.4",
     (
-        "Merge pull request #139 from Lee-W/fix-init-clean-config-file\n"
+        "Merge pull request #139 from Lee-W/fix-init-clean-config-file\n\n"
         "Fix init clean config file"
     ),
     "ci(pyproject.toml): add configuration for coverage",
-    "fix(commands/init): fix clean up file when initialize commitizen config\n#138",
+    "fix(commands/init): fix clean up file when initialize commitizen config\n\n#138",
     "refactor(defaults): split config files into long term support and deprecated ones",
     "bump: version 1.16.2 → 1.16.3",
     (
-        "Merge pull request #136 from Lee-W/remove-redundant-readme\n"
+        "Merge pull request #136 from Lee-W/remove-redundant-readme\n\n"
         "Remove redundant readme"
     ),
     "fix: replace README.rst with docs/README.md in config files",
     (
-        "refactor(docs): remove README.rst and use docs/README.md\n"
+        "refactor(docs): remove README.rst and use docs/README.md\n\n"
         "By removing README.rst, we no longer need to maintain "
         "two document with almost the same content\n"
         "Github can read docs/README.md as README for the project."
@@ -38,10 +38,10 @@ COMMIT_LOG = [
     "docs(check): pin pre-commit to v1.16.2",
     "docs(check): fix pre-commit setup",
     "bump: version 1.16.1 → 1.16.2",
-    "Merge pull request #135 from Lee-W/fix-pre-commit-hook\nFix pre commit hook",
+    "Merge pull request #135 from Lee-W/fix-pre-commit-hook\n\nFix pre commit hook",
     "docs(check): enforce cz check only whem committing",
     (
-        'Revert "fix(pre-commit): set pre-commit check stage to commit-msg"\n'
+        'Revert "fix(pre-commit): set pre-commit check stage to commit-msg"\n\n'
         "This reverts commit afc70133e4a81344928561fbf3bb20738dfc8a0b."
     ),
     "feat!: add user stuff",

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -129,6 +129,11 @@ def test_check_conventional_commit_succeeds(mocker, capsys):
     (
         "feat!(lang): removed polish language",
         "no conventional commit",
+        (
+            "ci: check commit message on merge\n"
+            "testing with more complex commit mes\n\n"
+            "age with error"
+        ),
     ),
 )
 def test_check_no_conventional_commit(commit_msg, config, mocker, tmpdir):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

Closes #449 

## Description
<!-- Describe what the change is -->

Currently the schema pattern of `cz` only checks the first line of commit message, so that some invalid format cannot be detected by `cz check`. I update the pattern to ensure there is a blank line between subject and body (if exists) and add some comments to make the regex a little more readable.

Meanwhile, because the inconsistent implementation of `Check._get_commits` for `--commit-msg-file` and `--message`, give a commit message file missing the blank line will also pass the validation (the missing line will be added by `Check`).

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

Miss blank line between subject and body will not pass `cz check`.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

```bash
cat << EOF > /tmp/BAD_MSG                                                                                                                                          
ci: check commit message on merge
testing with more complex commit mes

age with error
EOF
cz check --commit-message-file /tmp/BAD_MSG
```

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
