### PR TITLE
Feature: version providers

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -21,6 +21,7 @@ from commitizen.exceptions import (
     NotAllowed,
     NoVersionSpecifiedError,
 )
+from commitizen.providers import get_provider
 
 logger = getLogger("commitizen")
 
@@ -94,13 +95,13 @@ class Bump:
 
     def __call__(self):  # noqa: C901
         """Steps executed to bump."""
+        provider = get_provider(self.config)
+        current_version: str = provider.get_version()
+
         try:
-            current_version_instance: Version = Version(self.bump_settings["version"])
+            current_version_instance: Version = Version(current_version)
         except TypeError:
             raise NoVersionSpecifiedError()
-
-        # Initialize values from sources (conf)
-        current_version: str = self.config.settings["version"]
 
         tag_format: str = self.bump_settings["tag_format"]
         bump_commit_message: str = self.bump_settings["bump_message"]
@@ -280,7 +281,7 @@ class Bump:
             check_consistency=self.check_consistency,
         )
 
-        self.config.set_key("version", str(new_version))
+        provider.set_version(str(new_version))
 
         if self.pre_bump_hooks:
             hooks.run(

--- a/commitizen/commands/version.py
+++ b/commitizen/commands/version.py
@@ -4,6 +4,7 @@ import sys
 from commitizen import out
 from commitizen.__version__ import __version__
 from commitizen.config import BaseConfig
+from commitizen.providers import get_provider
 
 
 class Version:
@@ -21,14 +22,14 @@ class Version:
             out.write(f"Python Version: {self.python_version}")
             out.write(f"Operating System: {self.operating_system}")
         elif self.parameter.get("project"):
-            version = self.config.settings["version"]
+            version = get_provider(self.config).get_version()
             if version:
                 out.write(f"{version}")
             else:
                 out.error("No project information in this project.")
         elif self.parameter.get("verbose"):
             out.write(f"Installed Commitizen Version: {__version__}")
-            version = self.config.settings["version"]
+            version = get_provider(self.config).get_version()
             if version:
                 out.write(f"Project Version: {version}")
             else:

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -29,6 +29,7 @@ class Settings(TypedDict, total=False):
     name: str
     version: Optional[str]
     version_files: List[str]
+    version_provider: Optional[str]
     tag_format: Optional[str]
     bump_message: Optional[str]
     allow_abort: bool
@@ -59,6 +60,7 @@ DEFAULT_SETTINGS: Settings = {
     "name": "cz_conventional_commits",
     "version": None,
     "version_files": [],
+    "version_provider": "commitizen",
     "tag_format": None,  # example v$version
     "bump_message": None,  # bumped v$current_version to $new_version
     "allow_abort": False,

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -31,6 +31,7 @@ class ExitCode(enum.IntEnum):
     INVALID_MANUAL_VERSION = 24
     INIT_FAILED = 25
     RUN_HOOK_FAILED = 26
+    VERSION_PROVIDER_UNKNOWN = 27
 
 
 class CommitizenException(Exception):
@@ -173,3 +174,7 @@ class InitFailedError(CommitizenException):
 
 class RunHookError(CommitizenException):
     exit_code = ExitCode.RUN_HOOK_FAILED
+
+
+class VersionProviderUnknown(CommitizenException):
+    exit_code = ExitCode.VERSION_PROVIDER_UNKNOWN

--- a/commitizen/providers.py
+++ b/commitizen/providers.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import cast
+
+import importlib_metadata as metadata
+
+from commitizen.config.base_config import BaseConfig
+from commitizen.exceptions import VersionProviderUnknown
+
+PROVIDER_ENTRYPOINT = "commitizen.provider"
+DEFAULT_PROVIDER = "commitizen"
+
+
+class VersionProvider(ABC):
+    """
+    Abstract base class for version providers.
+
+    Each version provider should inherit and implement this class.
+    """
+
+    config: BaseConfig
+
+    def __init__(self, config: BaseConfig):
+        self.config = config
+
+    @abstractmethod
+    def get_version(self) -> str:
+        """
+        Get the current version
+        """
+        ...
+
+    @abstractmethod
+    def set_version(self, version: str):
+        """
+        Set the new current version
+        """
+        ...
+
+
+class CommitizenProvider(VersionProvider):
+    """
+    Default version provider: Fetch and set version in commitizen config.
+    """
+
+    def get_version(self) -> str:
+        return self.config.settings["version"]  # type: ignore
+
+    def set_version(self, version: str):
+        self.config.set_key("version", version)
+
+
+def get_provider(config: BaseConfig) -> VersionProvider:
+    """
+    Get the version provider as defined in the configuration
+
+    :raises VersionProviderUnknown: if the provider named by `version_provider` is not found.
+    """
+    provider_name = config.settings["version_provider"] or DEFAULT_PROVIDER
+    try:
+        (ep,) = metadata.entry_points(name=provider_name, group=PROVIDER_ENTRYPOINT)
+    except ValueError:
+        raise VersionProviderUnknown(f'Version Provider "{provider_name}" unknown.')
+    provider_cls = ep.load()
+    return cast(VersionProvider, provider_cls(config))

--- a/docs/config.md
+++ b/docs/config.md
@@ -119,6 +119,15 @@ Commitizen can read and write version from different sources.
 By default, it use the `commitizen` one which is using the `version` field from the commitizen settings.
 But you can use any `commitizen.provider` entrypoint as value for `version_provider`.
 
+Commitizen provides some version providers for some well known formats:
+
+| name | description |
+| ---- | ----------- |
+| `commitizen` | Default version provider: Fetch and set version in commitizen config. |
+| `pep621` | Get and set version from `pyproject.toml` `project.version` field |
+| `poetry` | Get and set version from `pyproject.toml` `tool.poetry.version` field |
+| `cargo` | Get and set version from `Cargo.toml` `project.version` field |
+
 ### Custom version provider
 
 You can add you own version provider by extending `VersionProvider` and exposing it on the `commitizen.provider` entrypoint.

--- a/docs/config.md
+++ b/docs/config.md
@@ -136,9 +136,7 @@ You can add you own version provider by extending `VersionProvider` and exposing
 
 Here a quick example of a `my-provider` provider reading and writing version in a `VERSION` file.
 
-`my_provider.py`
-
-```python
+```python title="my_provider.py"
 from pathlib import Path
 from commitizen.providers import VersionProvider
 
@@ -154,9 +152,7 @@ class MyProvider(VersionProvider):
 
 ```
 
-`setup.py`
-
-```python
+```python title="setup.py"
 from setuptools import setup
 
 setup(

--- a/docs/config.md
+++ b/docs/config.md
@@ -127,6 +127,8 @@ Commitizen provides some version providers for some well known formats:
 | `pep621` | Get and set version from `pyproject.toml` `project.version` field |
 | `poetry` | Get and set version from `pyproject.toml` `tool.poetry.version` field |
 | `cargo` | Get and set version from `Cargo.toml` `project.version` field |
+| `npm` | Get and set version from `package.json` `project.version` field |
+| `composer` | Get and set version from `composer.json` `project.version` field |
 
 ### Custom version provider
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -124,11 +124,15 @@ Commitizen provides some version providers for some well known formats:
 | name | description |
 | ---- | ----------- |
 | `commitizen` | Default version provider: Fetch and set version in commitizen config. |
+| `scm` | Fetch the version from git and does not need to set it back |
 | `pep621` | Get and set version from `pyproject.toml` `project.version` field |
 | `poetry` | Get and set version from `pyproject.toml` `tool.poetry.version` field |
 | `cargo` | Get and set version from `Cargo.toml` `project.version` field |
 | `npm` | Get and set version from `package.json` `project.version` field |
 | `composer` | Get and set version from `composer.json` `project.version` field |
+
+!!! note
+    The `scm` provider is meant to be used with `setuptools-scm` or any packager `*-scm` plugin.
 
 ### Custom version provider
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -7,6 +7,7 @@
 | `name`                     | `str`  | `"cz_conventional_commits"` | Name of the committing rules to use                                                                                                                                                                                                                  |
 | `version`                  | `str`  | `None`                      | Current version. Example: "0.1.2"                                                                                                                                                                                                                    |
 | `version_files`            | `list` | `[ ]`                       | Files were the version will be updated. A pattern to match a line, can also be specified, separated by `:` [See more][version_files]                                                                                                                 |
+| `version_provider`         | `str`  | `commitizen`                | Version provider used to read and write version [See more](#version-providers) |
 | `tag_format`               | `str`  | `None`                      | Format for the git tag, useful for old projects, that use a convention like `"v1.2.1"`. [See more][tag_format]                                                                                                                                       |
 | `update_changelog_on_bump` | `bool` | `false`                     | Create changelog when running `cz bump`                                                                                                                                                                                                              |
 | `gpg_sign`                 | `bool` | `false`                     | Use gpg signed tags instead of lightweight tags.                                                                                                                                                                                                     |
@@ -110,6 +111,54 @@ commitizen:
       - ""
     - - disabled
       - fg:#858585 italic
+```
+
+## Version providers
+
+Commitizen can read and write version from different sources.
+By default, it use the `commitizen` one which is using the `version` field from the commitizen settings.
+But you can use any `commitizen.provider` entrypoint as value for `version_provider`.
+
+### Custom version provider
+
+You can add you own version provider by extending `VersionProvider` and exposing it on the `commitizen.provider` entrypoint.
+
+Here a quick example of a `my-provider` provider reading and writing version in a `VERSION` file.
+
+`my_provider.py`
+
+```python
+from pathlib import Path
+from commitizen.providers import VersionProvider
+
+
+class MyProvider(VersionProvider):
+    file = Path() / "VERSION"
+
+    def get_version(self) -> str:
+        return self.file.read_text()
+
+    def set_version(self, version: str):
+        self.file.write_text(version)
+
+```
+
+`setup.py`
+
+```python
+from setuptools import setup
+
+setup(
+    name='my-commitizen-provider',
+    version='0.1.0',
+    py_modules=['my_provider'],
+    install_requires=['commitizen'],
+    entry_points = {
+        'commitizen.provider': [
+            'my-provider = my_provider:MyProvider',
+        ]
+    }
+)
 ```
 
 [version_files]: bump.md#version_files

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -30,4 +30,7 @@ These exit codes can be found in `commitizen/exceptions.py::ExitCode`.
 | NotAllowed                  | 20        | `--incremental` cannot be combined with a `rev_range`                                                       |
 | NoneIncrementExit           | 21        | The commits found are not eligible to be bumped                                                             |
 | CharacterSetDecodeError     | 22        | The character encoding of the command output could not be determined                                        |
-| GitCommandError             | 23       | Unexpected failure while calling a git command                                                              |
+| GitCommandError             | 23        | Unexpected failure while calling a git command                                                              |
+| InvalidManualVersion        | 24        | Manually provided version is invalid                                                                        |
+| InitFailedError             | 25        | Failed to initialize pre-commit                                                                             |
+| VersionProviderUnknown      | 26        | `version_provider` setting is set to an unknown version provider indentifier                                |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,26 +5,19 @@ PEP621 establishes a `[project]` definition inside `pyproject.toml`
 ```toml
 [project]
 name = "spam"
-version = "2020.0.0"
+version = "2.5.1"
 ```
 
-Commitizen **won't** use the `project.version` as a source of truth because it's a
-tool aimed for any kind of project.
-
-If we were to use it, it would increase the complexity of the tool. Also why
-wouldn't we support other project files like `cargo.toml` or `package.json`?
-
-Instead of supporting all the different project files, you can use `version_files`
-inside `[tool.commitizen]`, and it will cheaply keep any of these project files in sync
+Commitizen provides a [`pep621` version provider](config.md#version-providers) to get and set version from this field.
+You just need to set the proper `version_provider` setting:
 
 ```toml
-[tool.commitizen]
+[project]
+name = "spam"
 version = "2.5.1"
-version_files = [
-    "pyproject.toml:^version",
-    "cargo.toml:^version",
-    "package.json:\"version\":"
-]
+
+[tool.commitizen]
+version_provider = "pep621"
 ```
 
 ## Why are `revert` and `chore` valid types in the check pattern of cz conventional_commits but not types we can select?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,3 +35,5 @@ markdown_extensions:
   - admonition
   - codehilite
   - extra
+  - pymdownx.highlight
+  - pymdownx.superfences

--- a/poetry.lock
+++ b/poetry.lock
@@ -536,14 +536,14 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "markdown"
-version = "3.4.1"
+version = "3.3.7"
 description = "Python implementation of Markdown."
 category = "dev"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.6"
 files = [
-    {file = "Markdown-3.4.1-py3-none-any.whl", hash = "sha256:08fb8465cffd03d10b9dd34a5c3fea908e20391a2a90b88d66362cb05beed186"},
-    {file = "Markdown-3.4.1.tar.gz", hash = "sha256:3b809086bb6efad416156e00a0da66fe47618a5d6918dd688f53f40c8e4cfeff"},
+    {file = "Markdown-3.3.7-py3-none-any.whl", hash = "sha256:f5da449a6e1c989a4cea2631aa8ee67caa5a2ef855d551c88f9e309f4634c621"},
+    {file = "Markdown-3.3.7.tar.gz", hash = "sha256:cbb516f16218e643d8e0a95b309f77eb118cb138d39a4f27851e6a63581db874"},
 ]
 
 [package.dependencies]
@@ -643,48 +643,66 @@ files = [
 
 [[package]]
 name = "mkdocs"
-version = "1.3.0"
+version = "1.4.2"
 description = "Project documentation with Markdown."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "mkdocs-1.3.0-py3-none-any.whl", hash = "sha256:26bd2b03d739ac57a3e6eed0b7bcc86168703b719c27b99ad6ca91dc439aacde"},
-    {file = "mkdocs-1.3.0.tar.gz", hash = "sha256:b504405b04da38795fec9b2e5e28f6aa3a73bb0960cb6d5d27ead28952bd35ea"},
+    {file = "mkdocs-1.4.2-py3-none-any.whl", hash = "sha256:c8856a832c1e56702577023cd64cc5f84948280c1c0fcc6af4cd39006ea6aa8c"},
+    {file = "mkdocs-1.4.2.tar.gz", hash = "sha256:8947af423a6d0facf41ea1195b8e1e8c85ad94ac95ae307fe11232e0424b11c5"},
 ]
 
 [package.dependencies]
-click = ">=3.3"
+click = ">=7.0"
+colorama = {version = ">=0.4", markers = "platform_system == \"Windows\""}
 ghp-import = ">=1.0"
-importlib-metadata = ">=4.3"
-Jinja2 = ">=2.10.2"
-Markdown = ">=3.2.1"
+importlib-metadata = {version = ">=4.3", markers = "python_version < \"3.10\""}
+jinja2 = ">=2.11.1"
+markdown = ">=3.2.1,<3.4"
 mergedeep = ">=1.3.4"
 packaging = ">=20.5"
-PyYAML = ">=3.10"
+pyyaml = ">=5.1"
 pyyaml-env-tag = ">=0.1"
+typing-extensions = {version = ">=3.10", markers = "python_version < \"3.8\""}
 watchdog = ">=2.0"
 
 [package.extras]
 i18n = ["babel (>=2.9.0)"]
+min-versions = ["babel (==2.9.0)", "click (==7.0)", "colorama (==0.4)", "ghp-import (==1.0)", "importlib-metadata (==4.3)", "jinja2 (==2.11.1)", "markdown (==3.2.1)", "markupsafe (==2.0.1)", "mergedeep (==1.3.4)", "packaging (==20.5)", "pyyaml (==5.1)", "pyyaml-env-tag (==0.1)", "typing-extensions (==3.10)", "watchdog (==2.0)"]
 
 [[package]]
 name = "mkdocs-material"
-version = "4.6.3"
-description = "A Material Design theme for MkDocs"
+version = "8.5.11"
+description = "Documentation that simply works"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 files = [
-    {file = "mkdocs-material-4.6.3.tar.gz", hash = "sha256:1d486635b03f5a2ec87325842f7b10c7ae7daa0eef76b185572eece6a6ea212c"},
-    {file = "mkdocs_material-4.6.3-py2.py3-none-any.whl", hash = "sha256:7f3afa0a09c07d0b89a6a9755fdb00513aee8f0cec3538bb903325c80f66f444"},
+    {file = "mkdocs_material-8.5.11-py3-none-any.whl", hash = "sha256:c907b4b052240a5778074a30a78f31a1f8ff82d7012356dc26898b97559f082e"},
+    {file = "mkdocs_material-8.5.11.tar.gz", hash = "sha256:b0ea0513fd8cab323e8a825d6692ea07fa83e917bb5db042e523afecc7064ab7"},
 ]
 
 [package.dependencies]
+jinja2 = ">=3.0.2"
 markdown = ">=3.2"
-mkdocs = ">=1.0"
-Pygments = ">=2.4"
-pymdown-extensions = ">=6.3"
+mkdocs = ">=1.4.0"
+mkdocs-material-extensions = ">=1.1"
+pygments = ">=2.12"
+pymdown-extensions = ">=9.4"
+requests = ">=2.26"
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.1.1"
+description = "Extension pack for Python Markdown and MkDocs Material."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mkdocs_material_extensions-1.1.1-py3-none-any.whl", hash = "sha256:e41d9f38e4798b6617ad98ca8f7f1157b1e4385ac1459ca1e4ea219b556df945"},
+    {file = "mkdocs_material_extensions-1.1.1.tar.gz", hash = "sha256:9c003da71e2cc2493d910237448c672e00cefc800d3d6ae93d2fc69979e3bd93"},
+]
 
 [[package]]
 name = "mypy"
@@ -857,14 +875,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "2.20.0"
+version = "2.21.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pre_commit-2.20.0-py2.py3-none-any.whl", hash = "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7"},
-    {file = "pre_commit-2.20.0.tar.gz", hash = "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"},
+    {file = "pre_commit-2.21.0-py2.py3-none-any.whl", hash = "sha256:e2f91727039fc39a92f58a588a25b87f936de6567eed4f0e673e0507edc75bad"},
+    {file = "pre_commit-2.21.0.tar.gz", hash = "sha256:31ef31af7e474a8d8995027fefdfcf509b5c913ff31f2015b4ec4beb26a6f658"},
 ]
 
 [package.dependencies]
