### PR TITLE
fix(pre-commit): Correct pre-commit Hook Definition

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
   entry: cz check --commit-msg-file
   language: python
   language_version: python3
-  minimum_pre_commit_version: "0.15.4"
+  minimum_pre_commit_version: "1.4.3"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,8 @@
 - id: commitizen
   name: commitizen check
   description: "Check whether the commit message follows commiting rules"
-  entry: cz check --commit-msg-file
+  entry: cz check
+  args: [--allow-abort, --commit-msg-file]
   stages: [commit-msg]
   language: python
   language_version: python3

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,7 @@
   name: commitizen check
   description: "Check whether the commit message follows commiting rules"
   entry: cz check --commit-msg-file
+  stages: [commit-msg]
   language: python
   language_version: python3
   minimum_pre_commit_version: "1.4.3"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,4 @@
   entry: cz check --commit-msg-file
   language: python
   language_version: python3
-  require_serial: true
   minimum_pre_commit_version: "0.15.4"

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -114,7 +114,7 @@ class Init:
         cz_hook_config = {
             "repo": "https://github.com/commitizen-tools/commitizen",
             "rev": f"v{__version__}",
-            "hooks": [{"id": "commitizen", "stages": ["commit-msg"]}],
+            "hooks": [{"id": "commitizen"}],
         }
 
         config_data = {}

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,7 +111,6 @@ repos:
     rev: master
     hooks:
       - id: commitizen
-        stages: [commit-msg]
 ```
 
 After the configuration is added, you'll need to run

--- a/docs/auto_check.md
+++ b/docs/auto_check.md
@@ -22,7 +22,6 @@ repos:
     rev: v1.17.0
     hooks:
       - id: commitizen
-        stages: [commit-msg]
 ```
 
 * Step 3: Install the configuration into git hook through `pre-commit`

--- a/docs/auto_check.md
+++ b/docs/auto_check.md
@@ -50,7 +50,7 @@ Open the file and edit it:
 ```sh
 #!/bin/bash
 MSG_FILE=$1
-cz check --commit-msg-file $MSG_FILE
+cz check --allow-abort --commit-msg-file $MSG_FILE
 ```
 
 Where `$1` is the name of the temporary file that contains the current commit message. To be more explicit, the previous variable is stored in another variable called `$MSG_FILE`, for didactic purposes.

--- a/tests/commands/test_init_command.py
+++ b/tests/commands/test_init_command.py
@@ -21,7 +21,7 @@ pre_commit_config_filename = ".pre-commit-config.yaml"
 cz_hook_config = {
     "repo": "https://github.com/commitizen-tools/commitizen",
     "rev": f"v{__version__}",
-    "hooks": [{"id": "commitizen", "stages": ["commit-msg"]}],
+    "hooks": [{"id": "commitizen"}],
 }
 
 expected_config = (


### PR DESCRIPTION
## Description

Use new `--allow-abort` option. Prevent pre-commit hook from complaining when a commit is aborted by default, but allow users to override this option in their pre-commit config by specifying it in `args`, not `entry`. Move `--commit-msg-file` option from `entry` to `args` since it has to be the last option.

Confine hook to `commit-msg` stage. The Commitizen pre-commit hook runs `cz check`, which only makes sense to do on a commit message, not at other Git hook stages. By default the hook is currently run on staged files `pre-commit`, which is nonsensical unless the files in the repository themselves contain Git commit messages. The hook is an implausible candidate even for the `prepare-commit-msg` stage since this stage is intended for hooks that modify the commit message rather than check it. Specifying the hook stage centrally makes it less error-prone to use and saves one line of configuration for users of the pre-commit hook.

Change minimum pre-commit version from 0.15.4 to 1.4.3. pre-commit 1.4.3, released 2018-01-02, is the minimum pre-commit version at which `language_version: python3` is translated to the correct py launcher call on Windows.

Don't require serial execution. `require_serial` is not pertinent to `commit-msg` hooks or hooks that themselves execute serially. The option is intended to prevent fork-bombing that can occur when pre-commit runs a hook that itself spawns many processes many times in parallel.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior

The commit hook continues to work as before but without requiring that the `commit-msg` stage be specified in your `.pre-commit-config.yaml` or giving a misleading error message when the commit is aborted by saving an empty commit message in your editor.

## Steps to Test This Pull Request

1. Replace your Commitizen hook config in your `.pre-commit-config.yaml` with the following:

      ```yaml
      repos:
        - repo: https://github.com/Kurt-von-Laven/commitizen
          rev: allow-abort
          hooks:
            - id: commitizen
      ```

1. Ensure that you have pre-commit 1.4.3 or higher installed.
1. Install `commit-msg` hooks if you haven't already via: `pre-commit install --hook-type commit-msg`.
1. Commit some changes to your repository.
1. If the commit message was invalid, the hook will fail, and otherwise it will succeed. Empty commit messages now fall in the latter category, and the commit aborts cleanly without a misleading error.

## Additional context

Follows on #512, which added the `--allow-abort` option to `cz check`. Reverts #135, which removed `stages: [commit-msg]`.