### PR TITLE
Ensure At Least One Blank Line Between Old and New Changelog Content

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Please fill in the following content to let us know better about this change.
 ## Checklist
 
 - [ ] Add test cases to all the changes you introduce
-- [ ] Run `./script/format` and `./script/test` locally to ensure this change passes linter check and test
+- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
 - [ ] Test the changes on the local machine manually
 - [ ] Update the documentation for the changes
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
-        exclude: "tests/[test_*|data|commands/tests_*]/*"
+        exclude: "tests/((commands|data)/|test_).+"
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
       - id: debug-statements

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
       - id: debug-statements
       - id: no-commit-to-branch
 
-  - repo: https://github.com/Woile/commitizen
-    rev: v1.23.0
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v2.24.0 # automatically updated by Commitizen
     hooks:
       - id: commitizen
         stages: [commit-msg]

--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -235,7 +235,7 @@ def get_metadata(filepath: str) -> Dict:
     }
 
 
-def incremental_build(new_content: str, lines: List, metadata: Dict) -> List:
+def incremental_build(new_content: str, lines: List[str], metadata: Dict) -> List[str]:
     """Takes the original lines and updates with new_content.
 
     The metadata governs how to remove the old unreleased section and where to place the
@@ -253,7 +253,7 @@ def incremental_build(new_content: str, lines: List, metadata: Dict) -> List:
     unreleased_end = metadata.get("unreleased_end")
     latest_version_position = metadata.get("latest_version_position")
     skip = False
-    output_lines: List = []
+    output_lines: List[str] = []
     for index, line in enumerate(lines):
         if index == unreleased_start:
             skip = True
@@ -270,13 +270,8 @@ def incremental_build(new_content: str, lines: List, metadata: Dict) -> List:
         if skip:
             continue
 
-        if (
-            isinstance(latest_version_position, int)
-            and index == latest_version_position
-        ):
-
-            output_lines.append(new_content)
-            output_lines.append("\n")
+        if index == latest_version_position:
+            output_lines.extend([new_content, "\n"])
 
         output_lines.append(line)
     if not isinstance(latest_version_position, int):

--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -238,8 +238,8 @@ def get_metadata(filepath: str) -> Dict:
 def incremental_build(new_content: str, lines: List, metadata: Dict) -> List:
     """Takes the original lines and updates with new_content.
 
-    The metadata holds information enough to remove the old unreleased and
-    where to place the new content
+    The metadata governs how to remove the old unreleased section and where to place the
+    new content.
 
     Args:
         lines: The lines from the changelog

--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -275,6 +275,9 @@ def incremental_build(new_content: str, lines: List[str], metadata: Dict) -> Lis
 
         output_lines.append(line)
     if not isinstance(latest_version_position, int):
+        if output_lines and output_lines[-1].strip():
+            # Ensure at least one blank line between existing and new content.
+            output_lines.append("\n")
         output_lines.append(new_content)
     return output_lines
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ version = "2.24.0"
 tag_format = "v$version"
 version_files = [
   "pyproject.toml:version",
-  "commitizen/__version__.py"
+  "commitizen/__version__.py",
+  ".pre-commit-config.yaml:rev.\\s+(?=[^\\n]+Commitizen)"
 ]
 
 [tool.black]

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -320,6 +320,30 @@ def test_changelog_multiple_incremental_do_not_add_new_lines(
     assert out.startswith("#")
 
 
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_changelog_incremental_newline_separates_new_content_from_old(
+    mocker, changelog_path
+):
+    """Test for https://github.com/commitizen-tools/commitizen/issues/509"""
+    with open(changelog_path, "w") as f:
+        f.write("Pre-existing content that should be kept\n")
+
+    create_file_and_commit("feat: add more cat videos")
+
+    testargs = ["cz", "changelog", "--incremental"]
+
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    with open(changelog_path, "r") as f:
+        out = f.read()
+
+    assert (
+        out
+        == "Pre-existing content that should be kept\n\n## Unreleased\n\n### Feat\n\n- add more cat videos\n"
+    )
+
+
 def test_changelog_without_revision(mocker, tmp_commitizen_project):
     changelog_file = tmp_commitizen_project.join("CHANGELOG.md")
     changelog_file.write(


### PR DESCRIPTION
## Description

Ensure there is at least one blank line separating old and new content when appending incrementally to the changelog. Log entries for each release are already separated with blank lines, so separate pre-existing content from the first release with a blank line as well. If the pre-existing content ends with a blank line, then don't add an extra one.

I also fixed some unrelated pre-existing issues with `.pre-commit-config.yaml` in order to be able to comply with the contributing guidelines.

Please let me know which documentation I should update if you feel this change warrants mention. I wasn't sure whether to classify this as a tiny feature or a bug fix.

Closes #509.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior

If the changelog already says "This changelog is auto-generated by the Python-based
[Commitizen](https://commitizen-tools.github.io/commitizen).", then when the first release is added by Commitizen, it doesn't ram right up against the pre-existing content.

## Steps to Test This Pull Request

1. Create `CHANGELOG.md`, and add some content to it that doesn't end in an extra blank line (besides the one at the end of the file).
2. Make a feature commit.
3. Run `cz changelog --incremental`.
4. The changelog is updated with a note for the new feature appended to the bottom of the file. There is exactly one blank line between the pre-existing and new content.
