### PR TITLE
adds a changelog tag parser to filter tags (--tag-parser; tag_parser)

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -220,6 +220,13 @@ data = {
                             "If not set, it will generate changelog from the start"
                         ),
                     },
+                    {
+                        "name": "--tag-parser",
+                        "help": (
+                            "regex match for tags represented "
+                            "within the changelog. default: '.*'"
+                        ),
+                    },
                 ],
             },
             {

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -1,4 +1,5 @@
 import os.path
+import re
 from difflib import SequenceMatcher
 from operator import itemgetter
 from typing import Callable, Dict, List, Optional
@@ -51,6 +52,10 @@ class Changelog:
         self.tag_format = args.get("tag_format") or self.config.settings.get(
             "tag_format"
         )
+        tag_parser = args.get("tag_parser")
+        if tag_parser is None:
+            tag_parser = self.config.settings.get("tag_parser", r".*")
+        self.tag_pattern = re.compile(tag_parser)
 
     def _find_incremental_rev(self, latest_version: str, tags: List[GitTag]) -> str:
         """Try to find the 'start_rev'.
@@ -154,6 +159,7 @@ class Changelog:
             unreleased_version,
             change_type_map=change_type_map,
             changelog_message_builder_hook=changelog_message_builder_hook,
+            tag_pattern=self.tag_pattern,
         )
         if self.change_type_order:
             tree = changelog.order_changelog_tree(tree, self.change_type_order)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -161,6 +161,24 @@ cz changelog --start-rev="v0.2.0"
 changelog_start_rev = "v0.2.0"
 ```
 
+### `tag-parser`
+
+This value can be set in the `toml` file with the key `tag_parser` under `tools.commitizen`
+
+The default the changelog will capture all git tags (e.g. regex `.*`).
+The user may specify a regex pattern of their own display only
+specific tags within the changelog.
+
+```bash
+cz changelog --tag-parser=".*"
+```
+
+```toml
+[tools.commitizen]
+# ...
+tag_parser = "v[0-9]*\\.[0-9]*\\.[0-9]*"
+```
+
 ## Hooks
 
 Supported hook methods:

--- a/docs/config.md
+++ b/docs/config.md
@@ -128,6 +128,7 @@ commitizen:
 | `version`                  | `str`  | `None`                      | Current version. Example: "0.1.2"                                                                                                                                                               |
 | `version_files`            | `list` | `[ ]`                       | Files were the version will be updated. A pattern to match a line, can also be specified, separated by `:` [See more][version_files]                                                            |
 | `tag_format`               | `str`  | `None`                      | Format for the git tag, useful for old projects, that use a convention like `"v1.2.1"`. [See more][tag_format]                                                                                  |
+| `tag_parser `              | `str`  | `.*`                        | Generate changelog using only tags matching the regex pattern (e.g. `"v([0-9.])*"`). [See more][tag_parser]                                                                                  |
 | `update_changelog_on_bump` | `bool` | `false`                     | Create changelog when running `cz bump`                                                                                                                                                         |
 | `annotated_tag`            | `bool` | `false`                     | Use annotated tags instead of lightweight tags. [See difference][annotated-tags-vs-lightweight]                                                                                                 |
 | `bump_message`             | `str`  | `None`                      | Create custom commit message, useful to skip ci. [See more][bump_message]                                                                                                                       |
@@ -142,6 +143,7 @@ commitizen:
 [version_files]: bump.md#version_files
 [tag_format]: bump.md#tag_format
 [bump_message]: bump.md#bump_message
+[tag_parser]: changelog.md#tag_parser
 [allow_abort]: check.md#allow-abort
 [additional-features]: https://github.com/tmbo/questionary#additional-features
 [customization]: customization.md

--- a/tests/CHANGELOG_FOR_TEST.md
+++ b/tests/CHANGELOG_FOR_TEST.md
@@ -54,6 +54,8 @@
 
 ## v1.0.0b1 (2019-01-17)
 
+## user_def (2019-01-10)
+
 ### feat
 
 - py3 only, tests and conventional commits 1.0

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -843,6 +843,7 @@ def test_generate_tree_from_commits(gitcommits, tags, tag_parser):
         expected_tree = _filter_tree(tag_pattern, COMMITS_TREE)
 
     # compare the contents of each tree
+    tree = list(tree)
     for outcome, expected in zip(tree, expected_tree):
         assert outcome == expected
 


### PR DESCRIPTION
## Description
Some repositories have tags that are not matching the `bump` version pattern (e.g. `alpha`/`beta` release) #519.
It makes sense to be able to filter those out. See this "Expected Behavior" section for an example.

The first commit:
1. feat: adds the filtering.

Subsequent commits (probably best reviewing each commit individually):
1. test: adds a test for when a "feat:" commit is tagged. Previously only "bump:" commits were tagged.
1. refactor: the linter was complaining. Mostly a copy/paste to reduce function complexity.
1. refactor: further refactoring to reduce the number of `if` (by avoiding an optional).

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
originally:
```
## v1.1.0(2022-02-13)
### Feat
- add more

## v1.1.0-beta (2022-02-13)
### Feat
- add new

## v1.0.0 (2022-02-13)
### Feat
- initial
```

once filtered with `cz changelog --dry-run --tag-parser 'v[0-9]*\.[0-9]*\.[0-9]*'` will be:
```
## v1.1.0 (2022-02-13)
### Feat
- add more
- add new

## v1.0.0 (2022-02-13)
### Feat
- initial
```
Similar can be done with the `toml` option: `tag_parser: "v[0-9]*\\.[0-9]*\\.[0-9]*"`. Note `toml` required an extra `\`.

## Steps to Test This Pull Request
1. `scripts/test`

In the case below there is a filterable tag as the first commit. 
```
## v1.2.0-beta (2022-02-13)
### Feat
- another thing

## v1.1.0 (2022-02-13)
### Feat
- add more
- add new

## v1.0.0 (2022-02-13)
### Feat
- initial
```

Question:
 * Should the `v1.2.0-beta` tag:
    * stay as `## v1.2.0-beta`?
    * be replaced with `## Unreleased`? 
    * Maybe `## Prerelease tag: v1.2.0-beta`?
    * be customizable?
 * No test in place yet. 



## Additional context

#519 
