### PR TITLE
fix(commands/changelog): use topological order for commit ordering

### DIFF
--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -144,9 +144,7 @@ class Changelog:
                 tag_format=self.tag_format,
             )
 
-        commits = git.get_commits(
-            start=start_rev, end=end_rev, args="--author-date-order"
-        )
+        commits = git.get_commits(start=start_rev, end=end_rev, args="--topo-order")
         if not commits:
             raise NoCommitsFoundError("No commits found")
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,6 +26,31 @@ def create_file_and_commit(message: str, filename: Optional[str] = None):
         raise exceptions.CommitError(c.err)
 
 
+def create_branch(name: str):
+    c = cmd.run(f"git branch {name}")
+    if c.return_code != 0:
+        raise exceptions.GitCommandError(c.err)
+
+
+def switch_branch(branch: str):
+    c = cmd.run(f"git switch {branch}")
+    if c.return_code != 0:
+        raise exceptions.GitCommandError(c.err)
+
+
+def merge_branch(branch: str):
+    c = cmd.run(f"git merge {branch}")
+    if c.return_code != 0:
+        raise exceptions.GitCommandError(c.err)
+
+
+def get_current_branch() -> str:
+    c = cmd.run("git rev-parse --abbrev-ref HEAD")
+    if c.return_code != 0:
+        raise exceptions.GitCommandError(c.err)
+    return c.out
+
+
 def create_tag(tag: str):
     c = git.tag(tag)
     if c.return_code != 0:


### PR DESCRIPTION
## Description
This MR comes from an issue raised [here](https://github.com/commitizen-tools/commitizen/issues/660)

Topological ordering should be used when ordering commits in changelog history. This allows commits to be shown properly in the order they were added to the codebase, even if non-linear merges were used


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes
   - No documentation to update

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

With a git history that has non-linear merges, I want my commits to be ordered in the order that they were introduced in the codebase.

So having a git graph like so:
```bash
* feat: I will be merged first - (2023-03-01 11:35:51 +0100) |  (branchB)
| * feat: I will be merged second - (2023-03-01 11:35:22 +0100) |  (branchA)
|/
* feat: initial commit - (2023-03-01 11:34:54 +0100) |  (HEAD -> main)
```

If I merge `branchB` before `branchA` like so:
```bash
*   Merge branch 'branchA' - (2023-03-01 11:42:59 +0100) |  (HEAD -> main)
|\
| * feat: I will be merged second - (2023-03-01 11:35:22 +0100) |  (branchA)
* | feat: I will be merged first - (2023-03-01 11:35:51 +0100) |  (branchB)
|/
* feat: initial commit - (2023-03-01 11:34:54 +0100) |
```

I expect the generated changelog to be this:
```bash
## Unreleased

### Feat
- I will be merged second
- I will be merged first
- initial commit
```

I also expect commands like `cz changelog v0.3.0` and `cz changelog v0.2.0..v0.3.0` to produce identical changelogs for `v.0.3.0` (which isn't currently the case - [see issue](https://github.com/commitizen-tools/commitizen/issues/660))

## Steps to Test This Pull Request
1. Initialize an empty repository
2. Create an initial commit "feat: initial commit`
3. Create a new branch `branchA`
4. Create a new branch `branchB`
5. Switch to `branchA`
6. Commit a change `feat: I will be merged second`
7. Switch to `branchB`
8. Commit a change `feat: I will be merged first`
9. Switch to `main`
10. Merge `branchB` into `main`
11. Merge `branchA` into `main`
12. Generate a changelog `cz changelog --dry-run`
13. See that the changes are ordered by their introduction in the codebase
```bash
## Unreleased

### Feat
- I will be merged second
- I will be merged first
- initial commit
```


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
