### PR TITLE
fix(bump): fixed environment variables in bump hooks

### DIFF
--- a/commitizen/hooks.py
+++ b/commitizen/hooks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from commitizen import cmd, out
 from commitizen.exceptions import RunHookError
 
@@ -25,7 +27,7 @@ def run(hooks, _env_prefix="CZ_", **env):
 def _format_env(prefix: str, env: dict[str, str]) -> dict[str, str]:
     """_format_env() prefixes all given environment variables with the given
     prefix so it can be passed directly to cmd.run()."""
-    penv = dict()
+    penv = dict(os.environ)
     for name, value in env.items():
         name = prefix + name.upper()
         value = str(value) if value is not None else ""

--- a/tests/test_bump_hooks.py
+++ b/tests/test_bump_hooks.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import call
 
 import pytest
@@ -17,7 +18,10 @@ def test_run(mocker: MockFixture):
     hooks.run(bump_hooks)
 
     cmd_run_mock.assert_has_calls(
-        [call("pre_bump_hook", env={}), call("pre_bump_hook_1", env={})]
+        [
+            call("pre_bump_hook", env=dict(os.environ)),
+            call("pre_bump_hook_1", env=dict(os.environ)),
+        ]
     )
 
 


### PR DESCRIPTION
During development of #644, merging the hook environment variables with existing OS variables broke. This commit fixes that. I think it got missing during an additional rebase of that MR, but it is fixed again.
