### PR TITLE
Feature/allow empty commit

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -66,6 +66,11 @@ data = {
                         "action": "store_true",
                         "help": "Sign off the commit",
                     },
+                    {
+                        "name": "--allow-empty",
+                        "action": "store_true",
+                        "help": "Allow to create commit on an empty staging",
+                    },
                 ],
             },
             {

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -62,9 +62,13 @@ class Commit:
         return cz.message(answers)
 
     def __call__(self):
-        dry_run: bool = self.arguments.get("dry_run")
-
+        args = []
         allow_empty: bool = self.arguments.get("allow_empty")
+
+        if allow_empty:
+            args.append("--allow-empty")
+
+        dry_run: bool = self.arguments.get("dry_run")
 
         if git.is_staging_clean() and not (dry_run or allow_empty):
             raise NothingToCommitError("No files added to staging!")
@@ -84,9 +88,9 @@ class Commit:
         signoff: bool = self.arguments.get("signoff")
 
         if signoff:
-            c = git.commit(m, "-s")
-        else:
-            c = git.commit(m)
+            args.append("-s")
+
+        c = git.commit(m, *args)
 
         if c.return_code != 0:
             out.error(c.err)

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -64,7 +64,9 @@ class Commit:
     def __call__(self):
         dry_run: bool = self.arguments.get("dry_run")
 
-        if git.is_staging_clean() and not dry_run:
+        allow_empty: bool = self.arguments.get("allow_empty")
+
+        if git.is_staging_clean() and not (dry_run or allow_empty):
             raise NothingToCommitError("No files added to staging!")
 
         retry: bool = self.arguments.get("retry")

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -38,7 +38,7 @@ def test_commit(config, mocker):
     success_mock = mocker.patch("commitizen.out.success")
 
     commands.Commit(config, {})()
-    success_mock.assert_called_once()
+   success_mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("staging_is_clean")

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -53,6 +53,26 @@ def test_commit_retry_fails_no_backup(config, mocker):
 
 
 @pytest.mark.usefixtures("staging_is_clean")
+def test_commit_allow_empty(config, mocker):
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "closes #21",
+        "footer": "",
+    }
+
+    commit_mock = mocker.patch("commitizen.git.commit")
+    commit_mock.return_value = cmd.Command("success", "", "", "", 0)
+    success_mock = mocker.patch("commitizen.out.success")
+
+    commands.Commit(config, {"allow_empty": True})()
+    success_mock.assert_called_once()
+
+
+@pytest.mark.usefixtures("staging_is_clean")
 def test_commit_retry_works(config, mocker):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -38,7 +38,7 @@ def test_commit(config, mocker):
     success_mock = mocker.patch("commitizen.out.success")
 
     commands.Commit(config, {})()
-   success_mock.assert_called_once()
+    success_mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("staging_is_clean")


### PR DESCRIPTION
## Description
Add allow to create empty commit


## Checklist

- [x] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
  - _One error on create commit message seem to be here before_
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes
  - _Not needed_

## Expected behavior
Allow to invoke cz and create a commit without any change in it

## Additional context
Relates to #247 & #590