### PR TITLE
fix: bump changelog for prerelease without commits

### DIFF
--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -90,10 +90,12 @@ def generate_tree_from_commits(
     pat = re.compile(changelog_pattern)
     map_pat = re.compile(commit_parser, re.MULTILINE)
     body_map_pat = re.compile(commit_parser, re.MULTILINE | re.DOTALL)
+    current_tag: Optional[GitTag] = None
 
     # Check if the latest commit is not tagged
-    latest_commit = commits[0]
-    current_tag: Optional[GitTag] = get_commit_tag(latest_commit, tags)
+    if commits:
+        latest_commit = commits[0]
+        current_tag = get_commit_tag(latest_commit, tags)
 
     current_tag_name: str = unreleased_version or "Unreleased"
     current_tag_date: str = ""

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_alpha_alpha_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_alpha_alpha_.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0a1 (2021-06-11)
+
+## 0.2.0a0 (2021-06-11)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_alpha_beta_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_alpha_beta_.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0b0 (2021-06-11)
+
+## 0.2.0a0 (2021-06-11)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_alpha_rc_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_alpha_rc_.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0rc0 (2021-06-11)
+
+## 0.2.0a0 (2021-06-11)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_beta_alpha_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_beta_alpha_.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0a0 (2021-06-11)
+
+## 0.2.0b0 (2021-06-11)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_beta_beta_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_beta_beta_.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0b1 (2021-06-11)
+
+## 0.2.0b0 (2021-06-11)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_beta_rc_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_beta_rc_.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0rc0 (2021-06-11)
+
+## 0.2.0b0 (2021-06-11)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_alpha_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_alpha_.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0a0 (2021-06-11)
+
+## 0.2.0rc0 (2021-06-11)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_beta_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_beta_.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0b0 (2021-06-11)
+
+## 0.2.0rc0 (2021-06-11)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_rc_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_rc_.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.0rc1 (2021-06-11)
+
+## 0.2.0rc0 (2021-06-11)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1083,6 +1083,17 @@ def test_generate_tree_from_commits(gitcommits, tags, merge_prereleases):
         assert tuple(tree) == COMMITS_TREE
 
 
+def test_generate_tree_from_commits_with_no_commits(tags):
+    gitcommits = []
+    parser = defaults.commit_parser
+    changelog_pattern = defaults.bump_pattern
+    tree = changelog.generate_tree_from_commits(
+        gitcommits, tags, parser, changelog_pattern
+    )
+
+    assert tuple(tree) == ({"changes": {}, "date": "", "version": "Unreleased"},)
+
+
 @pytest.mark.parametrize(
     "change_type_order, expected_reordering",
     (


### PR DESCRIPTION
## Description
This changes lets the changelog be generated for version bumps from a prerelease version without new commits, which the `bump` command already allows.


## Checklist

- [X] Add test cases to all the changes you introduce
- [X] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
User should be able to bump a prerelease version and generate a changelog for the new version without adding new commits


## Steps to Test This Pull Request
1. Generate a prerelease version with `bump` command: `cz bump --changelog --prerelease alpha`
2. Generate a new version with `bump` command without adding new commits: `cz bump --changelog [--prerelease beta]`

#### Current behavior:
Fails when attempting to generate the changelog with `--changelog` flag

```shell
$ cz bump --changelog --prerelease alpha --yes
bump: release 0.37.0 → 0.38.0a0

Automatically generated by Commitizen.

tag to create: v0.38.0a0
increment detected: MINOR

[main 013cdd0] bump: release 0.37.0 → 0.38.0a0
 4 files changed, 9 insertions(+), 3 deletions(-)

Done!
$ cz bump --changelog --prerelease rc --yes
bump: release 0.38.0a0 → 0.38.0rc0

Automatically generated by Commitizen.

tag to create: v0.38.0rc0

No commits found
```

#### Expected behavior:
Should bump version and generate changelog with empty change list

```shell
$ cz bump --changelog --prerelease alpha --yes
bump: release 0.37.0 → 0.38.0a0

Automatically generated by Commitizen.

tag to create: v0.38.0a0
increment detected: MINOR

[main 013cdd0] bump: release 0.37.0 → 0.38.0a0
 4 files changed, 9 insertions(+), 3 deletions(-)

Done!
$ cz bump --changelog --prerelease rc --yes
bump: release 0.38.0a0 → 0.38.0rc0

Automatically generated by Commitizen.

tag to create: v0.38.0rc0

[main b7c5999] bump: release 0.38.0a0 → 0.38.0rc0
 4 files changed, 5 insertions(+), 3 deletions(-)

Done!
```



## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
