### PR TITLE
feat: configurable commit validation

### DIFF
--- a/commitizen/cz/__init__.py
+++ b/commitizen/cz/__init__.py
@@ -5,7 +5,7 @@ from typing import Dict, Iterable, Type
 
 from commitizen.cz.base import BaseCommitizen
 from commitizen.cz.conventional_commits import ConventionalCommitsCz
-from commitizen.cz.customize import CustomizeCommitsCz
+from commitizen.cz.customize import CustomizeCommitsCz, CustomizeCommitValidationCz
 from commitizen.cz.jira import JiraSmartCz
 
 
@@ -34,6 +34,7 @@ registry: Dict[str, Type[BaseCommitizen]] = {
     "cz_conventional_commits": ConventionalCommitsCz,
     "cz_jira": JiraSmartCz,
     "cz_customize": CustomizeCommitsCz,
+    "cz_custom_validation": CustomizeCommitValidationCz,
 }
 
 registry.update(discover_plugins())

--- a/commitizen/cz/customize/__init__.py
+++ b/commitizen/cz/customize/__init__.py
@@ -1,1 +1,1 @@
-from .customize import CustomizeCommitsCz  # noqa
+from .customize import CustomizeCommitsCz, CustomizeCommitValidationCz  # noqa


### PR DESCRIPTION
Allow clients overriding the BaseCommitizen object to have more custom commit message validation beyond just matching a regex schema. This lets clients have custom error messages and more intelligent pattern matching.

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
This change lets users add certain things like bad word filters or more intelligent task ID listing (for example, make sure one or more IDs appears in the commit message, and in no particular order).

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
Override `validate_commit` or `validate_commits` in `BaseCommitizen` for commit validation functions that are expressible in Python, and not just by a regular expression.

## Steps to Test This Pull Request
Run the `test_check_custom_validation_succeeds` and `test_check_custom_validation_fails` test cases in `tests/commands/test_check_command.py`.

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
I noticed during my development that the `test_check_command_with_empty_range` case was failing with the error:

```
commitizen.exceptions.GitCommandError: fatal: ambiguous argument 'master..master': unknown revision or path not in the working tree.
```

instead of generating its expected output. I did my best to make sure that this failure wasn't related to my changes, since it also reproduced when I ran the test suite against `master`. It could just be an issue with my local environment.