### PR TITLE
feat(bump): added support for running arbitrary hooks during bump

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   python-check:
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         platform: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/commitizen/cmd.py
+++ b/commitizen/cmd.py
@@ -27,13 +27,14 @@ def _try_decode(bytes_: bytes) -> str:
             raise CharacterSetDecodeError() from e
 
 
-def run(cmd: str) -> Command:
+def run(cmd: str, env=None) -> Command:
     process = subprocess.Popen(
         cmd,
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         stdin=subprocess.PIPE,
+        env=env,
     )
     stdout, stderr = process.communicate()
     return_code = process.returncode

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -40,6 +40,8 @@ class Settings(TypedDict, total=False):
     style: Optional[List[Tuple[str, str]]]
     customize: CzSettings
     major_version_zero: bool
+    pre_bump_hooks: Optional[List[str]]
+    post_bump_hooks: Optional[List[str]]
 
 
 name: str = "cz_conventional_commits"
@@ -65,6 +67,8 @@ DEFAULT_SETTINGS: Settings = {
     "update_changelog_on_bump": False,
     "use_shortcuts": False,
     "major_version_zero": False,
+    "pre_bump_hooks": [],
+    "post_bump_hooks": [],
 }
 
 MAJOR = "MAJOR"

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -30,6 +30,7 @@ class ExitCode(enum.IntEnum):
     GIT_COMMAND_ERROR = 23
     INVALID_MANUAL_VERSION = 24
     INIT_FAILED = 25
+    RUN_HOOK_FAILED = 26
 
 
 class CommitizenException(Exception):
@@ -168,3 +169,7 @@ class InvalidManualVersion(CommitizenException):
 
 class InitFailedError(CommitizenException):
     exit_code = ExitCode.INIT_FAILED
+
+
+class RunHookError(CommitizenException):
+    exit_code = ExitCode.RUN_HOOK_FAILED

