### PR TITLE
Self Check With New `commitizen-branch` pre-commit Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
-default_stages: [push]
+default_stages:
+  - commit
+  - push
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,10 @@ repos:
     rev: v2.32.2 # automatically updated by Commitizen
     hooks:
       - id: commitizen
+      - id: commitizen-branch
+        stages:
+          - post-commit
+          - push
 
   - repo: local
     hooks:


### PR DESCRIPTION
## Description

Check existing commit messages. Use new `commitizen-branch` hook to verify correctness of existing commit messages post-commit and pre-push. This guards against cherry-picked commits with invalid commit messages as well as empty commit messages (e.g., created with `git commit --allow-empty-message`).

Run hooks pre-commit by default. They already run pre-push, and this behavior is left unchanged. Running hooks pre-commit gives developers more immediate feedback and improves commit quality by blocking an often unnecessary series of fix commits.

When testing this change locally, `poetry install` failed with the following error:

```
Creating virtualenv commitizen-9emEp_2F-py3.10 in ~/.cache/pypoetry/virtualenvs
Installing dependencies from lock file
Warning: The lock file is not up to date with the latest changes in pyproject.toml. You may be getting outdated dependencies. Run update to update them.

  SolverProblemError

  Because commitizen depends on charset-normalizer (^2.1.0) which doesn't match any versions, version solving failed.

  at ~/.asdf/installs/poetry/1.1.14/lib/poetry/puzzle/solver.py:241 in _solve
      237│             packages = result.packages
      238│         except OverrideNeeded as e:
      239│             return self.solve_in_compatibility_mode(e.overrides, use_latest=use_latest)
      240│         except SolveFailure as e:
    → 241│             raise SolverProblemError(e)
      242│ 
      243│         results = dict(
      244│             depth_first_search(
      245│                 PackageNode(self._package, packages), aggregate_package_nodes
```

I think `poetry update` may need to be run, but when I tried that, I encountered 51 test failures.

## Checklist

- [x] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
The new `commitizen-branch` hook passes.

## Steps to Test This Pull Request
1. Run `poetry update` to work around issue described above.
2. Run `poetry install` to install pre-commit and other dependencies.
3. Make a test commit since presently the `commitizen-branch` hook fails when the range `origin/HEAD..HEAD` contains no commits.
4. Run `poetry run pre-commit run --all-files --hook-stage push` to run all pre-push hooks.

## Additional context
Follows on #517.
