### PR TITLE
git.get_commits error check

### DIFF
--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -35,7 +35,7 @@ from jinja2 import Environment, PackageLoader
 
 from commitizen import defaults
 from commitizen.bump import normalize_tag
-from commitizen.exceptions import InvalidConfigurationError
+from commitizen.exceptions import InvalidConfigurationError, NoCommitsFoundError
 from commitizen.git import GitCommit, GitTag
 
 
@@ -309,7 +309,7 @@ def get_oldest_and_newest_rev(
 
     tags_range = get_smart_tag_range(tags, newest=newest_tag, oldest=oldest_tag)
     if not tags_range:
-        return None, None
+        raise NoCommitsFoundError("Could not find a valid revision range.")
 
     oldest_rev: Optional[str] = tags_range[-1].name
     newest_rev = newest_tag

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -16,10 +16,6 @@ from commitizen.exceptions import (
 from commitizen.git import GitTag, smart_open
 
 
-def similar(a, b):
-    return SequenceMatcher(None, a, b).ratio()
-
-
 class Changelog:
     """Generate a changelog based on the commit history."""
 

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -27,6 +27,7 @@ class ExitCode(enum.IntEnum):
     NOT_ALLOWED = 20
     NO_INCREMENT = 21
     UNRECOGNIZED_CHARACTERSET_ENCODING = 22
+    GIT_COMMAND_ERROR = 23
 
 
 class CommitizenException(Exception):
@@ -153,3 +154,7 @@ class NotAllowed(CommitizenException):
 
 class CharacterSetDecodeError(CommitizenException):
     exit_code = ExitCode.UNRECOGNIZED_CHARACTERSET_ENCODING
+
+
+class GitCommandError(CommitizenException):
+    exit_code = ExitCode.GIT_COMMAND_ERROR

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -105,27 +105,12 @@ def get_commits(
     start: Optional[str] = None,
     end: str = "HEAD",
     *,
-    log_format: str = "%H%n%s%n%an%n%ae%n%b",
-    delimiter: str = "----------commit-delimiter----------",
     args: str = "",
 ) -> List[GitCommit]:
     """Get the commits between start and end."""
-    git_log_cmd = (
-        f"git -c log.showSignature=False log --pretty={log_format}{delimiter} {args}"
-    )
-
-    if start:
-        command = f"{git_log_cmd} {start}..{end}"
-    else:
-        command = f"{git_log_cmd} {end}"
-    c = cmd.run(command)
-    if c.return_code != 0:
-        raise GitCommandError(c.err)
-    if not c.out:
-        return []
-
+    git_log_entries = _get_log_as_str_list(start, end, args)
     git_commits = []
-    for rev_and_commit in c.out.split(f"{delimiter}\n"):
+    for rev_and_commit in git_log_entries:
         if not rev_and_commit:
             continue
         rev, title, author, author_email, *body_list = rev_and_commit.split("\n")
@@ -236,3 +221,22 @@ def get_eol_style() -> EOLTypes:
 def smart_open(*args, **kargs):
     """Open a file with the EOL style determined from Git."""
     return open(*args, newline=get_eol_style().get_eol_for_open(), **kargs)
+
+
+def _get_log_as_str_list(start: Optional[str], end: str, args: str) -> List[str]:
+    """Get string representation of each log entry"""
+    delimiter = "----------commit-delimiter----------"
+    log_format: str = "%H%n%s%n%an%n%ae%n%b"
+    git_log_cmd = (
+        f"git -c log.showSignature=False log --pretty={log_format}{delimiter} {args}"
+    )
+    if start:
+        command = f"{git_log_cmd} {start}..{end}"
+    else:
+        command = f"{git_log_cmd} {end}"
+    c = cmd.run(command)
+    if c.return_code != 0:
+        raise GitCommandError(c.err)
+    if not c.out:
+        return []
+    return c.out.split(f"{delimiter}\n")

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List, Optional
 
-from commitizen import cmd
+from commitizen import cmd, out
 from commitizen.exceptions import GitCommandError
 
 UNIX_EOL = "\n"
@@ -150,8 +150,13 @@ def get_tags(dateformat: str = "%Y-%m-%d") -> List[GitTag]:
         f'%(object)"'
     )
     c = cmd.run(f"git tag --format={formatter} --sort=-creatordate")
+    if c.return_code != 0:
+        raise GitCommandError(c.err)
 
-    if c.err or not c.out:
+    if c.err:
+        out.warn(f"Attempting to proceed after: {c.err}")
+
+    if not c.out:
         return []
 
     git_tags = [

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -6,6 +6,7 @@ from tempfile import NamedTemporaryFile
 from typing import List, Optional
 
 from commitizen import cmd
+from commitizen.exceptions import GitCommandError
 
 UNIX_EOL = "\n"
 WINDOWS_EOL = "\r\n"
@@ -118,6 +119,8 @@ def get_commits(
     else:
         command = f"{git_log_cmd} {end}"
     c = cmd.run(command)
+    if c.return_code != 0:
+        raise GitCommandError(c.err)
     if not c.out:
         return []
 

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -30,3 +30,4 @@ These exit codes can be found in `commitizen/exceptions.py::ExitCode`.
 | NotAllowed                  | 20        | `--incremental` cannot be combined with a `rev_range`                                                       |
 | NoneIncrementExit           | 21        | The commits found are not eligible to be bumped                                                             |
 | CharacterSetDecodeError     | 22        | The character encoding of the command output could not be determined                                        |
+| GitCommandError             | 23       | Unexpected failure while calling a git command                                                              |

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -273,9 +273,19 @@ def test_bump_when_version_is_not_specify(mocker):
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
 def test_bump_when_no_new_commit(mocker):
+    """bump without any commits since the last bump."""
+    # We need this first commit otherwise the revision is invalid.
+    create_file_and_commit("feat: initial")
+
     testargs = ["cz", "bump", "--yes"]
     mocker.patch.object(sys, "argv", testargs)
 
+    # First bump.
+    # The next bump should fail since
+    # there is not a commit between the two bumps.
+    cli.main()
+
+    # bump without a new commit.
     with pytest.raises(NoCommitsFoundError) as excinfo:
         cli.main()
 

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -633,6 +633,7 @@ def test_changelog_from_rev_latest_version_from_arg(
 def test_changelog_from_rev_single_version_not_found(
     mocker, config_path, changelog_path
 ):
+    """Provides an invalid revision ID to changelog command"""
     with open(config_path, "a") as f:
         f.write('tag_format = "$version"\n')
 
@@ -657,12 +658,13 @@ def test_changelog_from_rev_single_version_not_found(
     with pytest.raises(NoCommitsFoundError) as excinfo:
         cli.main()
 
-    assert "No commits found" in str(excinfo)
+    assert "Could not find a valid revision" in str(excinfo)
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
 @pytest.mark.freeze_time("2022-02-13")
 def test_changelog_from_rev_range_version_not_found(mocker, config_path):
+    """Provides an invalid end revision ID to changelog command"""
     with open(config_path, "a") as f:
         f.write('tag_format = "$version"\n')
 
@@ -684,7 +686,7 @@ def test_changelog_from_rev_range_version_not_found(mocker, config_path):
     with pytest.raises(NoCommitsFoundError) as excinfo:
         cli.main()
 
-    assert "No commits found" in str(excinfo)
+    assert "Could not find a valid revision" in str(excinfo)
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -6,6 +6,7 @@ from commitizen import cli, git
 from commitizen.commands.changelog import Changelog
 from commitizen.exceptions import (
     DryRunExit,
+    GitCommandError,
     NoCommitsFoundError,
     NoRevisionError,
     NotAGitProjectError,
@@ -19,10 +20,12 @@ def test_changelog_on_empty_project(mocker):
     testargs = ["cz", "changelog", "--dry-run"]
     mocker.patch.object(sys, "argv", testargs)
 
-    with pytest.raises(NoCommitsFoundError) as excinfo:
+    with pytest.raises(GitCommandError):
         cli.main()
 
-    assert "No commits found" in str(excinfo)
+    #  git will error out with something like:
+    #  "your current branch 'XYZ' does not have any commits yet"
+    #  is it wise to assert the exception contains a message like this?
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -351,6 +351,15 @@ def test_changelog_without_revision(mocker, tmp_commitizen_project):
         cli.main()
 
 
+def test_changelog_incremental_with_revision(mocker):
+    """combining incremental with a revision doesn't make sense"""
+    testargs = ["cz", "changelog", "--incremental", "0.2.0"]
+    mocker.patch.object(sys, "argv", testargs)
+
+    with pytest.raises(NotAllowed):
+        cli.main()
+
+
 def test_changelog_with_different_tag_name_and_changelog_content(
     mocker, tmp_commitizen_project
 ):
@@ -918,3 +927,15 @@ def test_changelog_with_customized_change_type_order(
         out = f.read()
 
     file_regression.check(out, extension=".md")
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_empty_commit_list(mocker):
+    create_file_and_commit("feat: a new world")
+
+    # test changelog properly handles when no commits are found for the revision
+    mocker.patch("commitizen.git.get_commits", return_value=[])
+    testargs = ["cz", "changelog"]
+    mocker.patch.object(sys, "argv", testargs)
+    with pytest.raises(NoCommitsFoundError):
+        cli.main()

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -6,26 +6,12 @@ from commitizen import cli, git
 from commitizen.commands.changelog import Changelog
 from commitizen.exceptions import (
     DryRunExit,
-    GitCommandError,
     NoCommitsFoundError,
     NoRevisionError,
     NotAGitProjectError,
     NotAllowed,
 )
 from tests.utils import create_file_and_commit, wait_for_tag
-
-
-@pytest.mark.usefixtures("tmp_commitizen_project")
-def test_changelog_on_empty_project(mocker):
-    testargs = ["cz", "changelog", "--dry-run"]
-    mocker.patch.object(sys, "argv", testargs)
-
-    with pytest.raises(GitCommandError):
-        cli.main()
-
-    #  git will error out with something like:
-    #  "your current branch 'XYZ' does not have any commits yet"
-    #  is it wise to assert the exception contains a message like this?
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -10,6 +10,7 @@ from commitizen.exceptions import (
     InvalidCommitMessageError,
     NoCommitsFoundError,
 )
+from tests.utils import create_file_and_commit
 
 COMMIT_LOG = [
     "refactor: A code change that neither fixes a bug nor adds a feature",
@@ -217,7 +218,12 @@ def test_check_command_with_invalid_argument(config):
     )
 
 
+@pytest.mark.usefixtures("tmp_commitizen_project")
 def test_check_command_with_empty_range(config, mocker):
+
+    # must initialize git with a commit
+    create_file_and_commit("feat: initial")
+
     check_cmd = commands.Check(config=config, arguments={"rev_range": "master..master"})
     with pytest.raises(NoCommitsFoundError) as excinfo:
         check_cmd()

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 import pytest
 
-from commitizen import cmd, git
+from commitizen import cmd, exceptions, git
 from tests.utils import FakeCommand, create_file_and_commit
 
 
@@ -56,6 +56,16 @@ def test_git_message_with_empty_body():
     commit = git.GitCommit("test_rev", "Some Title", body="")
 
     assert commit.message == commit_title
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_get_log_as_str_list_empty():
+    """ensure an exception or empty list in an empty project"""
+    try:
+        gitlog = git._get_log_as_str_list(start=None, end="HEAD", args="")
+    except exceptions.GitCommandError:
+        return
+    assert len(gitlog) == 0, "list should be empty if no assert"
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")


### PR DESCRIPTION
## Description
`git.get_commits` could potentially fail silently. 

The first commit is the fix. 
See the git commit message for more info on all following commits (broken up for easier review). 
<img width="1206" alt="image" src="https://user-images.githubusercontent.com/33836927/182230454-cac349fc-c3cf-4b61-aede-4490b194c40e.png">


The final commit also improves error checking in `git.get_tags`  (closes #518).

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
Fail fast behavior and better reports to the user when something goes wrong with git.

Some of the tests showed the command was failing for unexpected reasons (e.g. invalid commit range `git log None..None`).

#### Example of a silent failure that is now caught:
Without this change users with really old versions of git will see is "No commits found" but after the change: <b>
`GitCommandError: fatal: unrecognized argument: --author-date-order`
* reason:  `commands/changelog.py` calls `git.get_commits` with `--author-date-order`  but this argument is not valid for older versions of it. 


## Steps to Test This Pull Request
1. ran tests locally and formatted.


## Additional context
