### PR TITLE
feat(ConventionalCommitsCz): allow to override defaults from config

### DIFF
--- a/commitizen/cz/jira/jira.py
+++ b/commitizen/cz/jira/jira.py
@@ -1,5 +1,6 @@
 import os
 
+from commitizen.config.base_config import BaseConfig
 from commitizen.cz.base import BaseCommitizen
 from commitizen.defaults import Questions
 
@@ -7,6 +8,13 @@ __all__ = ["JiraSmartCz"]
 
 
 class JiraSmartCz(BaseCommitizen):
+    def __init__(self, config: BaseConfig):
+        super().__init__(config)
+        self.bump_map = None
+        self.bump_pattern = None
+        self.commit_parser = r"(?P<message>.*)"
+        self.changelog_pattern = r".*"
+
     def questions(self) -> Questions:
         questions = [
             {

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -31,14 +31,23 @@ class Settings(TypedDict, total=False):
     version_files: List[str]
     tag_format: Optional[str]
     bump_message: Optional[str]
+    bump_pattern: Optional[str]
+    bump_map: Optional[Dict[str, str]]
     allow_abort: bool
     changelog_file: str
     changelog_incremental: bool
     changelog_start_rev: Optional[str]
+    changelog_pattern: Optional[str]
     update_changelog_on_bump: bool
     use_shortcuts: bool
-    style: Optional[List[Tuple[str, str]]]
+    style: List[Tuple[str, str]]
     customize: CzSettings
+    change_type_order: Optional[List[str]]
+    change_type_map: Optional[Dict[str, str]]
+    commit_parser: Optional[str]
+    schema: str
+    schema_pattern: str
+    questions: Questions
 
 
 name: str = "cz_conventional_commits"
@@ -80,8 +89,31 @@ bump_map = OrderedDict(
         (r"^perf", PATCH),
     )
 )
-change_type_order = ["BREAKING CHANGE", "Feat", "Fix", "Refactor", "Perf"]
+change_type_order: Optional[List[str]] = None
+
 bump_message = "bump: version $current_version → $new_version"
 
 commit_parser = r"^(?P<change_type>feat|fix|refactor|perf|BREAKING CHANGE)(?:\((?P<scope>[^()\r\n]*)\)|\()?(?P<breaking>!)?:\s(?P<message>.*)?"  # noqa
 version_parser = r"(?P<version>([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?(\w+)?)"
+
+change_type_map = {
+    "feat": "Feat",
+    "fix": "Fix",
+    "refactor": "Refactor",
+    "perf": "Perf",
+}
+
+changelog_pattern = bump_pattern
+
+style: List[Tuple[str, str]] = [
+    ("qmark", "fg:#ff9d00 bold"),
+    ("question", "bold"),
+    ("answer", "fg:#ff9d00 bold"),
+    ("pointer", "fg:#ff9d00 bold"),
+    ("highlighted", "fg:#ff9d00 bold"),
+    ("selected", "fg:#cc5454"),
+    ("separator", "fg:#cc5454"),
+    ("instruction", ""),
+    ("text", ""),
+    ("disabled", "fg:#858585 italic"),
+]

--- a/tests/test_bump_find_increment.py
+++ b/tests/test_bump_find_increment.py
@@ -5,6 +5,7 @@ SVE: Semantic version at the end
 import pytest
 
 from commitizen import bump
+from commitizen.config.base_config import BaseConfig
 from commitizen.cz import ConventionalCommitsCz
 from commitizen.git import GitCommit
 
@@ -72,11 +73,12 @@ semantic_version_map = {"MAJOR": "MAJOR", "MINOR": "MINOR", "PATCH": "PATCH"}
     ),
 )
 def test_find_increment(messages, expected_type):
+    cz = ConventionalCommitsCz(BaseConfig())
     commits = [GitCommit(rev="test", title=message) for message in messages]
     increment_type = bump.find_increment(
         commits,
-        regex=ConventionalCommitsCz.bump_pattern,
-        increments_map=ConventionalCommitsCz.bump_map,
+        regex=cz.bump_pattern,
+        increments_map=cz.bump_map,
     )
     assert increment_type == expected_type
 

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,6 +1,7 @@
 import pytest
 
 from commitizen import changelog, defaults, git
+from commitizen.config.base_config import BaseConfig
 from commitizen.cz.conventional_commits.conventional_commits import (
     ConventionalCommitsCz,
 )
@@ -844,8 +845,9 @@ def test_order_changelog_tree_raises():
 
 
 def test_render_changelog(gitcommits, tags, changelog_content):
-    parser = ConventionalCommitsCz.commit_parser
-    changelog_pattern = ConventionalCommitsCz.bump_pattern
+    cz = ConventionalCommitsCz(BaseConfig())
+    parser = cz.commit_parser
+    changelog_pattern = cz.bump_pattern
     tree = changelog.generate_tree_from_commits(
         gitcommits, tags, parser, changelog_pattern
     )
