### PR TITLE
fix(changelog): skip non-compliant commit subjects when building changelog

### DIFF
--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -38,6 +38,7 @@ class ConventionalCommitsCz(BaseCommitizen):
         "refactor": "Refactor",
         "perf": "Perf",
     }
+    changelog_pattern = defaults.bump_pattern
 
     def questions(self) -> Questions:
         questions: Questions = [

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -872,3 +872,21 @@ def test_changelog_from_rev_latest_version_dry_run(
     out, _ = capsys.readouterr()
 
     file_regression.check(out, extension=".md")
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_invalid_subject_is_skipped(mocker, capsys):
+    """Fix #510"""
+    non_conformant_commit_title = (
+        "Merge pull request #487 from manang/master\n\n"
+        "feat: skip merge messages that start with Pull request\n"
+    )
+    create_file_and_commit(non_conformant_commit_title)
+    create_file_and_commit("feat: a new world")
+    testargs = ["cz", "changelog", "--dry-run"]
+    mocker.patch.object(sys, "argv", testargs)
+    with pytest.raises(DryRunExit):
+        cli.main()
+    out, _ = capsys.readouterr()
+
+    assert out == ("## Unreleased\n\n### Feat\n\n- a new world\n\n")


### PR DESCRIPTION
This should fix duplicate entries in the changelog

Closes #510

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
Only entries that have a subject compliant with conventional commits should be included. 

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

Run on our own commitizen:

```
cz ch --dry-run 2.20.5..v2.21.0
```
Before it was including duplicated entries, now only good ones.

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
