### PR TITLE
build(poetry): relax charset-normalizer dependency to allow 3.0.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ jinja2 = ">=2.10.3"
 pyyaml = ">=3.08"
 argcomplete = ">=1.12.1,<2.1"
 typing-extensions = "^4.0.1"
-charset-normalizer = "^2.1.0"
+charset-normalizer = ">=2.1.0,<3.1"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.2"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Relax charset-normalizer dependency to support 3.0.x

## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
`poetry update` will update charset-normalizer to an up-to-date version, currently 3.0.1

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
Closes #635