@@ -854,9 +856,10 @@ def test_render_changelog(gitcommits, tags, changelog_content):
 
 
 def test_render_changelog_unreleased(gitcommits):
+    cz = ConventionalCommitsCz(BaseConfig())
     some_commits = gitcommits[:7]
-    parser = ConventionalCommitsCz.commit_parser
-    changelog_pattern = ConventionalCommitsCz.bump_pattern
+    parser = cz.commit_parser
+    changelog_pattern = cz.bump_pattern
     tree = changelog.generate_tree_from_commits(
         some_commits, [], parser, changelog_pattern
     )
@@ -869,9 +872,10 @@ def test_render_changelog_tag_and_unreleased(gitcommits, tags):
     single_tag = [
         tag for tag in tags if tag.rev == "56c8a8da84e42b526bcbe130bd194306f7c7e813"
     ]
+    cz = ConventionalCommitsCz(BaseConfig())
 
-    parser = ConventionalCommitsCz.commit_parser
-    changelog_pattern = ConventionalCommitsCz.bump_pattern
+    parser = cz.commit_parser
+    changelog_pattern = cz.bump_pattern
     tree = changelog.generate_tree_from_commits(
         some_commits, single_tag, parser, changelog_pattern
     )
@@ -882,10 +886,11 @@ def test_render_changelog_tag_and_unreleased(gitcommits, tags):
 
 
 def test_render_changelog_with_change_type(gitcommits, tags):
+    cz = ConventionalCommitsCz(BaseConfig())
     new_title = ":some-emoji: feature"
     change_type_map = {"feat": new_title}
-    parser = ConventionalCommitsCz.commit_parser
-    changelog_pattern = ConventionalCommitsCz.bump_pattern
+    parser = cz.commit_parser
+    changelog_pattern = cz.bump_pattern
     tree = changelog.generate_tree_from_commits(
         gitcommits, tags, parser, changelog_pattern, change_type_map=change_type_map
     )
@@ -900,8 +905,9 @@ def test_render_changelog_with_changelog_message_builder_hook(gitcommits, tags):
         ] = f"{message['message']} [link](github.com/232323232) {commit.author} {commit.author_email}"
         return message
 
-    parser = ConventionalCommitsCz.commit_parser
-    changelog_pattern = ConventionalCommitsCz.bump_pattern
+    cz = ConventionalCommitsCz(BaseConfig())
+    parser = cz.commit_parser
+    changelog_pattern = cz.bump_pattern
     tree = changelog.generate_tree_from_commits(
         gitcommits,
         tags,


### PR DESCRIPTION
Before fixing tests and adding extra ones, I would like to receive
partial feedback about my changes to see if this aligns with the desired
code changes by maintainers.

As addressed on #535, when using customize commitizen, if we want to
customize a small attribute, we need to redefine all commitizens options
to make our custom class work.

For example:

```diff
diff --git a/cz.yaml b/cz.yaml
index f2e19a9..302e961 100644
--- a/cz.yaml
+++ b/cz.yaml
@@ -1,6 +1,18 @@
 commitizen:
   annotated_tag: true
   bump_message: 'bump: $current_version -> $new_version [skip ci]'
-  name: cz_conventional_commits
+  name: cz_customize
   update_changelog_on_bump: true
   version: 0.11.0
+
+  customize:
+    bump_pattern: '^(fix|feat|docs|style|refactor|test|build|ci)'
+    bump_map:
+      fix: PATCH
+      feat: PATCH
+      docs: PATCH
+      style: PATCH
+      refactor: PATCH
+      test: PATCH
+      build: PATCH
+      ci: PATCH
diff --git a/t b/t
new file mode 100644
index 0000000..e69de29
diff --git a/t2 b/t2
new file mode 100644
index 0000000..e69de29

```

making the following change on a repo would cause an unexpected
behavior:

```python
+ bash -c cz commit

Traceback (most recent call last):
  File "/home/amit/.local/bin/cz", line 8, in <module>
    sys.exit(main())
  File "/home/amit/.local/lib/python3.10/site-packages/commitizen/cli.py", line 382, in main
    args.func(conf, vars(args))()
  File "/home/amit/.local/lib/python3.10/site-packages/commitizen/commands/commit.py", line 74, in __call__
    m = self.prompt_commit_questions()
  File "/home/amit/.local/lib/python3.10/site-packages/commitizen/commands/commit.py", line 49, in prompt_commit_questions
    for question in filter(lambda q: q["type"] == "list", questions):
  File "/home/amit/.local/lib/python3.10/site-packages/commitizen/commands/commit.py", line 49, in <lambda>
    for question in filter(lambda q: q["type"] == "list", questions):
KeyError: 'type'
```

From my best understanding, this error happens because I didn't defined
question section in config, though I'm ok with using
ConventionalCommitsCz default ones.

This commit extends ConventionalCommitsCz to read from config and
fallbacks to defaults if some are not provided.

By adding this change, potentially customize commitizen can be
deprecated.

A warning message will be printed when using `cz_customize`

Closes #535.

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