@@ -873,8 +891,7 @@ identify = ">=1.0.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
-toml = "*"
-virtualenv = ">=20.0.8"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prompt-toolkit"
@@ -1286,18 +1303,6 @@ files = [
 tests = ["pytest", "pytest-cov"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
-]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1518,4 +1523,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "bbe0d066f84d0f48ea255f0015ca216f455ac49d471e96162a14456dd7a6a12a"
+content-hash = "12181f1e683c5555c8be62a7de363a6c89b179ca070fbd4f0c68519d9509e47d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ cz_conventional_commits = "commitizen.cz.conventional_commits:ConventionalCommit
 cz_jira = "commitizen.cz.jira:JiraSmartCz"
 cz_customize = "commitizen.cz.customize:CustomizeCommitsCz"
 
+[tool.poetry.plugins."commitizen.provider"]
+commitizen = "commitizen.providers:CommitizenProvider"
+
 [tool.isort]
 profile = "black"
 known_first_party = ["commitizen", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ types-PyYAML = "^5.4.3"
 types-termcolor = "^0.1.1"
 # documentation
 mkdocs = "^1.0"
-mkdocs-material = "^4.1"
+mkdocs-material = "^8.5.11"
 pydocstyle = "^5.0.2"
 pytest-xdist = "^3.1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ composer = "commitizen.providers:ComposerProvider"
 npm = "commitizen.providers:NpmProvider"
 pep621 = "commitizen.providers:Pep621Provider"
 poetry = "commitizen.providers:PoetryProvider"
+scm = "commitizen.providers:ScmProvider"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ cz_customize = "commitizen.cz.customize:CustomizeCommitsCz"
 [tool.poetry.plugins."commitizen.provider"]
 cargo = "commitizen.providers:CargoProvider"
 commitizen = "commitizen.providers:CommitizenProvider"
+composer = "commitizen.providers:ComposerProvider"
+npm = "commitizen.providers:NpmProvider"
 pep621 = "commitizen.providers:Pep621Provider"
 poetry = "commitizen.providers:PoetryProvider"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,10 @@ cz_jira = "commitizen.cz.jira:JiraSmartCz"
 cz_customize = "commitizen.cz.customize:CustomizeCommitsCz"
 
 [tool.poetry.plugins."commitizen.provider"]
+cargo = "commitizen.providers:CargoProvider"
 commitizen = "commitizen.providers:CommitizenProvider"
+pep621 = "commitizen.providers:Pep621Provider"
+poetry = "commitizen.providers:PoetryProvider"
 
 [tool.isort]
 profile = "black"

--- a/tests/commands/test_version_command.py
+++ b/tests/commands/test_version_command.py
@@ -93,7 +93,12 @@ def test_version_use_version_provider(
 
     commands.Version(
         config,
-        {"report": False, "project": project, "commitizen": False, "verbose": True},
+        {
+            "report": False,
+            "project": project,
+            "commitizen": False,
+            "verbose": not project,
+        },
     )()
     captured = capsys.readouterr()
 

--- a/tests/commands/test_version_command.py
+++ b/tests/commands/test_version_command.py
@@ -1,8 +1,12 @@
 import platform
 import sys
 
+import pytest
+from pytest_mock import MockerFixture
+
 from commitizen import commands
 from commitizen.__version__ import __version__
+from commitizen.config.base_config import BaseConfig
 
 
 def test_version_for_showing_project_version(config, capsys):
@@ -70,3 +74,30 @@ def test_version_for_showing_commitizen_system_info(config, capsys):
     assert f"Commitizen Version: {__version__}" in captured.out
     assert f"Python Version: {sys.version}" in captured.out
     assert f"Operating System: {platform.system()}" in captured.out
+
+
+@pytest.mark.parametrize("project", (True, False))
+@pytest.mark.usefixtures("tmp_git_project")
+def test_version_use_version_provider(
+    mocker: MockerFixture,
+    config: BaseConfig,
+    capsys: pytest.CaptureFixture,
+    project: bool,
+):
+    version = "0.0.0"
+    mock = mocker.MagicMock(name="provider")
+    mock.get_version.return_value = version
+    get_provider = mocker.patch(
+        "commitizen.commands.version.get_provider", return_value=mock
+    )
+
+    commands.Version(
+        config,
+        {"report": False, "project": project, "commitizen": False, "verbose": True},
+    )()
+    captured = capsys.readouterr()
+
+    assert version in captured.out
+    get_provider.assert_called_once()
+    mock.get_version.assert_called_once()
+    mock.set_version.assert_not_called()

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -44,6 +44,7 @@ DICT_CONFIG = {
 _settings = {
     "name": "cz_jira",
     "version": "1.0.0",
+    "version_provider": "commitizen",
     "tag_format": None,
     "bump_message": None,
     "allow_abort": False,
@@ -63,6 +64,7 @@ _settings = {
 _new_settings = {
     "name": "cz_jira",
     "version": "2.0.0",
+    "version_provider": "commitizen",
     "tag_format": None,
     "bump_message": None,
     "allow_abort": False,

--- a/tests/test_version_providers.py
+++ b/tests/test_version_providers.py
@@ -1,15 +1,32 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import os
+from pathlib import Path
+from textwrap import dedent
+from typing import TYPE_CHECKING, Iterator
 
 import pytest
 
 from commitizen.config.base_config import BaseConfig
 from commitizen.exceptions import VersionProviderUnknown
-from commitizen.providers import CommitizenProvider, get_provider
+from commitizen.providers import (
+    CargoProvider,
+    CommitizenProvider,
+    Pep621Provider,
+    PoetryProvider,
+    get_provider,
+)
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+
+
+@pytest.fixture
+def chdir(tmp_path: Path) -> Iterator[Path]:
+    cwd = Path()
+    os.chdir(tmp_path)
+    yield tmp_path
+    os.chdir(cwd)
 
 
 def test_default_version_provider_is_commitizen_config(config: BaseConfig):
@@ -33,3 +50,78 @@ def test_commitizen_provider(config: BaseConfig, mocker: MockerFixture):
 
     provider.set_version("43.1")
     mock.assert_called_once_with("version", "43.1")
+
+
+def test_pep621_provider(config: BaseConfig, chdir: Path):
+    pyproject_toml = chdir / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [project]
+            version = "0.1.0"
+            """
+        )
+    )
+
+    provider = Pep621Provider(config)
+
+    assert provider.get_version() == "0.1.0"
+
+    provider.set_version("43.1")
+
+    assert pyproject_toml.read_text() == dedent(
+        """\
+        [project]
+        version = "43.1"
+        """
+    )
+
+
+def test_poetry_provider(config: BaseConfig, chdir: Path):
+    pyproject_toml = chdir / "pyproject.toml"
+    pyproject_toml.write_text(
+        dedent(
+            """\
+            [tool.poetry]
+            version = "0.1.0"
+            """
+        )
+    )
+    config.settings["version_provider"] = "poetry"
+
+    provider = get_provider(config)
+    assert isinstance(provider, PoetryProvider)
+    assert provider.get_version() == "0.1.0"
+
+    provider.set_version("43.1")
+    assert pyproject_toml.read_text() == dedent(
+        """\
+        [tool.poetry]
+        version = "43.1"
+        """
+    )
+
+
+def test_cargo_provider(config: BaseConfig, chdir: Path):
+    cargo_toml = chdir / "Cargo.toml"
+    cargo_toml.write_text(
+        dedent(
+            """\
+            [package]
+            version = "0.1.0"
+            """
+        )
+    )
+    config.settings["version_provider"] = "cargo"
+
+    provider = get_provider(config)
+    assert isinstance(provider, CargoProvider)
+    assert provider.get_version() == "0.1.0"
+
+    provider.set_version("43.1")
+    assert cargo_toml.read_text() == dedent(
+        """\
+        [package]
+        version = "43.1"
+        """
+    )

--- a/tests/test_version_providers.py
+++ b/tests/test_version_providers.py
@@ -12,6 +12,8 @@ from commitizen.exceptions import VersionProviderUnknown
 from commitizen.providers import (
     CargoProvider,
     CommitizenProvider,
+    ComposerProvider,
+    NpmProvider,
     Pep621Provider,
     PoetryProvider,
     get_provider,
@@ -123,5 +125,63 @@ def test_cargo_provider(config: BaseConfig, chdir: Path):
         """\
         [package]
         version = "43.1"
+        """
+    )
+
+
+def test_npm_provider(config: BaseConfig, chdir: Path):
+    package_json = chdir / "package.json"
+    package_json.write_text(
+        dedent(
+            """\
+            {
+              "name": "whatever",
+              "version": "0.1.0"
+            }
+            """
+        )
+    )
+    config.settings["version_provider"] = "npm"
+
+    provider = get_provider(config)
+    assert isinstance(provider, NpmProvider)
+    assert provider.get_version() == "0.1.0"
+
+    provider.set_version("43.1")
+    assert package_json.read_text() == dedent(
+        """\
+        {
+          "name": "whatever",
+          "version": "43.1"
+        }
+        """
+    )
+
+
+def test_composer_provider(config: BaseConfig, chdir: Path):
+    composer_json = chdir / "composer.json"
+    composer_json.write_text(
+        dedent(
+            """\
+            {
+                "name": "whatever",
+                "version": "0.1.0"
+            }
+            """
+        )
+    )
+    config.settings["version_provider"] = "composer"
+
+    provider = get_provider(config)
+    assert isinstance(provider, ComposerProvider)
+    assert provider.get_version() == "0.1.0"
+
+    provider.set_version("43.1")
+    assert composer_json.read_text() == dedent(
+        """\
+        {
+            "name": "whatever",
+            "version": "43.1"
+        }
         """
     )

--- a/tests/test_version_providers.py
+++ b/tests/test_version_providers.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from commitizen.config.base_config import BaseConfig
+from commitizen.exceptions import VersionProviderUnknown
+from commitizen.providers import CommitizenProvider, get_provider
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def test_default_version_provider_is_commitizen_config(config: BaseConfig):
+    provider = get_provider(config)
+
+    assert isinstance(provider, CommitizenProvider)
+
+
+def test_raise_for_unknown_provider(config: BaseConfig):
+    config.settings["version_provider"] = "unknown"
+    with pytest.raises(VersionProviderUnknown):
+        get_provider(config)
+
+
+def test_commitizen_provider(config: BaseConfig, mocker: MockerFixture):
+    config.settings["version"] = "42"
+    mock = mocker.patch.object(config, "set_key")
+
+    provider = CommitizenProvider(config)
+    assert provider.get_version() == "42"
+
+    provider.set_version("43.1")
+    mock.assert_called_once_with("version", "43.1")


### PR DESCRIPTION
## Description

This PR is a proposal because I know it has been stated than there won't be an official PEP621.

This PR doesn't focus on `PEP621` but on opening the version source of trust by introducing a version provider.

If has been splitted in multiple commits that can be removed from the PR depending on your acceptance.

The first one is simply introducing the entrypoint `commitizen.provider` and the `commitizen` provider which is the current scheme (version taken from commitizen configuration) and backward compatible.

The second one introduce some common TOML-based formats (PEP621, poetry, Cargo) as `tomlkit` is style preserving. Those implementations does not suffer from the regexp side-effect aka. changing any field matching the criteria (happen as soon as you have another version matching in the file) because they are using the format structured access instead of search and replace.

The third one introduce the JSON-based providers for some formats (npm/package.json, composer), mostly to showcase the possibility (and to echo the [FAQ entry](https://commitizen-tools.github.io/commitizen/faq/#support-for-pep621) for package.json/npm projects).
Given the builtin `json` is not style preserving (I assume an indentation for each one), I would totally understand their removal.

The fourth one is simply a documentation update to be able to have proper snippets with title in the documentation.

The last one is exactly #647 but was required to make this PR CI green. See [the previous build](https://github.com/commitizen-tools/commitizen/actions/runs/3796117778/jobs/6455902375) failing on some totally unrelated (and untouched) cases.

This PR is backward compatible (aka. it is possible not to change the version provider as well as using the `pep621` provider while handling both `Cargo.toml` and `package.json` with `version_files`), tested and documented.

Note: this PR use the same extension mechanism as #632 and it is totally possible to extract all implementations to only keep the `commitizen` one given they can be provided as an external package.

Edit: Added an extra commit to add an `scm` provider for #641. It handles `tag_format` reverse parsing. I discovered an issue (I will submit) on the [`tag_format` handling](https://commitizen-tools.github.io/commitizen/bump/#tag_format): while `devrelease` is documented as being a variable placeholder in `tag_format`, it is not handled as a template variable but appended to the tag (`.devX` when submitted as `--devrelease X`) whatever it's position is in the template, even if it is not present in the template.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

