### PR TITLE
refactor(tool): use charset_normalizer instead of chardet

### DIFF
--- a/commitizen/cmd.py
+++ b/commitizen/cmd.py
@@ -1,7 +1,7 @@
 import subprocess
 from typing import NamedTuple
 
-import chardet
+from charset_normalizer import from_bytes
 
 
 class Command(NamedTuple):
@@ -23,8 +23,8 @@ def run(cmd: str) -> Command:
     stdout, stderr = process.communicate()
     return_code = process.returncode
     return Command(
-        stdout.decode(chardet.detect(stdout)["encoding"] or "utf-8"),
-        stderr.decode(chardet.detect(stderr)["encoding"] or "utf-8"),
+        str(from_bytes(stdout).best()),
+        str(from_bytes(stderr).best()),
         stdout,
         stderr,
         return_code,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ jinja2 = ">=2.10.3"
 pyyaml = ">=3.08"
 argcomplete = "^1.12.1"
 typing-extensions = "^4.0.1"
-chardet = "^5.0.0"
+charset-normalizer = "^2.1.0"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.2"
@@ -82,7 +82,6 @@ mkdocs = "^1.0"
 mkdocs-material = "^4.1"
 pydocstyle = "^5.0.2"
 pytest-xdist = "^2.5.0"
-types-chardet = "^5.0.2"
 
 [tool.poetry.scripts]
 cz = "commitizen.cli:main"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
move from chardet to charset_normalizer to avoid recent issue on wrong encoding.


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
commitizen is able to decode command's strings without issue on `decode` .


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->

https://github.com/commitizen-tools/commitizen/pull/545

https://github.com/commitizen-tools/commitizen/issues/544

