### PR TITLE
docs(README.md): update poetry dev dependency usage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ pip install -U commitizen
 ```
 
 ```bash
-poetry add commitizen --dev
+poetry add commitizen --group dev
 ```
 
 ### macOS

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,8 +58,16 @@ You can add it to your local project using one of these:
 pip install -U commitizen
 ```
 
+for Poetry >= 1.2.0:
+
 ```bash
 poetry add commitizen --group dev
+```
+
+for Poetry < 1.2.0:
+
+```bash
+poetry add commitizen --dev
 ```
 
 ### macOS


### PR DESCRIPTION
Since Poetry 1.2.0 dependency groups are introduced, and `--dev` becomes deprecated, and instead `--with dev` has to be provided. This PR updates the documentation to reflect this change.

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Change the documentation in order to reflect the updated way for dependency groups.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
The documentation can be followed as it is, instead of getting warnings/ errors.
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
1. Review the documentation, and wether it reflects the desired state
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
![image](https://user-images.githubusercontent.com/29300910/202193327-baf9a9b7-cda2-4032-bebb-8ab1b6f04d05.png)

