### PR TITLE
Specify `bash` shell in CI Workflows

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,29 +10,29 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install -U pip poetry
-          poetry --version
-          poetry install
-      - name: Run tests and linters
-        run: |
-          git config --global user.email "action@github.com"
-          git config --global user.name "GitHub Action"
-          ./scripts/test
-        shell: bash
-      - name: Upload coverage to Codecov
-        if: runner.os == 'Linux'
-        uses: codecov/codecov-action@v1.0.3
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip poetry
+        poetry --version
+        poetry install
+    - name: Run tests and linters
+      run: |
+        git config --global user.email "action@github.com"
+        git config --global user.name "GitHub Action"
+        ./scripts/test
+      shell: bash
+    - name: Upload coverage to Codecov
+      if: runner.os == 'Linux'
+      uses: codecov/codecov-action@v1.0.3
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -10,28 +10,29 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install -U pip poetry
-        poetry --version
-        poetry install
-    - name: Run tests and linters
-      run: |
-        git config --global user.email "action@github.com"
-        git config --global user.name "GitHub Action"
-        ./scripts/test
-    - name: Upload coverage to Codecov
-      if: runner.os == 'Linux'
-      uses: codecov/codecov-action@v1.0.3
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip poetry
+          poetry --version
+          poetry install
+      - name: Run tests and linters
+        run: |
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
+          ./scripts/test
+        shell: bash
+      - name: Upload coverage to Codecov
+        if: runner.os == 'Linux'
+        uses: codecov/codecov-action@v1.0.3
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella

--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -1,3 +1,4 @@
+import os
 import re
 from collections import OrderedDict
 from itertools import zip_longest
