### PR TITLE
feat: add functionality for dev-releases

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -69,6 +69,18 @@ def prerelease_generator(current_version: str, prerelease: Optional[str] = None)
     return pre_version
 
 
+def devrelease_generator(devrelease: int = None) -> str:
+    """Generate devrelease
+
+    The devrelease version should be passed directly and is not
+    inferred based on the previous version.
+    """
+    if devrelease is None:
+        return ""
+
+    return f"dev{devrelease}"
+
+
 def semver_generator(current_version: str, increment: str = None) -> str:
     version = Version(current_version)
     prev_release = list(version.release)
@@ -102,6 +114,7 @@ def generate_version(
     current_version: str,
     increment: str,
     prerelease: Optional[str] = None,
+    devrelease: Optional[int] = None,
     is_local_version: bool = False,
 ) -> Version:
     """Based on the given increment a proper semver will be generated.
@@ -117,17 +130,18 @@ def generate_version(
     """
     if is_local_version:
         version = Version(current_version)
+        dev_version = devrelease_generator(devrelease=devrelease)
         pre_version = prerelease_generator(str(version.local), prerelease=prerelease)
         semver = semver_generator(str(version.local), increment=increment)
 
-        return Version(f"{version.public}+{semver}{pre_version}")
+        return Version(f"{version.public}+{semver}{pre_version}{dev_version}")
     else:
+        dev_version = devrelease_generator(devrelease=devrelease)
         pre_version = prerelease_generator(current_version, prerelease=prerelease)
         semver = semver_generator(current_version, increment=increment)
 
         # TODO: post version
