### PR TITLE
fix(bump.py): `CHANGELOG.md` gets git added and commited correctly

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -205,7 +205,11 @@ class Bump:
                 },
             )
             changelog_cmd()
-            c = cmd.run(f"git add {changelog_cmd.file_name} {' '.join(version_files)}")
+            git_add_changelog_and_version_files_command = (
+                f"git add {changelog_cmd.file_name} "
+                f"{' '.join(file_name.partition(':')[0] for file_name in version_files)}"
+            )
+            c = cmd.run(git_add_changelog_and_version_files_command)
 
         # Do not perform operations over files or git.
         if dry_run:
@@ -228,7 +232,7 @@ class Bump:
             # Maybe pre-commit reformatted some files? Retry once
             logger.debug("1st git.commit error: %s", c.err)
             logger.info("1st commit attempt failed; retrying once")
-            cmd.run(f"git add {changelog_cmd.file_name} {' '.join(version_files)}")
+            cmd.run(git_add_changelog_and_version_files_command)
             c = git.commit(message, args=self._get_commit_args())
         if c.return_code != 0:
             raise BumpCommitFailedError(f'2nd git.commit error: "{c.err.strip()}"')

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -126,6 +126,20 @@ def get_commits(
     return git_commits
 
 
+def get_filenames_in_commit(git_reference: str = ""):
+    """Get the list of files that were committed in the requested git reference.
+
+    :param git_reference: a git reference as accepted by `git show`, default: the last commit
+
+    :returns: file names committed in the last commit by default or inside the passed git reference
+    """
+    c = cmd.run(f"git show --name-only --pretty=format: {git_reference}")
+    if c.return_code == 0:
+        return c.out.strip().split("\n")
+    else:
+        raise GitCommandError(c.err)
+
+
 def get_tags(dateformat: str = "%Y-%m-%d") -> List[GitTag]:
     inner_delimiter = "---inner_delimiter---"
     formatter = (


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
The elements in `version_files` may contain not only a file path, but also a regex after a colon. Thus make sure to only pass the file path to
 `git add`.

Fixes a regression introduced in https://github.com/commitizen-tools/commitizen/commit/12b56ad6375bb116e6554b8771b27c7adbbc237f.


## Checklist

- [ ] Add test cases to all the changes you introduce 
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
`CHANGELOG.md` gets `git added` and commited no matter what version files (+ regex) one specifies.


## Before and After

Before the following, broken, command was executed:
` git add CHANGELOG.md pyproject.toml:^version src/my_package/__init__.py:^__version__`


With this MR, the command looks like this:
`git add CHANGELOG.md pyproject.toml src/my_package/__init__.py`


## Steps to Test This Pull Request
Have the following commitizen settings in `pyproject.toml` file:
```toml
[tool.commitizen]
version = "1.0.2"
version_files = [
    "pyproject.toml:^version",  # use regex to only update version at start of line (https://github.com/commitizen-tools/commitizen/issues/496)
    "src/my_package/__init__.py:^__version__",
]
tag_format = "v$major.$minor.$patch$prerelease"
```
In the git repo of `my_package` make sure there is no `CHANGELOG.md` file tracked by git yet.
Running `cz bump` will update the version correctly and also write the changelog file, but fail to `git add` it.



## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
