### PR TITLE
tidy of python 3 code

### DIFF
--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -31,7 +31,7 @@ class Commit:
         self.arguments = arguments
         self.temp_file: str = os.path.join(
             tempfile.gettempdir(),
-            "cz.commit{user}.backup".format(user=os.environ.get("USER", "")),
+            f"cz.commit{os.environ.get('USER', '')}.backup",
         )
 
     def read_backup_message(self) -> str:

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -9,7 +9,7 @@ from .base_config import BaseConfig
 
 class JsonConfig(BaseConfig):
     def __init__(self, *, data: Union[bytes, str], path: Union[Path, str]):
-        super(JsonConfig, self).__init__()
+        super().__init__()
         self.is_empty_config = False
         self._parse_setting(data)
         self.add_path(path)

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -9,7 +9,7 @@ from .base_config import BaseConfig
 
 class TomlConfig(BaseConfig):
     def __init__(self, *, data: Union[bytes, str], path: Union[Path, str]):
-        super(TomlConfig, self).__init__()
+        super().__init__()
         self.is_empty_config = False
         self._parse_setting(data)
         self.add_path(path)

--- a/commitizen/config/yaml_config.py
+++ b/commitizen/config/yaml_config.py
@@ -10,7 +10,7 @@ from .base_config import BaseConfig
 
 class YAMLConfig(BaseConfig):
     def __init__(self, *, data: Union[bytes, str], path: Union[Path, str]):
-        super(YAMLConfig, self).__init__()
+        super().__init__()
         self.is_empty_config = False
         self._parse_setting(data)
         self.add_path(path)

--- a/commitizen/cz/customize/customize.py
+++ b/commitizen/cz/customize/customize.py
@@ -20,7 +20,7 @@ class CustomizeCommitsCz(BaseCommitizen):
     change_type_order = defaults.change_type_order
 
     def __init__(self, config: BaseConfig):
-        super(CustomizeCommitsCz, self).__init__(config)
+        super().__init__(config)
 
         if "customize" not in self.config.settings:
             raise MissingCzCustomizeConfigError()

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockFixture
 
-import commitizen.commands.bump as bump
+from commitizen.commands import bump
 from commitizen import cli, cmd, git
 from commitizen.exceptions import (
     BumpTagFailedError,

--- a/tests/test_bump_find_version.py
+++ b/tests/test_bump_find_version.py
@@ -84,15 +84,12 @@ def test_generate_version(test_input, expected):
     increment = test_input[1]
     prerelease = test_input[2]
     devrelease = test_input[3]
-    assert (
-        generate_version(
-            current_version,
-            increment=increment,
-            prerelease=prerelease,
-            devrelease=devrelease,
-        )
-        == Version(expected)
-    )
+    assert generate_version(
+        current_version,
+        increment=increment,
+        prerelease=prerelease,
+        devrelease=devrelease,
+    ) == Version(expected)
 
 
 @pytest.mark.parametrize(
@@ -105,13 +102,10 @@ def test_generate_version_local(test_input, expected):
     prerelease = test_input[2]
     devrelease = test_input[3]
     is_local_version = True
-    assert (
-        generate_version(
-            current_version,
-            increment=increment,
-            prerelease=prerelease,
-            devrelease=devrelease,
-            is_local_version=is_local_version,
-        )
-        == Version(expected)
-    )
+    assert generate_version(
+        current_version,
+        increment=increment,
+        prerelease=prerelease,
+        devrelease=devrelease,
+        is_local_version=is_local_version,
+    ) == Version(expected)


### PR DESCRIPTION
## Description
 - converted format string to f-string
 - replaced super calls with python 3 versions
 - formatted some asserts
 - made an import consistent


## Checklist

- [N/A ] Add test cases to all the changes you introduce
- [ fails on windows ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [Y - I managed to manually run poetry to run the above tests] Test the changes on the local machine manually
- [ NA] Update the documentation for the changes

## Expected behavior
Should be no visible change, just an updating of code to python 3 and tidy.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...Run the tests I guess, but there's not really big functional changes.
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
