### PR TITLE
fix(bump): log git commit stderr and stdout during bump

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -230,6 +230,12 @@ class Bump:
             c = git.commit(message, args=self._get_commit_args())
         if c.return_code != 0:
             raise BumpCommitFailedError(f'2nd git.commit error: "{c.err.strip()}"')
+
+        if c.out:
+            out.write(c.out)
+        if c.err:
+            out.write(c.err)
+
         c = git.tag(
             new_tag_version,
             signed=self.bump_settings.get("gpg_sign", False)


### PR DESCRIPTION
## Description

I notice that the the [commit command outputs both `stderr` and `stdout` of `git commit`](https://github.com/commitizen-tools/commitizen/blob/8cb1e22d72abd855f221556f2a1c8fc0ddded109/commitizen/commands/commit.py#L104). I am thinking it might be a good idea for the bump command to do the same. This way if there are any hook warnings it will show up in the bump output.

What do you think?

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
*  `cz bump --changelog` outputs: 
<img width="562" alt="image" src="https://user-images.githubusercontent.com/33836927/188024369-c2c080f2-cea1-4b10-babb-89d4b69723e0.png">



## Steps to Test This Pull Request
*  `scripts/test`

## Additional context
Helpful in diagnosing #520 
