### PR TITLE
use error_code to do "is_signed_tag" check to avoid language issue

### DIFF
--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -1,5 +1,4 @@
 import os
-import re
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List, Optional
@@ -143,11 +142,7 @@ def tag_exist(tag: str) -> bool:
 
 
 def is_signed_tag(tag: str) -> bool:
-    c = cmd.run(f"git tag -v {tag}")
-    _ret = False
-    if re.match("gpg: Signature made [0-9/:A-Za-z ]*", c.err):
-        _ret = True
-    return _ret
+    return cmd.run(f"git tag -v {tag}").return_code == 0
 
 
 def get_latest_tag_name() -> Optional[str]:


### PR DESCRIPTION
## Description
as title


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
pass all the test cases even when `LC_ALL` is set to non-English


## Steps to Test This Pull Request
1. `export LC_ALL=zh_TW.UTF-8`
2. `./script/test`


## Additional context
#542