--- a/commitizen/hooks.py
+++ b/commitizen/hooks.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from commitizen import cmd, out
+from commitizen.exceptions import RunHookError
+
+
+def run(hooks, _env_prefix="CZ_", **env):
+    if isinstance(hooks, str):
+        hooks = [hooks]
+
+    for hook in hooks:
+        out.info(f"Running hook '{hook}'")
+
+        c = cmd.run(hook, env=_format_env(_env_prefix, env))
+
+        if c.out:
+            out.write(c.out)
+        if c.err:
+            out.error(c.err)
+
+        if c.return_code != 0:
+            raise RunHookError(f"Running hook '{hook}' failed")
+
+
+def _format_env(prefix: str, env: dict[str, str]) -> dict[str, str]:
+    """_format_env() prefixes all given environment variables with the given
+    prefix so it can be passed directly to cmd.run()."""
+    penv = dict()
+    for name, value in env.items():
+        name = prefix + name.upper()
+        value = str(value) if value is not None else ""
+        penv[name] = value
+
+    return penv

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -411,6 +411,61 @@ Defaults to: `false`
 major_version_zero = true
 ```
 
+---
+
+### `pre_bump_hooks`
+
+A list of optional commands that will run right _after_ updating `version_files`
+and _before_ actual committing and tagging the release.
+
+Useful when you need to generate documentation based on the new version. During
+execution of the script, some environment variables are available:
+
+| Variable                     | Description                                                |
+| ---------------------------- | ---------------------------------------------------------- |
+| `CZ_PRE_IS_INITIAL`          | `True` when this is the initial release, `False` otherwise |
+| `CZ_PRE_CURRENT_VERSION`     | Current version, before the bump                           |
+| `CZ_PRE_CURRENT_TAG_VERSION` | Current version tag, before the bump                       |
+| `CZ_PRE_NEW_VERSION`         | New version, after the bump                                |
+| `CZ_PRE_NEW_TAG_VERSION`     | New version tag, after the bump                            |
+| `CZ_PRE_MESSAGE`             | Commit message of the bump                                 |
+| `CZ_PRE_INCREMENT`           | Whether this is a `MAJOR`, `MINOR` or `PATH` release       |
+| `CZ_PRE_CHANGELOG_FILE_NAME` | Path to the changelog file, if available                   |
+
+```toml
+[tool.commitizen]
+pre_bump_hooks = [
+  "scripts/generate_documentation.sh"
+]
+```
+
+---
+
+### `post_bump_hooks`
+
+A list of optional commands that will run right _after_ committing and tagging the release.
+
+Useful when you need to send notifications about a release, or further automate deploying the
+release. During execution of the script, some environment variables are available:
+
+| Variable                       | Description                                                 |
+| ------------------------------ | ----------------------------------------------------------- |
+| `CZ_POST_WAS_INITIAL`          | `True` when this was the initial release, `False` otherwise |
+| `CZ_POST_PREVIOUS_VERSION`     | Previous version, before the bump                           |
+| `CZ_POST_PREVIOUS_TAG_VERSION` | Previous version tag, before the bump                       |
+| `CZ_POST_CURRENT_VERSION`      | Current version, after the bump                             |
+| `CZ_POST_CURRENT_TAG_VERSION`  | Current version tag, after the bump                         |
+| `CZ_POST_MESSAGE`              | Commit message of the bump                                  |
+| `CZ_POST_INCREMENT`            | Whether this wass a `MAJOR`, `MINOR` or `PATH` release      |
+| `CZ_POST_CHANGELOG_FILE_NAME`  | Path to the changelog file, if available                    |
+
+```toml
+[tool.commitizen]
+post_bump_hooks = [
+  "scripts/slack_notification.sh"
+]
+```
+
 ## Custom bump
 
 Read the [customizing section](./customization.md).

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1,13 +1,13 @@
 import inspect
 import sys
 from typing import Tuple
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 from pytest_mock import MockFixture
 
 import commitizen.commands.bump as bump
-from commitizen import cli, cmd, git
+from commitizen import cli, cmd, git, hooks
 from commitizen.exceptions import (
     BumpTagFailedError,
     CommitizenException,
@@ -759,3 +759,58 @@ def test_bump_manual_version_disallows_major_version_zero(mocker):
         "--major-version-zero cannot be combined with MANUAL_VERSION"
     )
     assert expected_error_message in str(excinfo.value)
+
+
+@pytest.mark.parametrize("commit_msg", ("feat: new file", "feat(user): new file"))
+def test_bump_with_pre_bump_hooks(
+    commit_msg, mocker: MockFixture, tmp_commitizen_project
+):
+    pre_bump_hook = "scripts/pre_bump_hook.sh"
+    post_bump_hook = "scripts/post_bump_hook.sh"
+
+    tmp_commitizen_cfg_file = tmp_commitizen_project.join("pyproject.toml")
+    tmp_commitizen_cfg_file.write(
+        f"{tmp_commitizen_cfg_file.read()}\n"
+        f'pre_bump_hooks = ["{pre_bump_hook}"]\n'
+        f'post_bump_hooks = ["{post_bump_hook}"]\n'
+    )
+
+    run_mock = mocker.Mock()
+    mocker.patch.object(hooks, "run", run_mock)
+
+    create_file_and_commit(commit_msg)
+    testargs = ["cz", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    tag_exists = git.tag_exist("0.2.0")
+    assert tag_exists is True
+
+    run_mock.assert_has_calls(
+        [
+            call(
+                [pre_bump_hook],
+                _env_prefix="CZ_PRE_",
+                is_initial=True,
+                current_version="0.1.0",
+                current_tag_version="0.1.0",
+                new_version="0.2.0",
+                new_tag_version="0.2.0",
+                message="bump: version 0.1.0 → 0.2.0",
+                increment="MINOR",
+                changelog_file_name=None,
+            ),
+            call(
+                [post_bump_hook],
+                _env_prefix="CZ_POST_",
+                was_initial=True,
+                previous_version="0.1.0",
+                previous_tag_version="0.1.0",
+                current_version="0.2.0",
+                current_tag_version="0.2.0",
+                message="bump: version 0.1.0 → 0.2.0",
+                increment="MINOR",
+                changelog_file_name=None,
+            ),
+        ]
+    )

--- a/tests/test_bump_hooks.py
+++ b/tests/test_bump_hooks.py
@@ -1,4 +1,35 @@
-from commitizen import hooks
+from unittest.mock import call
+
+import pytest
+from pytest_mock import MockFixture
+
+from commitizen import cmd, hooks
+from commitizen.exceptions import RunHookError
+
+
+def test_run(mocker: MockFixture):
+    bump_hooks = ["pre_bump_hook", "pre_bump_hook_1"]
+
+    cmd_run_mock = mocker.Mock()
+    cmd_run_mock.return_value.return_code = 0
+    mocker.patch.object(cmd, "run", cmd_run_mock)
+
+    hooks.run(bump_hooks)
+
+    cmd_run_mock.assert_has_calls(
+        [call("pre_bump_hook", env={}), call("pre_bump_hook_1", env={})]
+    )
+
+
+def test_run_error(mocker: MockFixture):
+    bump_hooks = ["pre_bump_hook", "pre_bump_hook_1"]
+
+    cmd_run_mock = mocker.Mock()
+    cmd_run_mock.return_value.return_code = 1
+    mocker.patch.object(cmd, "run", cmd_run_mock)
+
+    with pytest.raises(RunHookError):
+        hooks.run(bump_hooks)
 
 
 def test_format_env():

--- a/tests/test_bump_hooks.py
+++ b/tests/test_bump_hooks.py
@@ -1,0 +1,7 @@
+from commitizen import hooks
+
+
+def test_format_env():
+    result = hooks._format_env("TEST_", {"foo": "bar", "bar": "baz"})
+    assert "TEST_FOO" in result and result["TEST_FOO"] == "bar"
+    assert "TEST_BAR" in result and result["TEST_BAR"] == "baz"

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -19,6 +19,10 @@ style = [
     ["pointer", "reverse"],
     ["question", "underline"]
 ]
+pre_bump_hooks = [
+    "scripts/generate_documentation.sh"
+]
+post_bump_hooks = ["scripts/slack_notification.sh"]
 
 [tool.black]
 line-length = 88
@@ -31,6 +35,8 @@ DICT_CONFIG = {
         "version": "1.0.0",
         "version_files": ["commitizen/__version__.py", "pyproject.toml"],
         "style": [["pointer", "reverse"], ["question", "underline"]],
+        "pre_bump_hooks": ["scripts/generate_documentation.sh"],
+        "post_bump_hooks": ["scripts/slack_notification.sh"],
     }
 }
 
@@ -49,6 +55,8 @@ _settings = {
     "update_changelog_on_bump": False,
     "use_shortcuts": False,
     "major_version_zero": False,
+    "pre_bump_hooks": ["scripts/generate_documentation.sh"],
+    "post_bump_hooks": ["scripts/slack_notification.sh"],
 }
 
 _new_settings = {
@@ -65,6 +73,8 @@ _new_settings = {
     "update_changelog_on_bump": False,
     "use_shortcuts": False,
     "major_version_zero": False,
+    "pre_bump_hooks": ["scripts/generate_documentation.sh"],
+    "post_bump_hooks": ["scripts/slack_notification.sh"],
 }
 
 _read_settings = {
@@ -73,6 +83,8 @@ _read_settings = {
     "version_files": ["commitizen/__version__.py", "pyproject.toml"],
     "style": [["pointer", "reverse"], ["question", "underline"]],
     "changelog_file": "CHANGELOG.md",
+    "pre_bump_hooks": ["scripts/generate_documentation.sh"],
+    "post_bump_hooks": ["scripts/slack_notification.sh"],
 }
 
 


### PR DESCRIPTION
## Description

To make commitizen integrate even better, new configuration keys hooks_pre_bump and hooks_post_bump were added to allow to run arbitrary commands prior to and right after running bump.

I've backported the work done by @janw and slightly adjusted it:
- updated the patch to apply against the latest version of commitizen
- run `hooks_pre_bump` hooks *after* the versions have been updated but *before* they are committed and tagged, so additional documentation can be generated with the new version or other generators can be run and staged.
- I couldn't think of a usecase why you would want to hook into the process of generating the changelog so I completely removed this part.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Steps to Test This Pull Request
1. Add something like this in your commitizen config file:
```toml
[tool.commitizen]
hooks_pre_bump = [
  "touch foo.bar",
  "git add foo.bar"
]
```
2. Run `cz bump` and notice the `Running hook` output
3. Run `git show HEAD` to see `foo.bar` is part of the latest release


## Additional context
Closes: #292
Thanks to @janw to do the heavy lifting here.
