### PR TITLE
feat(poetry): relax packaging version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ termcolor = [
     { "version" = "^1.1", python = "< 3.7" },
     { "version" = ">= 1.1, < 3", python = ">= 3.7" },
 ]
-packaging = ">=19,<22"
+packaging = ">=19"
 tomlkit = ">=0.5.3,<1.0.0"
 jinja2 = ">=2.10.3"
 pyyaml = ">=3.08"


### PR DESCRIPTION
## Description
tox > 4.0.0 needs packaging 22.0


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
project with dependency tox >= 4.0.0 and commitizen  should not conflict


## Steps to Test This Pull Request
1. poetry install tox==4.0.0
2. poetry install commitizen

no conflict should happen


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
