### PR TITLE
fix(commands/changelog): Fixed issue #561 cz bump could not find the latest version tag with custom tag_format

### DIFF
--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -3,7 +3,7 @@ from difflib import SequenceMatcher
 from operator import itemgetter
 from typing import Callable, Dict, List, Optional
 
-from commitizen import changelog, defaults, factory, git, out
+from commitizen import bump, changelog, defaults, factory, git, out
 from commitizen.config import BaseConfig
 from commitizen.exceptions import (
     DryRunExit,
@@ -132,7 +132,10 @@ class Changelog:
             changelog_meta = changelog.get_metadata(self.file_name)
             latest_version = changelog_meta.get("latest_version")
             if latest_version:
-                start_rev = self._find_incremental_rev(latest_version, tags)
+                latest_tag_version: str = bump.normalize_tag(
+                    latest_version, tag_format=self.tag_format
+                )
+                start_rev = self._find_incremental_rev(latest_tag_version, tags)
 
         if self.rev_range and self.tag_format:
             start_rev, end_rev = changelog.get_oldest_and_newest_rev(

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -142,14 +142,14 @@ def test_changelog_incremental_angular_sample(
 ):
     with open(changelog_path, "w") as f:
         f.write(
-            "# [10.0.0-next.3](https://github.com/angular/angular/compare/10.0.0-next.2...10.0.0-next.3) (2020-04-22)\n"
+            "# [10.0.0-rc.3](https://github.com/angular/angular/compare/10.0.0-rc.2...10.0.0-rc.3) (2020-04-22)\n"
             "\n"
             "### Bug Fixes"
             "\n"
             "* **common:** format day-periods that cross midnight ([#36611](https://github.com/angular/angular/issues/36611)) ([c6e5fc4](https://github.com/angular/angular/commit/c6e5fc4)), closes [#36566](https://github.com/angular/angular/issues/36566)\n"
         )
     create_file_and_commit("irrelevant commit")
-    git.tag("10.0.0-next.3")
+    git.tag("10.0.0-rc.3")
 
     create_file_and_commit("feat: add new output")
     create_file_and_commit("fix: output glitch")

--- a/tests/commands/test_changelog_command/test_changelog_incremental_angular_sample.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_angular_sample.md
@@ -10,7 +10,7 @@
 - mama gotta work
 - output glitch
 
-# [10.0.0-next.3](https://github.com/angular/angular/compare/10.0.0-next.2...10.0.0-next.3) (2020-04-22)
+# [10.0.0-rc.3](https://github.com/angular/angular/compare/10.0.0-rc.2...10.0.0-rc.3) (2020-04-22)
 
 ### Bug Fixes
 * **common:** format day-periods that cross midnight ([#36611](https://github.com/angular/angular/issues/36611)) ([c6e5fc4](https://github.com/angular/angular/commit/c6e5fc4)), closes [#36566](https://github.com/angular/angular/issues/36566)


### PR DESCRIPTION
## Description
fix(command_changelog): Fixed issue #561 cz bump could not find the latest version tag with custom tag_format
- Updated args to _find_incremental_rev to use latest_tag_version instead of latest_version
- Updated test case for test_changelog_command.py from .next to .rc as python packaging lib doesn't take 'next' as a valid version


## Checklist

- [ ] Add test cases to all the changes you introduce
- [X] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
The changelog command will now use the tag_format_$version to lookup the git tags instead of just $version, which may fail if git tag has a long length which significally reduce the similarity


## Steps to Test This Pull Request
Configuration
```
$ cat .cz.toml | grep tag_format
tag_format = "SOME_TAG_PREFIX_$version"
```

Commits
```
$ git tag
SOME_TAG_PREFIX_1.0.0

$ git log
commit 11ba99fd2907be046e814662e3057c4bdd9f3db0 (HEAD -> master)
Author: Sam SIU <23556929+ssiuhk@users.noreply.github.com>
Date:   Fri Aug 19 19:35:08 2022 +0000

    feat(Testing): Testing something

commit db20a16f6ed45ef1470b131f65c9006b094c4a58 (tag: SOME_TAG_PREFIX_1.0.0)
Author: Sam SIU <23556929+ssiuhk@users.noreply.github.com>
Date:   Fri Aug 19 18:54:18 2022 +0000

    First release
```

Command run
```
$ cz bump --dry-run --changelog
bump: version 1.0.0 → 1.1.0
tag to create: SOME_TAG_PREFIX_1.1.0
increment detected: MINOR

## SOME_TAG_PREFIX_1.1.0 (2022-08-19)

### Feat

- **Testing**: Testing something
```

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
