### PR TITLE
fix(bump): Support regexes containing colons

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -141,8 +141,7 @@ def update_version_in_files(
     """
     # TODO: separate check step and write step
     for location in files:
-        filepath, *regexes = location.split(":")
-        regex = regexes[0] if regexes else None
+        filepath, _, regex = location.partition(":")
 
         with open(filepath, "r") as f:
             version_file = f.read()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ tag_format = "v$version"
 version_files = [
   "pyproject.toml:version",
   "commitizen/__version__.py",
-  ".pre-commit-config.yaml:rev.\\s+(?=[^\\n]+Commitizen)"
+  ".pre-commit-config.yaml:rev:.\\s+(?=[^\\n]+Commitizen)"
 ]
 
 [tool.black]


### PR DESCRIPTION
## Description

Fixes #499.

The `version_files` feature uses a colon to delimit filenames from a regex to use to find the version. Make `version_files` slightly more robust by splitting on the first colon rather than all colons, thereby permitting the regex to contain a colon. Maintain the pre-existing assumption that the filename doesn't contain a colon, as this is rare and would likely cause many other problems.

Include colon in `version_files` regex. Commitizen runs bump on itself to, among other things, manage the version it uses of its own pre-commit hooks. When searching `.pre-commit-config.yaml` for the version number of Commitizen, look for `"rev:"` rather than `"rev"` to reduce the likelihood of a false positive now that colons are permitted in `version_files` regexes.

## Checklist

- [x] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
The version of the Commitizen pre-commit hooks is incremented along with all other references to the Commitizen version number.

## Steps to Test This Pull Request
1. Run `cz bump`.

## Additional context
As mentioned in #565, I am encountering some difficulties testing Commitizen locally.