### PR TITLE
refactor(changelog): removes unused code

### DIFF
--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -38,29 +38,6 @@ from commitizen.bump import normalize_tag
 from commitizen.exceptions import InvalidConfigurationError
 from commitizen.git import GitCommit, GitTag
 
-CATEGORIES = [
-    ("fix", "fix"),
-    ("breaking", "BREAKING CHANGES"),
-    ("feat", "feat"),
-    ("refactor", "refactor"),
-    ("perf", "perf"),
-    ("test", "test"),
-    ("build", "build"),
-    ("ci", "ci"),
-    ("chore", "chore"),
-]
-
-
-def transform_change_type(change_type: str) -> str:
-    # TODO: Use again to parse, for this we have to wait until the maps get
-    # defined again.
-    _change_type_lower = change_type.lower()
-    for match_value, output in CATEGORIES:
-        if re.search(match_value, _change_type_lower):
-            return output
-    else:
-        raise ValueError(f"Could not match a change_type with {change_type}")
-
 
 def get_commit_tag(commit: GitCommit, tags: List[GitTag]) -> Optional[GitTag]:
     return next((tag for tag in tags if tag.rev == commit.rev), None)


### PR DESCRIPTION
## Description
duplicate code exists in `changelog_parser.py`. 
This bit of code seemed to be unused/untested and contributing to lower overall code coverage.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior


## Steps to Test This Pull Request



## Additional context

