### PR TITLE
feat(bump): make increment option case insensitive

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -145,6 +145,7 @@ data = {
                         "name": ["--increment"],
                         "help": "manually specify the desired increment",
                         "choices": ["MAJOR", "MINOR", "PATCH"],
+                        "type": str.upper,
                     },
                     {
                         "name": ["--check-consistency", "-cc"],

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -110,6 +110,27 @@ def test_bump_major_increment(commit_msg, mocker):
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
+@pytest.mark.parametrize(
+    "commit_msg,increment,expected_tag",
+    [
+        ("feat: new file", "PATCH", "0.1.1"),
+        ("fix: username exception", "major", "1.0.0"),
+        ("refactor: remove ini configuration support", "patch", "0.1.1"),
+        ("BREAKING CHANGE: age is no longer supported", "minor", "0.2.0"),
+    ],
+)
+def test_bump_command_increment_option(commit_msg, increment, expected_tag, mocker):
+    create_file_and_commit(commit_msg)
+
+    testargs = ["cz", "bump", "--increment", increment, "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    tag_exists = git.tag_exist(expected_tag)
+    assert tag_exists is True
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
 def test_bump_command_prelease(mocker):
     # PRERELEASE
     create_file_and_commit("feat: location")


### PR DESCRIPTION
Use `str.upper` to pre-process the input of --increment

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

Support lower case arguments for the `--increment` option of the `bump` command.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior

```console
$ cz bump --increment patch
bump: version 0.6.1 → 0.6.2
tag to create: v0.6.2
increment detected: PATCH
```

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context

Related:

- Closes https://github.com/commitizen-tools/commitizen/issues/533