@@ -155,7 +156,9 @@ def update_version_in_files(
     """
     # TODO: separate check step and write step
     for location in files:
-        filepath, _, regex = location.partition(":")
+        drive, tail = os.path.splitdrive(location)
+        path, _, regex = tail.partition(":")
+        filepath = drive + path
         if not regex:
             regex = _version_to_regex(current_version)
 

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -1,3 +1,4 @@
+import os
 from logging import getLogger
 from typing import List, Optional
 
@@ -230,9 +231,15 @@ class Bump:
                 },
             )
             changelog_cmd()
+            file_names = []
+            for file_name in version_files:
+                drive, tail = os.path.splitdrive(file_name)
+                path, _, regex = tail.partition(":")
+                path = drive + path if path != "" else drive + regex
+                file_names.append(path)
             git_add_changelog_and_version_files_command = (
                 f"git add {changelog_cmd.file_name} "
-                f"{' '.join(file_name.partition(':')[0] for file_name in version_files)}"
+                f"{' '.join(name for name in file_names)}"
             )
             c = cmd.run(git_add_changelog_and_version_files_command)
 

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -40,7 +40,7 @@ class Check:
             arg is not None
             for arg in (self.commit_msg_file, self.commit_msg, self.rev_range)
         )
-        if num_exclusive_args_provided == 0 and not os.isatty(0):
+        if num_exclusive_args_provided == 0 and not sys.stdin.isatty():
             self.commit_msg: Optional[str] = sys.stdin.read()
         elif num_exclusive_args_provided != 1:
             raise InvalidCommandArgumentError(

--- a/scripts/format
+++ b/scripts/format
@@ -3,20 +3,6 @@ set -e
 
 export PREFIX="poetry run python -m "
 
-if [ -d 'venv' ] ; then
-    case $(uname -s) in
-    Linux|FreeBSD|OpenBSD|NetBSD|Darwin)
-        export PREFIX="venv/bin/"
-        ;;
-    *MINGW*)
-        export PREFIX="venv/Scripts/"
-        ;;
-    *)
-        exit 1
-        ;;
-    esac
-fi
-
 set -x
 
 ${PREFIX}isort commitizen tests

--- a/scripts/format
+++ b/scripts/format
@@ -1,8 +1,20 @@
-#!/usr/bin/env sh -e
+#!/usr/bin/env sh
+set -e
 
 export PREFIX="poetry run python -m "
+
 if [ -d 'venv' ] ; then
-    export PREFIX="venv/bin/"
+    case $(uname -s) in
+    Linux|FreeBSD|OpenBSD|NetBSD|Darwin)
+        export PREFIX="venv/bin/"
+        ;;
+    *MINGW*)
+        export PREFIX="venv/Scripts/"
+        ;;
+    *)
+        exit 1
+        ;;
+    esac
 fi
 
 set -x

--- a/scripts/format
+++ b/scripts/format
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/usr/bin/env sh -e
 
 export PREFIX="poetry run python -m "
 if [ -d 'venv' ] ; then

--- a/scripts/test
+++ b/scripts/test
@@ -12,6 +12,7 @@ if [ -d 'venv' ] ; then
         export PREFIX="venv/Scripts/"
         ;;
     *)
+        echo "ERROR: Script 'test' encountered unsupported operating system $(uname -s)"
         exit 1
         ;;
     esac

--- a/scripts/test
+++ b/scripts/test
@@ -8,5 +8,5 @@ ${PREFIX}black commitizen tests --check
 ${PREFIX}isort --check-only commitizen tests
 ${PREFIX}flake8 commitizen/ tests/
 ${PREFIX}mypy commitizen/ tests/
-${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415 --match-dir='^(?![.]|venv).*'
+${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415 --match-dir="^(?![.]|venv).*"
 ${PREFIX}commitizen check --rev-range origin/master..

--- a/scripts/test
+++ b/scripts/test
@@ -1,12 +1,13 @@
 #!/usr/bin/env sh
 set -e
 
-export PREFIX="poetry run python -m "
+export PREFIX='poetry run python -m '
+export REGEX='^(?![.]|venv).*'
 
 ${PREFIX}pytest -n 3 --cov-report term-missing --cov-report=xml:coverage.xml --cov=commitizen tests/
 ${PREFIX}black commitizen tests --check
 ${PREFIX}isort --check-only commitizen tests
 ${PREFIX}flake8 commitizen/ tests/
 ${PREFIX}mypy commitizen/ tests/
-${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415 --match-dir="^(?![.]|venv).*"
+${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415 --match-dir='"${REGEX}"'
 ${PREFIX}commitizen check --rev-range origin/master..

--- a/scripts/test
+++ b/scripts/test
@@ -3,25 +3,10 @@ set -e
 
 export PREFIX="poetry run python -m "
 
-if [ -d 'venv' ] ; then
-    case $(uname -s) in
-    Linux|FreeBSD|OpenBSD|NetBSD|Darwin)
-        export PREFIX="venv/bin/"
-        ;;
-    *MINGW*)
-        export PREFIX="venv/Scripts/"
-        ;;
-    *)
-        echo "ERROR: Script 'test' encountered unsupported operating system $(uname -s)"
-        exit 1
-        ;;
-    esac
-fi
-
 ${PREFIX}pytest -n 3 --cov-report term-missing --cov-report=xml:coverage.xml --cov=commitizen tests/
 ${PREFIX}black commitizen tests --check
 ${PREFIX}isort --check-only commitizen tests
 ${PREFIX}flake8 commitizen/ tests/
 ${PREFIX}mypy commitizen/ tests/
 ${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415 --match-dir='^(?![.]|venv).*'
-${PREFIX}cz check --rev-range origin/master..
+${PREFIX}commitizen check --rev-range origin/master..

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/usr/bin/env sh -e
 
 export PREFIX="poetry run python -m "
 if [ -d 'venv' ] ; then

--- a/scripts/test
+++ b/scripts/test
@@ -22,5 +22,5 @@ ${PREFIX}black commitizen tests --check
 ${PREFIX}isort --check-only commitizen tests
 ${PREFIX}flake8 commitizen/ tests/
 ${PREFIX}mypy commitizen/ tests/
-${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415
-${PREFIX}commitizen check --rev-range origin/master..
+${PREFIX}pydocstyle --convention=google --add-ignore=D1,D415 --match-dir='^(?![.]|venv).*'
+${PREFIX}cz check --rev-range origin/master..

--- a/scripts/test
+++ b/scripts/test
@@ -1,8 +1,20 @@
-#!/usr/bin/env sh -e
+#!/usr/bin/env sh
+set -e
 
 export PREFIX="poetry run python -m "
+
 if [ -d 'venv' ] ; then
-    export PREFIX="venv/bin/"
+    case $(uname -s) in
+    Linux|FreeBSD|OpenBSD|NetBSD|Darwin)
+        export PREFIX="venv/bin/"
+        ;;
+    *MINGW*)
+        export PREFIX="venv/Scripts/"
+        ;;
+    *)
+        exit 1
+        ;;
+    esac
 fi
 
 ${PREFIX}pytest -n 3 --cov-report term-missing --cov-report=xml:coverage.xml --cov=commitizen tests/

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -302,9 +302,10 @@ def test_bump_when_version_inconsistent_in_version_files(
     tmp_version_file = tmp_commitizen_project.join("__version__.py")
     tmp_version_file.write("100.999.10000")
     tmp_commitizen_cfg_file = tmp_commitizen_project.join("pyproject.toml")
+    tmp_version_file_string = str(tmp_version_file).replace("\\", "/")
     tmp_commitizen_cfg_file.write(
         f"{tmp_commitizen_cfg_file.read()}\n"
-        f'version_files = ["{str(tmp_version_file)}"]'
+        f'version_files = ["{tmp_version_file_string}"]'
     )
 
     create_file_and_commit("feat: new file")
@@ -323,9 +324,10 @@ def test_bump_files_only(mocker, tmp_commitizen_project):
     tmp_version_file = tmp_commitizen_project.join("__version__.py")
     tmp_version_file.write("0.1.0")
     tmp_commitizen_cfg_file = tmp_commitizen_project.join("pyproject.toml")
+    tmp_version_file_string = str(tmp_version_file).replace("\\", "/")
     tmp_commitizen_cfg_file.write(
         f"{tmp_commitizen_cfg_file.read()}\n"
-        f'version_files = ["{str(tmp_version_file)}"]'
+        f'version_files = ["{tmp_version_file_string}"]'
     )
 
     create_file_and_commit("feat: new user interface")
@@ -355,10 +357,11 @@ def test_bump_local_version(mocker, tmp_commitizen_project):
     tmp_version_file = tmp_commitizen_project.join("__version__.py")
     tmp_version_file.write("4.5.1+0.1.0")
     tmp_commitizen_cfg_file = tmp_commitizen_project.join("pyproject.toml")
+    tmp_version_file_string = str(tmp_version_file).replace("\\", "/")
     tmp_commitizen_cfg_file.write(
         f"[tool.commitizen]\n"
         'version="4.5.1+0.1.0"\n'
-        f'version_files = ["{str(tmp_version_file)}"]'
+        f'version_files = ["{tmp_version_file_string}"]'
     )
 
     create_file_and_commit("feat: new user interface")

--- a/tests/commands/test_init_command.py
+++ b/tests/commands/test_init_command.py
@@ -65,7 +65,7 @@ def test_init_without_setup_pre_commit_hook(tmpdir, mocker, config):
 
 def test_init_when_config_already_exists(config, capsys):
     # Set config path
-    path = "tests/pyproject.toml"
+    path = os.sep.join(["tests", "pyproject.toml"])
     config.add_path(path)
 
     commands.Init(config)()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,8 @@ def tmp_commitizen_project_with_gpg(tmp_commitizen_project):
     # create a temporary GPGHOME to store a temporary keyring.
     # Home path must be less than 104 characters
     gpg_home = tempfile.TemporaryDirectory(suffix="_cz")
-    os.environ["GNUPGHOME"] = gpg_home.name  # tempdir = temp keyring
+    # os.environ["GNUPGHOME"] = gpg_home.name  # tempdir = temp keyring
+    # os.environ["HOMEDIR"] = gpg_home.name
 
     # create a key (a keyring will be generated within GPUPGHOME)
     c = cmd.run(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def tmp_commitizen_project(tmp_git_project):
 def _get_gpg_keyid(signer_mail):
     _new_key = cmd.run(f"gpg --list-secret-keys {signer_mail}")
     _m = re.search(
-        rf"[a-zA-Z0-9 \[\]-_]*{os.linesep}[ ]*([0-9A-Za-z]*){os.linesep}[{os.linesep}a-zA-Z0-9 \[\]-_<>@]*",
+        r"[a-zA-Z0-9 \[\]-_]*\n[ ]*([0-9A-Za-z]*)\n[\na-zA-Z0-9 \[\]-_<>@]*",
         _new_key.out,
     )
     return _m.group(1) if _m else None
@@ -42,8 +42,8 @@ def tmp_commitizen_project_with_gpg(tmp_commitizen_project):
     # create a temporary GPGHOME to store a temporary keyring.
     # Home path must be less than 104 characters
     gpg_home = tempfile.TemporaryDirectory(suffix="_cz")
-    # os.environ["GNUPGHOME"] = gpg_home.name  # tempdir = temp keyring
-    # os.environ["HOMEDIR"] = gpg_home.name
+    if os.name != "nt":
+        os.environ["GNUPGHOME"] = gpg_home.name  # tempdir = temp keyring
 
     # create a key (a keyring will be generated within GPUPGHOME)
     c = cmd.run(

--- a/tests/test_bump_create_commit_message.py
+++ b/tests/test_bump_create_commit_message.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from pathlib import Path
 from textwrap import dedent
@@ -55,7 +56,10 @@ def test_bump_pre_commit_changelog(tmp_commitizen_project, mocker, freezer, retr
             """
         )
         cmd.run("git add -A")
