### PR TITLE
fix(cmd): improve character encoding detection for sub-commands

### DIFF
--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -26,6 +26,7 @@ class ExitCode(enum.IntEnum):
     INVALID_CONFIGURATION = 19
     NOT_ALLOWED = 20
     NO_INCREMENT = 21
+    UNRECOGNIZED_CHARACTERSET_ENCODING = 22
 
 
 class CommitizenException(Exception):
@@ -148,3 +149,7 @@ class InvalidConfigurationError(CommitizenException):
 
 class NotAllowed(CommitizenException):
     exit_code = ExitCode.NOT_ALLOWED
+
+
+class CharacterSetDecodeError(CommitizenException):
+    exit_code = ExitCode.UNRECOGNIZED_CHARACTERSET_ENCODING

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -28,4 +28,5 @@ These exit codes can be found in `commitizen/exceptions.py::ExitCode`.
 | InvalidCommandArgumentError | 18        | The argument provide to command is invalid (e.g. `cz check -commit-msg-file filename --rev-range master..`) |
 | InvalidConfigurationError   | 19        | An error was found in the Commitizen Configuration, such as duplicates in `change_type_order`               |
 | NotAllowed                  | 20        | `--incremental` cannot be combined with a `rev_range`                                                       |
-| NoneIncrementExit           | 21        | The commits found are not elegible to be bumped                                                             |
+| NoneIncrementExit           | 21        | The commits found are not eligible to be bumped                                                             |
+| CharacterSetDecodeError     | 22        | The character encoding of the command output could not be determined                                        |

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,0 +1,53 @@
+import pytest
+
+from commitizen import cmd
+from commitizen.exceptions import CharacterSetDecodeError
+
+
+# https://docs.python.org/3/howto/unicode.html
+def test_valid_utf8_encoded_strings():
+    valid_strings = (
+        "",
+        "ascii",
+        "🤦🏻‍♂️",
+        "﷽",
+        "\u0000",
+    )
+    assert all(s == cmd._try_decode(s.encode("utf-8")) for s in valid_strings)
+
+
+# A word of caution: just because an encoding can be guessed for a given
+# sequence of bytes and because that guessed encoding may yield a decoded
+# string, does not mean that that string was the original! For more, see:
+# https://docs.python.org/3/library/codecs.html#standard-encodings
+
+
+# Pick a random, non-utf8 encoding to test.
+def test_valid_cp1250_encoded_strings():
+    valid_strings = (
+        "",
+        "ascii",
+        "äöüß",
+        "ça va",
+        "jak se máte",
+    )
+    for s in valid_strings:
+        assert cmd._try_decode(s.encode("cp1250")) or True
+
+
+def test_invalid_bytes():
+    invalid_bytes = (b"\x73\xe2\x9d\xff\x00",)
+    for s in invalid_bytes:
+        with pytest.raises(CharacterSetDecodeError):
+            cmd._try_decode(s)
+
+
+def test_always_fail_decode():
+    class _bytes(bytes):
+        def decode(self, encoding="utf-8", errors="strict"):
+            raise UnicodeDecodeError(
+                encoding, self, 0, 0, "Failing intentionally for testing"
+            )
+
+    with pytest.raises(CharacterSetDecodeError):
+        cmd._try_decode(_bytes())


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

Fixes #544 
Redo #545 

## Checklist

- [x] Add test cases to all the changes you introduce
- [X] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior

See issue #544: `cz` now creates the changelog without failing
