### PR TITLE
feat: add major-version-zero option to support initial package development

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -184,6 +184,12 @@ data = {
                         "help": "retry commit if it fails the 1st time",
                     },
                     {
+                        "name": ["--major-version-zero"],
+                        "action": "store_true",
+                        "default": None,
+                        "help": "keep major version at zero, even for breaking changes",
+                    },
+                    {
                         "name": "manual_version",
                         "type": str,
                         "nargs": "?",

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 import questionary
 from packaging.version import InvalidVersion, Version
 
-from commitizen import bump, cmd, factory, git, out
+from commitizen import bump, cmd, defaults, factory, git, out
 from commitizen.commands.changelog import Changelog
 from commitizen.config import BaseConfig
 from commitizen.exceptions import (
@@ -44,6 +44,7 @@ class Bump:
                     "bump_message",
                     "gpg_sign",
                     "annotated_tag",
+                    "major_version_zero",
                 ]
                 if arguments[key] is not None
             },
@@ -100,6 +101,7 @@ class Bump:
         tag_format: str = self.bump_settings["tag_format"]
         bump_commit_message: str = self.bump_settings["bump_message"]
         version_files: List[str] = self.bump_settings["version_files"]
+        major_version_zero: bool = self.bump_settings["major_version_zero"]
 
         dry_run: bool = self.arguments["dry_run"]
         is_yes: bool = self.arguments["yes"]
@@ -124,6 +126,20 @@ class Bump:
                 raise NotAllowed(
                     "--local-version cannot be combined with MANUAL_VERSION"
                 )
+
+            if major_version_zero:
+                raise NotAllowed(
+                    "--major-version-zero cannot be combined with MANUAL_VERSION"
+                )
+
+        if major_version_zero:
+            if not current_version.startswith("0."):
+                raise NotAllowed(
+                    f"--major-version-zero is meaningless for current version {current_version}"
+                )
+
+            # Update the bump map to ensure major version doesn't increment.
+            self.cz.bump_map = defaults.bump_map_major_version_zero
 
         current_tag_version: str = bump.normalize_tag(
             current_version, tag_format=tag_format

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -39,6 +39,7 @@ class Settings(TypedDict, total=False):
     use_shortcuts: bool
     style: Optional[List[Tuple[str, str]]]
     customize: CzSettings
+    major_version_zero: bool
 
 
 name: str = "cz_conventional_commits"
@@ -63,6 +64,7 @@ DEFAULT_SETTINGS: Settings = {
     "changelog_start_rev": None,
     "update_changelog_on_bump": False,
     "use_shortcuts": False,
+    "major_version_zero": False,
 }
 
 MAJOR = "MAJOR"
@@ -74,6 +76,16 @@ bump_map = OrderedDict(
     (
         (r"^.+!$", MAJOR),
         (r"^BREAKING[\-\ ]CHANGE", MAJOR),
+        (r"^feat", MINOR),
+        (r"^fix", PATCH),
+        (r"^refactor", PATCH),
+        (r"^perf", PATCH),
+    )
+)
+bump_map_major_version_zero = OrderedDict(
+    (
+        (r"^.+!$", MINOR),
+        (r"^BREAKING[\-\ ]CHANGE", MINOR),
         (r"^feat", MINOR),
         (r"^fix", PATCH),
         (r"^refactor", PATCH),

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -59,7 +59,8 @@ usage: cz bump [-h] [--dry-run] [--files-only] [--local-version] [--changelog]
                [--bump-message BUMP_MESSAGE] [--prerelease {alpha,beta,rc}]
                [--devrelease DEVRELEASE] [--increment {MAJOR,MINOR,PATCH}]
                [--check-consistency] [--annotated-tag] [--gpg-sign]
-               [--changelog-to-stdout] [--retry] [MANUAL_VERSION]
+               [--changelog-to-stdout] [--retry] [--major-version-zero]
+               [MANUAL_VERSION]
 
 positional arguments:
   MANUAL_VERSION        bump to the given version (e.g: 1.5.3)
@@ -93,6 +94,7 @@ options:
   --changelog-to-stdout
                         Output changelog to the stdout
   --retry               retry commit if it fails the 1st time
+  --major-version-zero  keep major version at zero, even for breaking changes
 ```
 
 ### `--files-only`
@@ -198,6 +200,18 @@ If you use tools like [pre-commit](https://pre-commit.com/), add this flag.
 It will retry the commit if it fails the 1st time.
 
 Useful to combine with code formatters, like [Prettier](https://prettier.io/).
+
+### `--major-version-zero`
+
+A project in its initial development should have a major version zero, and even breaking changes
+should not bump that major version from zero. This command ensures that behavior.
+
+If `--major-version-zero` is used for projects that have a version number greater than zero it fails.
+If used together with a manual version the command also fails.
+
+We recommend setting `major_version_zero = true` in your configuration file while a project
+is in its initial development. Remove that configuration using a breaking-change commit to bump
+your project’s major version to `v1.0.0` once your project has reached maturity.
 
 ## Avoid raising errors
 
@@ -369,6 +383,8 @@ When set to `true` commitizen will create annotated tags.
 
 ```toml
 [tool.commitizen]
+annotated_tag = true
+```
 
 ---
 
@@ -379,7 +395,20 @@ When set to `true` commitizen will create gpg signed tags.
 ```toml
 [tool.commitizen]
 gpg_sign = true
-annotated_tag = true
+```
+
+---
+
+### `major_version_zero`
+
+When set to `true` commitizen will keep the major version at zero.
+Useful during the initial development stage of your project.
+
+Defaults to: `false`
+
+```toml
+[tool.commitizen]
+major_version_zero = true
 ```
 
 ## Custom bump

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -48,6 +48,7 @@ _settings = {
     "changelog_start_rev": None,
     "update_changelog_on_bump": False,
     "use_shortcuts": False,
+    "major_version_zero": False,
 }
 
 _new_settings = {
@@ -63,6 +64,7 @@ _new_settings = {
     "changelog_start_rev": None,
     "update_changelog_on_bump": False,
     "use_shortcuts": False,
+    "major_version_zero": False,
 }
 
 _read_settings = {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,6 +26,12 @@ def create_file_and_commit(message: str, filename: Optional[str] = None):
         raise exceptions.CommitError(c.err)
 
 
+def create_tag(tag: str):
+    c = git.tag(tag)
+    if c.return_code != 0:
+        raise exceptions.CommitError(c.err)
+
+
 def wait_for_tag():
     """Wait for tag.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

Closes #501 
Closes #573

I guess instead of the current implementation, I could have also changed the `bump_map` in the settings and not touched any of the remaining code? Please let me know which approach you’d prefer.

Still need to write tests and documentation.

## Checklist

- [ ] Add test cases to all the changes you introduce
- [X] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior

As discussed in the connected issue.

## Steps to Test This Pull Request

Run the tests.

## Additional context

n/a