### PR TITLE
fix(changelog): allow rev range lookups without a tag format

### DIFF
--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -137,7 +137,7 @@ class Changelog:
                 )
                 start_rev = self._find_incremental_rev(latest_tag_version, tags)
 
-        if self.rev_range and self.tag_format:
+        if self.rev_range:
             start_rev, end_rev = changelog.get_oldest_and_newest_rev(
                 tags,
                 version=self.rev_range,

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -661,6 +661,37 @@ def test_changelog_from_rev_single_version_not_found(
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
 @pytest.mark.freeze_time("2022-02-13")
+def test_changelog_from_rev_range_default_tag_format(
+    mocker, config_path, changelog_path
+):
+    """Checks that rev_range is calculated with the default (None) tag format"""
+    # create commit and tag
+    create_file_and_commit("feat: new file")
+    testargs = ["cz", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    wait_for_tag()
+
+    create_file_and_commit("feat: after 0.2.0")
+    create_file_and_commit("feat: another feature")
+
+    testargs = ["cz", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    wait_for_tag()
+
+    testargs = ["cz", "changelog", "0.3.0"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    with open(changelog_path, "r") as f:
+        out = f.read()
+
+    assert "new file" not in out
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+@pytest.mark.freeze_time("2022-02-13")
 def test_changelog_from_rev_range_version_not_found(mocker, config_path):
     """Provides an invalid end revision ID to changelog command"""
     with open(config_path, "a") as f:


### PR DESCRIPTION
The current default setting for `tag_format` is `None`. This is not a problem for the `bump` command, since the `normalize_tag` function defaults to `$version` when no `tag_format` is passed. However it is a problem for the `changelog` command, which seems to explicitly demand a `tag_format` in order to run a rev-range lookup. This creates issues like https://github.com/commitizen-tools/commitizen/issues/622.

Either a sane default needs to be set for `tag_format` or the restriction in `changelog` has to be uplifted. In this commit the latter has been chosen. A test is also implemented to check that `changelog` will always compute a rev range with the default tag format.

Fixes https://github.com/commitizen-tools/commitizen/issues/622

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes -> Not needed

## Expected behavior
See https://github.com/commitizen-tools/commitizen/issues/622


## Steps to Test This Pull Request
See https://github.com/commitizen-tools/commitizen/issues/622