-        # TODO: dev version
-        return Version(f"{semver}{pre_version}")
+        return Version(f"{semver}{pre_version}{dev_version}")
 
 
 def update_version_in_files(

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -142,6 +142,11 @@ data = {
                         "choices": ["alpha", "beta", "rc"],
                     },
                     {
+                        "name": ["--devrelease", "-d"],
+                        "help": "specify non-negative integer for dev. release",
+                        "type": int,
+                    },
+                    {
                         "name": ["--increment"],
                         "help": "manually specify the desired increment",
                         "choices": ["MAJOR", "MINOR", "PATCH"],

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -103,6 +103,7 @@ class Bump:
         is_yes: bool = self.arguments["yes"]
         increment: Optional[str] = self.arguments["increment"]
         prerelease: str = self.arguments["prerelease"]
+        devrelease: Optional[int] = self.arguments["devrelease"]
         is_files_only: Optional[bool] = self.arguments["files_only"]
         is_local_version: Optional[bool] = self.arguments["local_version"]
 
@@ -151,6 +152,7 @@ class Bump:
             current_version,
             increment,
             prerelease=prerelease,
+            devrelease=devrelease,
             is_local_version=is_local_version,
         )
 

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -48,7 +48,7 @@ Some examples:
 2.0.1a
 ```
 
-`post` and `dev` releases are not supported yet.
+`post` releases are not supported yet.
 
 ## Usage
 
@@ -56,9 +56,10 @@ Some examples:
 $ cz bump --help
 usage: cz bump [-h] [--dry-run] [--files-only] [--local-version] [--changelog]
                [--no-verify] [--yes] [--tag-format TAG_FORMAT]
-               [--bump-message BUMP_MESSAGE] [--prerelease {alpha,beta,rc}]
-               [--increment {MAJOR,MINOR,PATCH}] [--check-consistency]
-               [--annotated-tag] [--gpg-sign] [--changelog-to-stdout] [--retry]
+               [--bump-message BUMP_MESSAGE] [--increment {MAJOR,MINOR,PATCH}]
+               [--prerelease {alpha,beta,rc}] [--devrelease {DEV}]
+               [--check-consistency] [--annotated-tag] [--gpg-sign]
+               [--changelog-to-stdout] [--retry]
 
 options:
   -h, --help            show this help message and exit
@@ -77,6 +78,7 @@ options:
                         when working with CI
   --prerelease {alpha,beta,rc}, -pr {alpha,beta,rc}
                         choose type of prerelease
+  --devrelease {DEV}    specify dev release
   --increment {MAJOR,MINOR,PATCH}
                         manually specify the desired increment
   --check-consistency, -cc
@@ -269,7 +271,7 @@ cz bump --tag-format="v$version"
 ```
 
 ```bash
-cz bump --tag-format="v$minor.$major.$patch$prerelease"
+cz bump --tag-format="v$minor.$major.$patch$prerelease.$devrelease"
 ```
 
 In your `pyproject.toml` or `.cz.toml`
@@ -283,13 +285,14 @@ The variables must be preceded by a `$` sign.
 
 Supported variables:
 
-| Variable      | Description                                |
-| ------------- | ------------------------------------------ |
-| `$version`    | full generated version                     |
-| `$major`      | MAJOR increment                            |
-| `$minor`      | MINOR increment                            |
-| `$patch`      | PATCH increment                            |
-| `$prerelease` | Prerelase (alpha, beta, release candidate) |
+| Variable      | Description                                 |
+| ------------- | --------------------------------------------|
+| `$version`    | full generated version                      |
+| `$major`      | MAJOR increment                             |
+| `$minor`      | MINOR increment                             |
+| `$patch`      | PATCH increment                             |
+| `$prerelease` | Prerelease (alpha, beta, release candidate) |
+| `$devrelease` | Development release                         |
 
 ---
 

--- a/tests/test_bump_find_version.py
+++ b/tests/test_bump_find_version.py
@@ -6,65 +6,72 @@ from packaging.version import Version
 from commitizen.bump import generate_version
 
 simple_flow = [
-    (("0.1.0", "PATCH", None), "0.1.1"),
-    (("0.1.1", "MINOR", None), "0.2.0"),
-    (("0.2.0", "MINOR", None), "0.3.0"),
-    (("0.3.0", "PATCH", None), "0.3.1"),
-    (("0.3.0", "PATCH", "alpha"), "0.3.1a0"),
-    (("0.3.1a0", None, "alpha"), "0.3.1a1"),
-    (("0.3.1a0", None, None), "0.3.1"),
-    (("0.3.1", "PATCH", None), "0.3.2"),
-    (("0.4.2", "MAJOR", "alpha"), "1.0.0a0"),
-    (("1.0.0a0", None, "alpha"), "1.0.0a1"),
-    (("1.0.0a1", None, "alpha"), "1.0.0a2"),
-    (("1.0.0a1", None, "beta"), "1.0.0b0"),
-    (("1.0.0b0", None, "beta"), "1.0.0b1"),
-    (("1.0.0b1", None, "rc"), "1.0.0rc0"),
-    (("1.0.0rc0", None, "rc"), "1.0.0rc1"),
-    (("1.0.0rc0", "PATCH", None), "1.0.0"),
-    (("1.0.0", "PATCH", None), "1.0.1"),
-    (("1.0.1", "PATCH", None), "1.0.2"),
-    (("1.0.2", "MINOR", None), "1.1.0"),
-    (("1.1.0", "MINOR", None), "1.2.0"),
-    (("1.2.0", "PATCH", None), "1.2.1"),
-    (("1.2.1", "MAJOR", None), "2.0.0"),
+    (("0.1.0", "PATCH", None, None), "0.1.1"),
+    (("0.1.0", "PATCH", None, 1), "0.1.1.dev1"),
+    (("0.1.1", "MINOR", None, None), "0.2.0"),
+    (("0.2.0", "MINOR", None, None), "0.3.0"),
+    (("0.2.0", "MINOR", None, 1), "0.3.0.dev1"),
+    (("0.3.0", "PATCH", None, None), "0.3.1"),
+    (("0.3.0", "PATCH", "alpha", None), "0.3.1a0"),
+    (("0.3.1a0", None, "alpha", None), "0.3.1a1"),
+    (("0.3.1a0", None, None, None), "0.3.1"),
+    (("0.3.1", "PATCH", None, None), "0.3.2"),
+    (("0.4.2", "MAJOR", "alpha", None), "1.0.0a0"),
+    (("1.0.0a0", None, "alpha", None), "1.0.0a1"),
+    (("1.0.0a1", None, "alpha", None), "1.0.0a2"),
+    (("1.0.0a1", None, "alpha", 1), "1.0.0a2.dev1"),
+    (("1.0.0a2.dev0", None, "alpha", 1), "1.0.0a3.dev1"),
+    (("1.0.0a2.dev0", None, "alpha", 0), "1.0.0a3.dev0"),
+    (("1.0.0a1", None, "beta", None), "1.0.0b0"),
+    (("1.0.0b0", None, "beta", None), "1.0.0b1"),
+    (("1.0.0b1", None, "rc", None), "1.0.0rc0"),
+    (("1.0.0rc0", None, "rc", None), "1.0.0rc1"),
+    (("1.0.0rc0", None, "rc", 1), "1.0.0rc1.dev1"),
+    (("1.0.0rc0", "PATCH", None, None), "1.0.0"),
+    (("1.0.0a3.dev0", None, "beta", None), "1.0.0b0"),
+    (("1.0.0", "PATCH", None, None), "1.0.1"),
+    (("1.0.1", "PATCH", None, None), "1.0.2"),
+    (("1.0.2", "MINOR", None, None), "1.1.0"),
+    (("1.1.0", "MINOR", None, None), "1.2.0"),
+    (("1.2.0", "PATCH", None, None), "1.2.1"),
+    (("1.2.1", "MAJOR", None, None), "2.0.0"),
 ]
 
 local_versions = [
-    (("4.5.0+0.1.0", "PATCH", None), "4.5.0+0.1.1"),
-    (("4.5.0+0.1.1", "MINOR", None), "4.5.0+0.2.0"),
-    (("4.5.0+0.2.0", "MAJOR", None), "4.5.0+1.0.0"),
+    (("4.5.0+0.1.0", "PATCH", None, None), "4.5.0+0.1.1"),
+    (("4.5.0+0.1.1", "MINOR", None, None), "4.5.0+0.2.0"),
+    (("4.5.0+0.2.0", "MAJOR", None, None), "4.5.0+1.0.0"),
 ]
 
 # this cases should be handled gracefully
 unexpected_cases = [
-    (("0.1.1rc0", None, "alpha"), "0.1.1a0"),
-    (("0.1.1b1", None, "alpha"), "0.1.1a0"),
+    (("0.1.1rc0", None, "alpha", None), "0.1.1a0"),
+    (("0.1.1b1", None, "alpha", None), "0.1.1a0"),
 ]
 
 weird_cases = [
-    (("1.1", "PATCH", None), "1.1.1"),
-    (("1", "MINOR", None), "1.1.0"),
-    (("1", "MAJOR", None), "2.0.0"),
-    (("1a0", None, "alpha"), "1.0.0a1"),
-    (("1", None, "beta"), "1.0.0b0"),
-    (("1beta", None, "beta"), "1.0.0b1"),
-    (("1.0.0alpha1", None, "alpha"), "1.0.0a2"),
-    (("1", None, "rc"), "1.0.0rc0"),
-    (("1.0.0rc1+e20d7b57f3eb", "PATCH", None), "1.0.0"),
+    (("1.1", "PATCH", None, None), "1.1.1"),
+    (("1", "MINOR", None, None), "1.1.0"),
+    (("1", "MAJOR", None, None), "2.0.0"),
+    (("1a0", None, "alpha", None), "1.0.0a1"),
+    (("1", None, "beta", None), "1.0.0b0"),
+    (("1beta", None, "beta", None), "1.0.0b1"),
+    (("1.0.0alpha1", None, "alpha", None), "1.0.0a2"),
+    (("1", None, "rc", None), "1.0.0rc0"),
+    (("1.0.0rc1+e20d7b57f3eb", "PATCH", None, None), "1.0.0"),
 ]
 
 # test driven development
 tdd_cases = [
-    (("0.1.1", "PATCH", None), "0.1.2"),
-    (("0.1.1", "MINOR", None), "0.2.0"),
-    (("2.1.1", "MAJOR", None), "3.0.0"),
-    (("0.9.0", "PATCH", "alpha"), "0.9.1a0"),
-    (("0.9.0", "MINOR", "alpha"), "0.10.0a0"),
-    (("0.9.0", "MAJOR", "alpha"), "1.0.0a0"),
-    (("1.0.0a2", None, "beta"), "1.0.0b0"),
-    (("1.0.0beta1", None, "rc"), "1.0.0rc0"),
-    (("1.0.0rc1", None, "rc"), "1.0.0rc2"),
+    (("0.1.1", "PATCH", None, None), "0.1.2"),
+    (("0.1.1", "MINOR", None, None), "0.2.0"),
+    (("2.1.1", "MAJOR", None, None), "3.0.0"),
+    (("0.9.0", "PATCH", "alpha", None), "0.9.1a0"),
+    (("0.9.0", "MINOR", "alpha", None), "0.10.0a0"),
+    (("0.9.0", "MAJOR", "alpha", None), "1.0.0a0"),
+    (("1.0.0a2", None, "beta", None), "1.0.0b0"),
+    (("1.0.0beta1", None, "rc", None), "1.0.0rc0"),
+    (("1.0.0rc1", None, "rc", None), "1.0.0rc2"),
 ]
 
 
@@ -76,9 +83,16 @@ def test_generate_version(test_input, expected):
     current_version = test_input[0]
     increment = test_input[1]
     prerelease = test_input[2]
-    assert generate_version(
-        current_version, increment=increment, prerelease=prerelease
-    ) == Version(expected)
+    devrelease = test_input[3]
+    assert (
+        generate_version(
+            current_version,
+            increment=increment,
+            prerelease=prerelease,
+            devrelease=devrelease,
+        )
+        == Version(expected)
+    )
 
 
 @pytest.mark.parametrize(
@@ -89,12 +103,14 @@ def test_generate_version_local(test_input, expected):
     current_version = test_input[0]
     increment = test_input[1]
     prerelease = test_input[2]
+    devrelease = test_input[3]
     is_local_version = True
     assert (
         generate_version(
             current_version,
             increment=increment,
             prerelease=prerelease,
+            devrelease=devrelease,
             is_local_version=is_local_version,
         )
         == Version(expected)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
This adds a `--devrelease` flag, expecting a non-negative integer, as per [PEP 440](https://peps.python.org/pep-0440/#developmental-releases); e.g. passing `--devrelease 1234` results in a developmental release segment of `.dev1234`.




## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior

When calling `cz bump`, passing `--devrelease`, followed by a non-negative integer will result in the bumped version adding a `.dev` suffix.

## Steps to Test This Pull Request

1. Check the existing behaviour: `python3 -m commitizen bump --dry-run`; for this branch, this gives `version 2.32.5 → 2.33.0`.
1. Check the new behaviour:  `python3 -m commitizen bump --dry-run --devrelease 0`; for this branch, this gives `version 2.32.5 → 2.33.0.dev0`.


## Additional context

See also discussions on #570.
