### PR TITLE
Relax runtime dependency specifications

### DIFF
--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -1,8 +1,12 @@
 import pathlib
+import sys
 from collections import OrderedDict
 from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Tuple, Union
 
-from typing_extensions import TypedDict
+if sys.version_info < (3, 8):
+    from typing_extensions import TypedDict
+else:
+    from typing import TypedDict
 
 # Type
 Questions = Iterable[MutableMapping[str, Any]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,7 @@ python = "^3.6.2"
 questionary = "^1.4.0"
 decli = "^0.5.2"
 colorama = "^0.4.1"
-termcolor = [
-    { "version" = "^1.1", python = "< 3.7" },
-    { "version" = ">= 1.1, < 3", python = ">= 3.7" },
-]
+termcolor = ">=1.1,<3"
 packaging = ">=19"
 tomlkit = ">=0.5.3,<1.0.0"
 jinja2 = ">=2.10.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ tomlkit = ">=0.5.3,<1.0.0"
 jinja2 = ">=2.10.3"
 pyyaml = ">=3.08"
 argcomplete = ">=1.12.1,<2.2"
-typing-extensions = "^4.0.1"
+typing-extensions = { version = "^4.0.1", python = "<3.8" }
 charset-normalizer = ">=2.1.0,<3.1"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,17 +42,8 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: Implementation :: CPython",
 ]
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ jinja2 = ">=2.10.3"
 pyyaml = ">=3.08"
 argcomplete = ">=1.12.1,<2.2"
 typing-extensions = { version = "^4.0.1", python = "<3.8" }
-charset-normalizer = ">=2.1.0,<3.1"
+charset-normalizer = ">=2.1.0,<4"
 
 [tool.poetry.dev-dependencies]
 ipython = "^7.2"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Relaxes overly strict runtime dependency specifications for semver packages.

## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
Allows for `commitizen` to be installed alongside current versions of runtime dependencies.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
Closes #683 