### PR TITLE
test: fix git_sandbox for git<2.33

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,9 +23,14 @@ def git_sandbox(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
             monkeypatch.delenv(var)
 
     # Define a dedicated temporary git config
-    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "gitconfig"))
-    cmd.run(f"git config --global user.name {SIGNER}")
-    cmd.run(f"git config --global user.email {SIGNER_MAIL}")
+    gitconfig = tmp_path / ".git" / "config"
+    if not gitconfig.parent.exists():
+        gitconfig.parent.mkdir()
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+    r = cmd.run(f"git config --file {gitconfig} user.name {SIGNER}")
+    assert r.return_code == 0, r.err
+    r = cmd.run(f"git config --file {gitconfig} user.email {SIGNER_MAIL}")
+    assert r.return_code == 0, r.err
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
for old git like git-2.30 the tests broke my ~/.gitconfig file and created thousands of `name=GitHub` lines

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
I checked the git documentation and worked out a workaround for my situation. I think it should work for a fresh git too
```
ENVIRONMENT
       GIT_CONFIG
           Take the configuration from the given file instead of .git/config. Using the "--global" option forces this to ~/.gitconfig. Using the "--system" option forces this to
           $(prefix)/etc/gitconfig.

       GIT_CONFIG_NOSYSTEM
           Whether to skip reading settings from the system-wide $(prefix)/etc/gitconfig file. See git(1) for details.

       See also the section called “FILES”.
```


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
no touch my ~/.gitconfig


## Steps to Test This Pull Request

run tests 


## Additional context
![image](https://user-images.githubusercontent.com/16043/233029846-d4f03262-9f55-4668-9435-3524e0069e56.png)
```
➜  ~ cat /etc/issue
Debian GNU/Linux 11 \n \l
➜  ~ git --version
git version 2.30.2
```
