### PR TITLE
fix: correct a typo in the pre-commit hook's exception message

### DIFF
--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -182,7 +182,7 @@ class Init:
 
         if not self._search_pre_commit():
             raise InitFailedError(
-                "pre-commit is not installed in current environement."
+                "pre-commit is not installed in current environment."
             )
         if hook_types is None:
             hook_types = ["commit-msg", "pre-push"]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
This PR fixes a typo in the exception message when the 'cz init' command is invoked, but it fails to install the pre-commit hook.
<!-- Describe what the change is -->


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
The exception message **pre-commit is not installed in the current environment.** should be visible to the user.

## Current behavior
The user sees the exception message **pre-commit is not installed in the current environement**.

<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