-        cmd.run("git commit -m 'fix: _test'")
+        if os.name == "nt":
+            cmd.run('git commit -m "fix: _test"')
+        else:
+            cmd.run("git commit -m 'fix: _test'")
         cmd.run("pre-commit install")
         cli.main()
         # Pre-commit fixed last line adding extra indent and "\" char
@@ -93,7 +97,10 @@ def test_bump_pre_commit_changelog_fails_always(
             """
         )
         cmd.run("git add -A")
-        cmd.run("git commit -m 'feat: forbid changelogs'")
+        if os.name == "nt":
+            cmd.run('git commit -m "feat: forbid changelogs"')
+        else:
+            cmd.run("git commit -m 'feat: forbid changelogs'")
         cmd.run("pre-commit install")
         with pytest.raises(exceptions.BumpCommitFailedError):
             cli.main()

--- a/tests/test_bump_update_version_in_files.py
+++ b/tests/test_bump_update_version_in_files.py
@@ -15,9 +15,9 @@ TESTING_FILE_PREFIX = "tests/data"
 def _copy_sample_file_to_tmpdir(
     tmpdir: LocalPath, source_filename: str, dest_filename: str
 ) -> str:
-    tmp_file = tmpdir.join(dest_filename)
-    copyfile(f"{TESTING_FILE_PREFIX}/{source_filename}", str(tmp_file))
-    return str(tmp_file)
+    tmp_file = str(tmpdir.join(dest_filename)).replace("\\", "/")
+    copyfile(f"{TESTING_FILE_PREFIX}/{source_filename}", tmp_file)
+    return tmp_file
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,7 +97,7 @@ def test_argcomplete_activation():
     Equivalent to run:
     $ eval "$(register-python-argcomplete pytest)"
     """
-    output = subprocess.run(["py", "-m", "register-python-argcomplete", "cz"])
+    output = subprocess.run(["register-python-argcomplete", "cz"])
 
     assert output.returncode == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -84,6 +85,10 @@ def test_commitizen_debug_excepthook(capsys):
     assert "NotAGitProjectError" in str(excinfo.traceback[0])
 
 
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="`argcomplete` does not support Git Bash on Windows.",
+)
 def test_argcomplete_activation():
     """
     This function is testing the one-time activation of argcomplete for
@@ -92,7 +97,7 @@ def test_argcomplete_activation():
     Equivalent to run:
     $ eval "$(register-python-argcomplete pytest)"
     """
-    output = subprocess.run(["register-python-argcomplete", "cz"])
+    output = subprocess.run(["py", "-m", "register-python-argcomplete", "cz"])
 
     assert output.returncode == 0
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -206,7 +206,10 @@ def test_is_staging_clean_when_updating_file(tmp_commitizen_project):
 
         cmd.run("touch test_file")
         cmd.run("git add test_file")
-        cmd.run("git commit -m 'add test_file'")
+        if os.name == "nt":
+            cmd.run('git commit -m "add test_file"')
+        else:
+            cmd.run("git commit -m 'add test_file'")
         cmd.run("echo 'test' > test_file")
 
         assert git.is_staging_clean() is True


### PR DESCRIPTION
- [x] Specify `shell` as `bash` in `Run tests and linters` step.
- [x] Fix failing tests on Windows

Failing Windows Tests (_generated with_ `pytest-html` _plugin_):
[pytest_report.zip](https://github.com/commitizen-tools/commitizen/files/9844702/pytest_report.zip)

Fixes: Issue #602, #604