### PR TITLE
test(commands): stores gpg keyring in a temporary directory

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
-from commitizen import cmd, git
+from commitizen import cmd, exceptions, git
 
 
 class FakeCommand:
@@ -18,8 +18,12 @@ def create_file_and_commit(message: str, filename: Optional[str] = None):
         filename = str(uuid.uuid4())
 
     Path(f"./{filename}").touch()
-    cmd.run("git add .")
-    git.commit(message)
+    c = cmd.run("git add .")
+    if c.return_code != 0:
+        raise exceptions.CommitError(c.err)
+    c = git.commit(message)
+    if c.return_code != 0:
+        raise exceptions.CommitError(c.err)
 
 
 def wait_for_tag():


### PR DESCRIPTION
## Description
The unit tests were creating a bunch of keys (run tests a few times and see `gpg --list-keys`).

This solution creates a temporary `GNUPGHOME`. Notably gpg-agent requires a socket path of less 104 characters otherwise the gpg command will fail.

I am not confident this is the best approach but it is probably the easiest fix for the moment.
Is this a portable solution?

Also, I reduced the key length down to a debug level key for speed and security reasons.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
no more added keys.

## Steps to Test This Pull Request
1. ran tests.
2. observed  `gpg --list-keys`

## Additional context

