### PR TITLE
fix(bump): send changelog to stdout when `dry-run` is paired with `changelog-to-stdout`

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -180,17 +180,6 @@ class Bump:
                 "The commits found are not elegible to be bumped"
             )
 
-        # Do not perform operations over files or git.
-        if dry_run:
-            raise DryRunExit()
-
-        bump.update_version_in_files(
-            current_version,
-            str(new_version),
-            version_files,
-            check_consistency=self.check_consistency,
-        )
-
         if self.changelog:
             if self.changelog_to_stdout:
                 changelog_cmd = Changelog(
@@ -215,6 +204,17 @@ class Bump:
             )
             changelog_cmd()
             c = cmd.run(f"git add {changelog_cmd.file_name} {' '.join(version_files)}")
+
+        # Do not perform operations over files or git.
+        if dry_run:
+            raise DryRunExit()
+
+        bump.update_version_in_files(
+            current_version,
+            str(new_version),
+            version_files,
+            check_consistency=self.check_consistency,
+        )
 
         self.config.set_key("version", str(new_version))
 

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -500,3 +500,21 @@ def test_bump_with_changelog_to_stdout_arg(mocker, capsys, changelog_path):
         out = f.read()
     assert out.startswith("#")
     assert "0.2.0" in out
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_with_changelog_to_stdout_dry_run_arg(mocker, capsys, changelog_path):
+    create_file_and_commit(
+        "feat(user): this should appear in stdout with dry-run enabled"
+    )
+    testargs = ["cz", "bump", "--yes", "--changelog-to-stdout", "--dry-run"]
+    mocker.patch.object(sys, "argv", testargs)
+    with pytest.raises(DryRunExit):
+        cli.main()
+    out, _ = capsys.readouterr()
+
+    tag_exists = git.tag_exist("0.2.0")
+    assert tag_exists is False
+    assert out.startswith("#")
+    assert "this should appear in stdout with dry-run enabled" in out
+    assert "0.2.0" in out


### PR DESCRIPTION




<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
This sends the changelog to stdout when paired with the `--dry-run` flag


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
when running `cz bump --changelog-to-stdout --dry-run`, the changelog should show in stdout

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
Closes #538
