### PR TITLE
Conditionally relax specification for termcolor dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,10 @@ python = "^3.6.2"
 questionary = "^1.4.0"
 decli = "^0.5.2"
 colorama = "^0.4.1"
-termcolor = "^1.1"
+termcolor = [
+    { "version" = "^1.1", python = "< 3.7" },
+    { "version" = ">= 1.1, < 3", python = ">= 3.7" },
+]
 packaging = ">=19,<22"
 tomlkit = ">=0.5.3,<1.0.0"
 jinja2 = ">=2.10.3"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

Closes #586 

## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

Allow for installation of termcolor 2.x in commitizen enabled projects under Python >= 3.7

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
