### PR TITLE
fix: update filter comments to exclude git diffs

### DIFF
--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -98,8 +98,35 @@ class Check:
         # Get commit messages from git log (--rev-range)
         return git.get_commits(end=self.rev_range)
 
-    def _filter_comments(self, msg: str) -> str:
-        lines = [line for line in msg.split("\n") if not line.startswith("#")]
+    @staticmethod
+    def _filter_comments(msg: str) -> str:
+        """Filter the commit message by removing comments.
+
+        When using `git commit --verbose`, we exclude the diff that is going to
+        generated, like the following example:
+
+        ```bash
+        ...
+        # ------------------------ >8 ------------------------
+        # Do not modify or remove the line above.
+        # Everything below it will be ignored.
+        diff --git a/... b/...
+        ...
+        ```
+
+        Args:
+            msg: The commit message to filter.
+
+        Returns:
+            The filtered commit message without comments.
+        """
+
+        lines = []
+        for line in msg.split("\n"):
+            if "# ------------------------ >8 ------------------------" in line:
+                break
+            if not line.startswith("#"):
+                lines.append(line)
         return "\n".join(lines)
 
     def validate_commit_message(self, commit_msg: str, pattern: str) -> bool:

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -349,3 +349,34 @@ def test_check_command_with_comment_in_messege_file(mocker, capsys):
     cli.main()
     out, _ = capsys.readouterr()
     assert "Commit validation: successful!" in out
+
+
+def test_check_conventional_commit_succeed_with_git_diff(mocker, capsys):
+    commit_msg = (
+        "feat: This is a test commit\n"
+        "# Please enter the commit message for your changes. Lines starting\n"
+        "# with '#' will be ignored, and an empty message aborts the commit.\n"
+        "#\n"
+        "# On branch ...\n"
+        "# Changes to be committed:\n"
+        "#	modified:  ...\n"
+        "#\n"
+        "# ------------------------ >8 ------------------------\n"
+        "# Do not modify or remove the line above.\n"
+        "# Everything below it will be ignored.\n"
+        "diff --git a/... b/...\n"
+        "index f1234c..1c5678 1234\n"
+        "--- a/...\n"
+        "+++ b/...\n"
+        "@@ -92,3 +92,4 @@ class Command(BaseCommand):\n"
+        '+            "this is a test"\n'
+    )
+    testargs = ["cz", "check", "--commit-msg-file", "some_file"]
+    mocker.patch.object(sys, "argv", testargs)
+    mocker.patch(
+        "commitizen.commands.check.open",
+        mocker.mock_open(read_data=commit_msg),
+    )
+    cli.main()
+    out, _ = capsys.readouterr()
+    assert "Commit validation: successful!" in out


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
When running `git commit --verbose` when using commitizen as a pre-commit we
have a bug because of the diff that is incorrectly included.

I have filtered out everything that is auto-generated by git and normally excluded.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
When running a verbose git commit with `git commit --verbose` I expect to have the diff not included in the message (and this causes a bug that raise an not expected error to the user)

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
When using commitizen as a pre-commit check:
1. Run `git commit -v`
2. Write one line commit like `feat: i am a test feature`
3. No errors should happen

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
https://github.com/commitizen-tools/commitizen/issues/598