### PR TITLE
test: improve git isolation and fixes test missing a repository

### DIFF
--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -275,7 +275,8 @@ def test_bump_on_git_with_hooks_no_verify_enabled(mocker):
     assert tag_exists is True
 
 
-def test_bump_when_bumpping_is_not_support(mocker, tmp_commitizen_project):
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_when_bumpping_is_not_support(mocker):
     create_file_and_commit(
         "feat: new user interface\n\nBREAKING CHANGE: age is no longer supported"
     )
@@ -429,7 +430,8 @@ def test_bump_local_version(mocker, tmp_commitizen_project):
         assert "4.5.1+0.2.0" in f.read()
 
 
-def test_bump_dry_run(mocker, capsys, tmp_commitizen_project):
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_dry_run(mocker, capsys):
     create_file_and_commit("feat: new file")
 
     testargs = ["cz", "bump", "--yes", "--dry-run"]
@@ -471,9 +473,7 @@ def test_none_increment_exit_is_exception():
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
-def test_none_increment_should_not_call_git_tag_and_error_code_is_not_zero(
-    mocker, tmp_commitizen_project
-):
+def test_none_increment_should_not_call_git_tag_and_error_code_is_not_zero(mocker):
     create_file_and_commit("test(test_get_all_droplets): fix bad comparison test")
     testargs = ["cz", "bump", "--yes"]
     mocker.patch.object(sys, "argv", testargs)
@@ -528,9 +528,8 @@ def test_bump_with_changelog_config(mocker, changelog_path, config_path):
     assert "0.2.0" in out
 
 
-def test_prevent_prerelease_when_no_increment_detected(
-    mocker, capsys, tmp_commitizen_project
-):
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_prevent_prerelease_when_no_increment_detected(mocker, capsys):
     create_file_and_commit("feat: new file")
 
     testargs = ["cz", "bump", "--yes"]
@@ -685,6 +684,7 @@ def test_bump_changelog_command_commits_untracked_changelog_and_version_files(
         ["cz", "bump", "--increment", "PATCH", "1.2.3"],
     ],
 )
+@pytest.mark.usefixtures("tmp_commitizen_project")
 def test_bump_invalid_manual_args_raises_exception(mocker, testargs):
     mocker.patch.object(sys, "argv", testargs)
 

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -340,6 +340,7 @@ def test_changelog_without_revision(mocker, tmp_commitizen_project):
         cli.main()
 
 
+@pytest.mark.usefixtures("tmp_commitizen_project")
 def test_changelog_incremental_with_revision(mocker):
     """combining incremental with a revision doesn't make sense"""
     testargs = ["cz", "changelog", "--incremental", "0.2.0"]

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -16,9 +16,10 @@ from commitizen.exceptions import (
 
 
 @pytest.fixture
-def staging_is_clean(mocker):
+def staging_is_clean(mocker, tmp_git_project):
     is_staging_clean_mock = mocker.patch("commitizen.git.is_staging_clean")
     is_staging_clean_mock.return_value = False
+    return tmp_git_project
 
 
 @pytest.mark.usefixtures("staging_is_clean")
@@ -127,6 +128,7 @@ def test_commit_command_with_signoff_option(config, mocker):
     success_mock.assert_called_once()
 
 
+@pytest.mark.usefixtures("tmp_git_project")
 def test_commit_when_nothing_to_commit(config, mocker):
     is_staging_clean_mock = mocker.patch("commitizen.git.is_staging_clean")
     is_staging_clean_mock.return_value = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,12 @@ SIGNER_MAIL = "action@github.com"
 @pytest.fixture(autouse=True)
 def git_sandbox(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     """Ensure git commands are executed without the current user settings"""
+    # Clear any GIT_ prefixed environment variable
+    for var in os.environ:
+        if var.startswith("GIT_"):
+            monkeypatch.delenv(var)
+
+    # Define a dedicated temporary git config
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "gitconfig"))
     cmd.run(f"git config --global user.name {SIGNER}")
     cmd.run(f"git config --global user.email {SIGNER_MAIL}")
@@ -30,11 +36,10 @@ def tmp_git_project(tmpdir):
 
 @pytest.fixture(scope="function")
 def tmp_commitizen_project(tmp_git_project):
-    with tmp_git_project.as_cwd():
-        tmp_commitizen_cfg_file = tmp_git_project.join("pyproject.toml")
-        tmp_commitizen_cfg_file.write("[tool.commitizen]\n" 'version="0.1.0"\n')
+    tmp_commitizen_cfg_file = tmp_git_project.join("pyproject.toml")
+    tmp_commitizen_cfg_file.write("[tool.commitizen]\n" 'version="0.1.0"\n')
 
-        yield tmp_git_project
+    yield tmp_git_project
 
 
 def _get_gpg_keyid(signer_mail):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,7 @@ def create_file_and_commit(message: str, filename: Optional[str] = None):
     if not filename:
         filename = str(uuid.uuid4())
 
-    Path(f"./{filename}").touch()
+    Path(filename).touch()
     c = cmd.run("git add .")
     if c.return_code != 0:
         raise exceptions.CommitError(c.err)


### PR DESCRIPTION
## Description
This PR follows #638 and extend the isolation to any `GIT_` prefixed variables. It also ensure that every test requiring a `tmp_git_project` or `tmp_commitizen_project`  fixture has it, even for test expecting a failure (to ensure the proper failure).

This fixes some false negatives in `pre-commit` as well as ordering side-effects for tests that were missing the fixture like [this build](https://github.com/commitizen-tools/commitizen/actions/runs/3796117778/jobs/6455902375) failing on some totally unrelated (and untouched) cases.

There is few misc fixes and redundancy removal (lots of unnecessary nested `.as_cwd()` calls as well as some fixtures extracted into `@pytest.mark.usefixtures()` when not used in the test but still requiring the fixture setup))

## Checklist

- [x] Add test cases to all the changes you introduce (N/A)
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes (N/A)
