### PR TITLE
feat(pre-commit): Add commitizen-branch hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ repos:
     rev: v2.31.0 # automatically updated by Commitizen
     hooks:
       - id: commitizen
-        stages: [commit-msg]
 
   - repo: local
     hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,27 @@
 - id: commitizen
   name: commitizen check
-  description: "Check whether the commit message follows commiting rules"
+  description: >
+    Check whether the current commit message follows commiting rules. Allow
+    empty commit messages by default, because they typically indicate to Git
+    that the commit should be aborted.
   entry: cz check
   args: [--allow-abort, --commit-msg-file]
   stages: [commit-msg]
+  language: python
+  language_version: python3
+  minimum_pre_commit_version: "1.4.3"
+
+- id: commitizen-branch
+  name: commitizen check branch
+  description: >
+    Check all commit messages that are already on the current branch but not the
+    default branch on the origin repository. Useful for checking messages after
+    the fact (e.g., pre-push or in CI) without an expensive check of the entire
+    repository history.
+  entry: cz check
+  args: [--rev-range, origin/HEAD..HEAD]
+  always_run: true
+  pass_filenames: false
   language: python
   language_version: python3
   minimum_pre_commit_version: "1.4.3"

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,7 +101,7 @@ cz commit -s
 ```
 
 ### Integrating with Pre-commit
-Commitizen can lint your commit message for you with `cz check`.
+Commitizen can lint your commit messages for you with `cz check`.
 You can integrate this in your [pre-commit](https://pre-commit.com/) config with:
 
 ```yaml
@@ -111,13 +111,22 @@ repos:
     rev: master
     hooks:
       - id: commitizen
+      - id: commitizen-branch
+        stages: [push]
 ```
 
-After the configuration is added, you'll need to run
+After the configuration is added, you'll need to run:
 
 ```sh
-pre-commit install --hook-type commit-msg
+pre-commit install --hook-type commit-msg pre-push
 ```
+
+If you aren't using both hooks, you needn't install both stages.
+
+| Hook              | Recommended Stage |
+| ----------------- | ----------------- |
+| commitizen        | commit-msg        |
+| commitizen-branch | pre-push          |
 
 Read more about the `check` command [here](check.md).
 


### PR DESCRIPTION
## Description

Check all commit messages on the current branch. This is useful for checking commit messages after the fact (e.g., pre-push or in CI) since the existing hook only works at commit time. Expand the documentation of the pre-existing commitizen hook to clarify the relationship between them. I wasn't sure whether it would be appropriate to add a section to [this documentation](https://commitizen-tools.github.io/commitizen/auto_check/).

Remove no longer needed `commit-msg` stage from self-use of `commitizen` pre-commit hook in `.pre-commit-config.yaml`. In v2.27.1, the `commitizen` pre-commit hook began specifying that it runs on the `commit-msg` stage in the hook definition in `.pre-commit-hooks.yaml`, so it is no longer necessary to specify the hook stage when using the hook in `.pre-commit-config.yaml`.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior

The `commitizen` hook continues to work as before, allowing empty commit messages. The `commitizen-branch` hook checks all commit messages on your branch, and doesn't allow empty commit messages.

## Steps to Test This Pull Request

1. Replace your Commitizen hook config in your `.pre-commit-config.yaml` with the following:

      ```yaml
      repos:
        - repo: https://github.com/Kurt-von-Laven/commitizen
          rev: pre-commit-hook
          hooks:
            - id: commitizen
            - id: commitizen-branch
              stages: [push]
      ```

1. Ensure that you have pre-commit 1.4.3 or higher installed.
1. Install `commit-msg` and `pre-push` hooks if you haven't already via: `pre-commit install --hook-type commit-msg pre-push`.
1. Commit some changes to your repository.
1. If the commit message was invalid, the `commitizen` hook will fail, and otherwise it will succeed.
1. Commit a change with an empty commit message: `git commit --allow-empty-message -m ""`.
1. Attempt to push your branch.
1. The push fails with an error regarding the empty commit message.

## Additional context
Follows on #512 and #514.