### PR TITLE
fix(cmd): improve character encoding detection for sub-commands

### DIFF
--- a/commitizen/cmd.py
+++ b/commitizen/cmd.py
@@ -12,6 +12,14 @@ class Command(NamedTuple):
     return_code: int
 
 
+def _try_decode(bytes_: bytes) -> str:
+    try:
+        return bytes_.decode("utf-8")
+    except UnicodeDecodeError:
+        result = chardet.detect(bytes_)
+        return bytes_.decode(result["encoding"] or "utf-8")
+
+
 def run(cmd: str) -> Command:
     process = subprocess.Popen(
         cmd,
@@ -23,8 +31,8 @@ def run(cmd: str) -> Command:
     stdout, stderr = process.communicate()
     return_code = process.returncode
     return Command(
-        stdout.decode(chardet.detect(stdout)["encoding"] or "utf-8"),
-        stderr.decode(chardet.detect(stderr)["encoding"] or "utf-8"),
+        _try_decode(stdout),
+        _try_decode(stderr),
         stdout,
         stderr,
         return_code,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

Fixes #544 

## Checklist

- [ ] Add test cases to all the changes you introduce
- [X] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior

See issue #544: `cz` now creates the changelog without failing
