### PR TITLE
feat: add --allow-no-commit option

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -371,6 +371,12 @@ data = {
                         "help": "Determine the next version and write to stdout",
                         "default": False,
                     },
+                    {
+                        "name": ["--empty"],
+                        "default": False,
+                        "help": "bump tags without new commits",
+                        "action": "store_true",
+                    },
                 ],
             },
             {

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -372,9 +372,9 @@ data = {
                         "default": False,
                     },
                     {
-                        "name": ["--empty"],
+                        "name": ["--allow-no-commit"],
                         "default": False,
-                        "help": "bump tags without new commits",
+                        "help": "bump version without eligible commits",
                         "action": "store_true",
                     },
                 ],

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -160,6 +160,7 @@ class Bump:
         build_metadata = self.arguments["build_metadata"]
         increment_mode: str = self.arguments["increment_mode"]
         get_next: bool = self.arguments["get_next"]
+        is_empty: bool | None = self.arguments["empty"]
 
         if manual_version:
             if increment:
@@ -250,7 +251,7 @@ class Bump:
 
                 # No commits, there is no need to create an empty tag.
                 # Unless we previously had a prerelease.
-                if not commits and not current_version.is_prerelease:
+                if not commits and not current_version.is_prerelease and not is_empty:
                     raise NoCommitsFoundError(
                         "[NO_COMMITS_FOUND]\nNo new commits found."
                     )
@@ -265,6 +266,10 @@ class Bump:
                     "No commits found to generate a pre-release.\n"
                     "To avoid this error, manually specify the type of increment with `--increment`"
                 )
+
+            # we create an empty PATCH increment for empty tag
+            if increment is None and is_empty:
+                increment = "PATCH"
 
             new_version = current_version.bump(
                 increment,

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -160,7 +160,7 @@ class Bump:
         build_metadata = self.arguments["build_metadata"]
         increment_mode: str = self.arguments["increment_mode"]
         get_next: bool = self.arguments["get_next"]
-        is_empty: bool | None = self.arguments["empty"]
+        allow_no_commit: bool | None = self.arguments["allow_no_commit"]
 
         if manual_version:
             if increment:
@@ -251,7 +251,11 @@ class Bump:
 
                 # No commits, there is no need to create an empty tag.
                 # Unless we previously had a prerelease.
-                if not commits and not current_version.is_prerelease and not is_empty:
+                if (
+                    not commits
+                    and not current_version.is_prerelease
+                    and not allow_no_commit
+                ):
                     raise NoCommitsFoundError(
                         "[NO_COMMITS_FOUND]\nNo new commits found."
                     )
@@ -268,7 +272,7 @@ class Bump:
                 )
 
             # we create an empty PATCH increment for empty tag
-            if increment is None and is_empty:
+            if increment is None and allow_no_commit:
                 increment = "PATCH"
 
             new_version = current_version.bump(

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -52,7 +52,6 @@ Some examples of pep440:
 
 ![cz bump --help](../images/cli_help/cz_bump___help.svg)
 
-
 ### `--files-only`
 
 Bumps the version in the files defined in `version_files` without creating a commit and tag on the git repository,
@@ -178,6 +177,7 @@ If `--local-version` is used, it will bump only the local version `0.1.0` and ke
 If `--annotated-tag` is used, commitizen will create annotated tags. Also available via configuration, in `pyproject.toml` or `.cz.toml`.
 
 ### `--annotated-tag-message`
+
 If `--annotated-tag-message` is used, commitizen will create annotated tags with the given message.
 
 ### `--changelog-to-stdout`
@@ -276,14 +276,14 @@ cz bump --build-metadata yourmetadata
 
 Will create a version like `1.1.2+yourmetadata`.
 This can be useful for multiple things
-* Git hash in version
-* Labeling the version with additional metadata.
+- Git hash in version
+- Labeling the version with additional metadata.
 
 Note that Commitizen ignores everything after `+` when it bumps the version. It is therefore safe to write different build-metadata between versions.
 
 You should normally not use this functionality, but if you decide to do, keep in mind that
-* Version `1.2.3+a`, and `1.2.3+b` are the same version! Tools should not use the string after `+` for version calculation. This is probably not a guarantee (example in helm) even tho it is in the spec.
-* It might be problematic having the metadata in place when doing upgrades depending on what tool you use.
+- Version `1.2.3+a`, and `1.2.3+b` are the same version! Tools should not use the string after `+` for version calculation. This is probably not a guarantee (example in helm) even tho it is in the spec.
+- It might be problematic having the metadata in place when doing upgrades depending on what tool you use.
 
 ### `--get-next`
 
@@ -317,6 +317,18 @@ The following output is the result of `cz bump --get-next`:
 The `--get-next` flag will raise a `NoneIncrementExit` if the found commits are not eligible for a version bump.
 
 For information on how to suppress this exit, see [avoid raising errors](#avoid-raising-errors).
+
+### `--allow-no-commit`
+
+Allow the project version to be bumped even when there's no eligible version. This is most useful when used with `--increment {MAJOR,MINOR,PATCH}` or `[MANUL_VERSION]`
+
+```sh
+# bump a minor version even when there's only bug fixes, documentation changes or even no commits
+cz bump --incremental MINOR --allow-no-commit
+
+# bump version to 2.0.0 even when there's no breaking changes changes or even no commits
+cz bump --allow-no-commit 2.0.0
+```
 
 ## Avoid raising errors
 
@@ -389,13 +401,13 @@ cz -nr 21 bump
 
 These are used in:
 
-* `cz bump`: Find previous release tag (exact match) and generate new tag.
-* Find previous release tags in `cz changelog`.
-  * If `--incremental`: Using latest version found in the changelog, scan existing Git tags with 89\% similarity match.
-  * `--rev-range` is converted to Git tag names with `tag_format` before searching Git history.
-* If the `scm` `version_provider` is used, it uses different regexes to find the previous version tags:
-  * If `tag_format` is set to `$version` (default): `VersionProtocol.parser` (allows `v` prefix)
-  * If `tag_format` is set: Custom regex similar to SemVer (not as lenient as PEP440 e.g. on dev-releases)
+- `cz bump`: Find previous release tag (exact match) and generate new tag.
+- Find previous release tags in `cz changelog`.
+  - If `--incremental`: Using latest version found in the changelog, scan existing Git tags with 89\% similarity match.
+  - `--rev-range` is converted to Git tag names with `tag_format` before searching Git history.
+- If the `scm` `version_provider` is used, it uses different regexes to find the previous version tags:
+  - If `tag_format` is set to `$version` (default): `VersionProtocol.parser` (allows `v` prefix)
+  - If `tag_format` is set: Custom regex similar to SemVer (not as lenient as PEP440 e.g. on dev-releases)
 
 Commitizen supports 2 types of formats, a simple and a more complex.
 

--- a/docs/images/cli_help/cz___help.svg
+++ b/docs/images/cli_help/cz___help.svg
@@ -19,133 +19,133 @@
         font-weight: 700;
     }
 
-    .terminal-2205183093-matrix {
+    .terminal-4198725382-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-2205183093-title {
+    .terminal-4198725382-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-2205183093-r1 { fill: #c5c8c6 }
-.terminal-2205183093-r2 { fill: #c5c8c6;font-weight: bold }
-.terminal-2205183093-r3 { fill: #d0b344 }
-.terminal-2205183093-r4 { fill: #1984e9;text-decoration: underline; }
-.terminal-2205183093-r5 { fill: #68a0b3;font-weight: bold }
+    .terminal-4198725382-r1 { fill: #c5c8c6 }
+.terminal-4198725382-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-4198725382-r3 { fill: #d0b344 }
+.terminal-4198725382-r4 { fill: #1984e9;text-decoration: underline; }
+.terminal-4198725382-r5 { fill: #68a0b3;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-2205183093-clip-terminal">
+    <clipPath id="terminal-4198725382-clip-terminal">
       <rect x="0" y="0" width="975.0" height="877.4" />
     </clipPath>
-    <clipPath id="terminal-2205183093-line-0">
+    <clipPath id="terminal-4198725382-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-1">
+<clipPath id="terminal-4198725382-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-2">
+<clipPath id="terminal-4198725382-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-3">
+<clipPath id="terminal-4198725382-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-4">
+<clipPath id="terminal-4198725382-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-5">
+<clipPath id="terminal-4198725382-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-6">
+<clipPath id="terminal-4198725382-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-7">
+<clipPath id="terminal-4198725382-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-8">
+<clipPath id="terminal-4198725382-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-9">
+<clipPath id="terminal-4198725382-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-10">
+<clipPath id="terminal-4198725382-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-11">
+<clipPath id="terminal-4198725382-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-12">
+<clipPath id="terminal-4198725382-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-13">
+<clipPath id="terminal-4198725382-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-14">
+<clipPath id="terminal-4198725382-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-15">
+<clipPath id="terminal-4198725382-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-16">
+<clipPath id="terminal-4198725382-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-17">
+<clipPath id="terminal-4198725382-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-18">
+<clipPath id="terminal-4198725382-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-19">
+<clipPath id="terminal-4198725382-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-20">
+<clipPath id="terminal-4198725382-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-21">
+<clipPath id="terminal-4198725382-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-22">
+<clipPath id="terminal-4198725382-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-23">
+<clipPath id="terminal-4198725382-line-23">
     <rect x="0" y="562.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-24">
+<clipPath id="terminal-4198725382-line-24">
     <rect x="0" y="587.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-25">
+<clipPath id="terminal-4198725382-line-25">
     <rect x="0" y="611.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-26">
+<clipPath id="terminal-4198725382-line-26">
     <rect x="0" y="635.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-27">
+<clipPath id="terminal-4198725382-line-27">
     <rect x="0" y="660.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-28">
+<clipPath id="terminal-4198725382-line-28">
     <rect x="0" y="684.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-29">
+<clipPath id="terminal-4198725382-line-29">
     <rect x="0" y="709.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-30">
+<clipPath id="terminal-4198725382-line-30">
     <rect x="0" y="733.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-31">
+<clipPath id="terminal-4198725382-line-31">
     <rect x="0" y="757.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-32">
+<clipPath id="terminal-4198725382-line-32">
     <rect x="0" y="782.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-33">
+<clipPath id="terminal-4198725382-line-33">
     <rect x="0" y="806.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-2205183093-line-34">
+<clipPath id="terminal-4198725382-line-34">
     <rect x="0" y="831.1" width="976" height="24.65"/>
             </clipPath>
     </defs>
@@ -157,45 +157,45 @@
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-2205183093-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-4198725382-clip-terminal)">
     
-    <g class="terminal-2205183093-matrix">
-    <text class="terminal-2205183093-r1" x="0" y="20" textLength="134.2" clip-path="url(#terminal-2205183093-line-0)">$&#160;cz&#160;--help</text><text class="terminal-2205183093-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2205183093-line-0)">
-</text><text class="terminal-2205183093-r1" x="0" y="44.4" textLength="122" clip-path="url(#terminal-2205183093-line-1)">usage:&#160;cz&#160;</text><text class="terminal-2205183093-r2" x="122" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">[</text><text class="terminal-2205183093-r1" x="134.2" y="44.4" textLength="24.4" clip-path="url(#terminal-2205183093-line-1)">-h</text><text class="terminal-2205183093-r2" x="158.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">]</text><text class="terminal-2205183093-r2" x="183" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">[</text><text class="terminal-2205183093-r1" x="195.2" y="44.4" textLength="183" clip-path="url(#terminal-2205183093-line-1)">--config&#160;CONFIG</text><text class="terminal-2205183093-r2" x="378.2" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">]</text><text class="terminal-2205183093-r2" x="402.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">[</text><text class="terminal-2205183093-r1" x="414.8" y="44.4" textLength="85.4" clip-path="url(#terminal-2205183093-line-1)">--debug</text><text class="terminal-2205183093-r2" x="500.2" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">]</text><text class="terminal-2205183093-r2" x="524.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">[</text><text class="terminal-2205183093-r1" x="536.8" y="44.4" textLength="85.4" clip-path="url(#terminal-2205183093-line-1)">-n&#160;NAME</text><text class="terminal-2205183093-r2" x="622.2" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">]</text><text class="terminal-2205183093-r2" x="646.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">[</text><text class="terminal-2205183093-r1" x="658.8" y="44.4" textLength="146.4" clip-path="url(#terminal-2205183093-line-1)">-nr&#160;NO_RAISE</text><text class="terminal-2205183093-r2" x="805.2" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">]</text><text class="terminal-2205183093-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-1)">
-</text><text class="terminal-2205183093-r2" x="122" y="68.8" textLength="12.2" clip-path="url(#terminal-2205183093-line-2)">{</text><text class="terminal-2205183093-r1" x="134.2" y="68.8" textLength="829.6" clip-path="url(#terminal-2205183093-line-2)">init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version</text><text class="terminal-2205183093-r2" x="963.8" y="68.8" textLength="12.2" clip-path="url(#terminal-2205183093-line-2)">}</text><text class="terminal-2205183093-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2205183093-line-2)">
-</text><text class="terminal-2205183093-r3" x="0" y="93.2" textLength="36.6" clip-path="url(#terminal-2205183093-line-3)">...</text><text class="terminal-2205183093-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-3)">
-</text><text class="terminal-2205183093-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-4)">
-</text><text class="terminal-2205183093-r1" x="0" y="142" textLength="707.6" clip-path="url(#terminal-2205183093-line-5)">Commitizen&#160;is&#160;a&#160;cli&#160;tool&#160;to&#160;generate&#160;conventional&#160;commits.</text><text class="terminal-2205183093-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2205183093-line-5)">
-</text><text class="terminal-2205183093-r1" x="0" y="166.4" textLength="524.6" clip-path="url(#terminal-2205183093-line-6)">For&#160;more&#160;information&#160;about&#160;the&#160;topic&#160;go&#160;to&#160;</text><text class="terminal-2205183093-r4" x="524.6" y="166.4" textLength="390.4" clip-path="url(#terminal-2205183093-line-6)">https://conventionalcommits.org/</text><text class="terminal-2205183093-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-6)">
-</text><text class="terminal-2205183093-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2205183093-line-7)">
-</text><text class="terminal-2205183093-r1" x="0" y="215.2" textLength="97.6" clip-path="url(#terminal-2205183093-line-8)">options:</text><text class="terminal-2205183093-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-8)">
-</text><text class="terminal-2205183093-r1" x="0" y="239.6" textLength="671" clip-path="url(#terminal-2205183093-line-9)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-2205183093-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-9)">
-</text><text class="terminal-2205183093-r1" x="0" y="264" textLength="658.8" clip-path="url(#terminal-2205183093-line-10)">&#160;&#160;--config&#160;CONFIG&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;path&#160;of&#160;configuration&#160;file</text><text class="terminal-2205183093-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2205183093-line-10)">
-</text><text class="terminal-2205183093-r1" x="0" y="288.4" textLength="463.6" clip-path="url(#terminal-2205183093-line-11)">&#160;&#160;--debug&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;use&#160;debug&#160;mode</text><text class="terminal-2205183093-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-11)">
-</text><text class="terminal-2205183093-r1" x="0" y="312.8" textLength="597.8" clip-path="url(#terminal-2205183093-line-12)">&#160;&#160;-n,&#160;--name&#160;NAME&#160;&#160;&#160;&#160;&#160;&#160;&#160;use&#160;the&#160;given&#160;commitizen&#160;</text><text class="terminal-2205183093-r2" x="597.8" y="312.8" textLength="12.2" clip-path="url(#terminal-2205183093-line-12)">(</text><text class="terminal-2205183093-r1" x="610" y="312.8" textLength="97.6" clip-path="url(#terminal-2205183093-line-12)">default:</text><text class="terminal-2205183093-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2205183093-line-12)">
-</text><text class="terminal-2205183093-r1" x="0" y="337.2" textLength="573.4" clip-path="url(#terminal-2205183093-line-13)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;cz_conventional_commits</text><text class="terminal-2205183093-r2" x="573.4" y="337.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-13)">)</text><text class="terminal-2205183093-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-13)">
-</text><text class="terminal-2205183093-r1" x="0" y="361.6" textLength="317.2" clip-path="url(#terminal-2205183093-line-14)">&#160;&#160;-nr,&#160;--no-raise&#160;NO_RAISE</text><text class="terminal-2205183093-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-14)">
-</text><text class="terminal-2205183093-r1" x="0" y="386" textLength="902.8" clip-path="url(#terminal-2205183093-line-15)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;comma&#160;separated&#160;error&#160;codes&#160;that&#160;won&#x27;t&#160;rise&#160;error,</text><text class="terminal-2205183093-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2205183093-line-15)">
-</text><text class="terminal-2205183093-r1" x="0" y="410.4" textLength="439.2" clip-path="url(#terminal-2205183093-line-16)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;e.g:&#160;cz&#160;-nr&#160;</text><text class="terminal-2205183093-r5" x="439.2" y="410.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-16)">1</text><text class="terminal-2205183093-r1" x="451.4" y="410.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-16)">,</text><text class="terminal-2205183093-r5" x="463.6" y="410.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-16)">2</text><text class="terminal-2205183093-r1" x="475.8" y="410.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-16)">,</text><text class="terminal-2205183093-r5" x="488" y="410.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-16)">3</text><text class="terminal-2205183093-r1" x="500.2" y="410.4" textLength="231.8" clip-path="url(#terminal-2205183093-line-16)">&#160;bump.&#160;See&#160;codes&#160;at</text><text class="terminal-2205183093-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-16)">
-</text><text class="terminal-2205183093-r4" x="292.8" y="434.8" textLength="231.8" clip-path="url(#terminal-2205183093-line-17)">https://commitizen-</text><text class="terminal-2205183093-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2205183093-line-17)">
-</text><text class="terminal-2205183093-r1" x="0" y="459.2" textLength="756.4" clip-path="url(#terminal-2205183093-line-18)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;tools.github.io/commitizen/exit_codes/</text><text class="terminal-2205183093-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-18)">
-</text><text class="terminal-2205183093-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-19)">
-</text><text class="terminal-2205183093-r1" x="0" y="508" textLength="109.8" clip-path="url(#terminal-2205183093-line-20)">commands:</text><text class="terminal-2205183093-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2205183093-line-20)">
-</text><text class="terminal-2205183093-r2" x="24.4" y="532.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-21)">{</text><text class="terminal-2205183093-r1" x="36.6" y="532.4" textLength="829.6" clip-path="url(#terminal-2205183093-line-21)">init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version</text><text class="terminal-2205183093-r2" x="866.2" y="532.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-21)">}</text><text class="terminal-2205183093-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-21)">
-</text><text class="terminal-2205183093-r1" x="0" y="556.8" textLength="646.6" clip-path="url(#terminal-2205183093-line-22)">&#160;&#160;&#160;&#160;init&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;init&#160;commitizen&#160;configuration</text><text class="terminal-2205183093-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2205183093-line-22)">
-</text><text class="terminal-2205183093-r1" x="0" y="581.2" textLength="134.2" clip-path="url(#terminal-2205183093-line-23)">&#160;&#160;&#160;&#160;commit&#160;</text><text class="terminal-2205183093-r2" x="134.2" y="581.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-23)">(</text><text class="terminal-2205183093-r1" x="146.4" y="581.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-23)">c</text><text class="terminal-2205183093-r2" x="158.6" y="581.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-23)">)</text><text class="terminal-2205183093-r1" x="170.8" y="581.2" textLength="329.4" clip-path="url(#terminal-2205183093-line-23)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;create&#160;new&#160;commit</text><text class="terminal-2205183093-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-23)">
-</text><text class="terminal-2205183093-r1" x="0" y="605.6" textLength="610" clip-path="url(#terminal-2205183093-line-24)">&#160;&#160;&#160;&#160;ls&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;available&#160;commitizens</text><text class="terminal-2205183093-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-24)">
-</text><text class="terminal-2205183093-r1" x="0" y="630" textLength="524.6" clip-path="url(#terminal-2205183093-line-25)">&#160;&#160;&#160;&#160;example&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;commit&#160;example</text><text class="terminal-2205183093-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-2205183093-line-25)">
-</text><text class="terminal-2205183093-r1" x="0" y="654.4" textLength="646.6" clip-path="url(#terminal-2205183093-line-26)">&#160;&#160;&#160;&#160;info&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;information&#160;about&#160;the&#160;cz</text><text class="terminal-2205183093-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-26)">
-</text><text class="terminal-2205183093-r1" x="0" y="678.8" textLength="512.4" clip-path="url(#terminal-2205183093-line-27)">&#160;&#160;&#160;&#160;schema&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;commit&#160;schema</text><text class="terminal-2205183093-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-2205183093-line-27)">
-</text><text class="terminal-2205183093-r1" x="0" y="703.2" textLength="805.2" clip-path="url(#terminal-2205183093-line-28)">&#160;&#160;&#160;&#160;bump&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;semantic&#160;version&#160;based&#160;on&#160;the&#160;git&#160;log</text><text class="terminal-2205183093-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-28)">
-</text><text class="terminal-2205183093-r1" x="0" y="727.6" textLength="170.8" clip-path="url(#terminal-2205183093-line-29)">&#160;&#160;&#160;&#160;changelog&#160;</text><text class="terminal-2205183093-r2" x="170.8" y="727.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-29)">(</text><text class="terminal-2205183093-r1" x="183" y="727.6" textLength="24.4" clip-path="url(#terminal-2205183093-line-29)">ch</text><text class="terminal-2205183093-r2" x="207.4" y="727.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-29)">)</text><text class="terminal-2205183093-r1" x="219.6" y="727.6" textLength="305" clip-path="url(#terminal-2205183093-line-29)">&#160;&#160;&#160;&#160;&#160;&#160;generate&#160;changelog&#160;</text><text class="terminal-2205183093-r2" x="524.6" y="727.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-29)">(</text><text class="terminal-2205183093-r1" x="536.8" y="727.6" textLength="329.4" clip-path="url(#terminal-2205183093-line-29)">note&#160;that&#160;it&#160;will&#160;overwrite</text><text class="terminal-2205183093-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-29)">
-</text><text class="terminal-2205183093-r1" x="0" y="752" textLength="451.4" clip-path="url(#terminal-2205183093-line-30)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;existing&#160;file</text><text class="terminal-2205183093-r2" x="451.4" y="752" textLength="12.2" clip-path="url(#terminal-2205183093-line-30)">)</text><text class="terminal-2205183093-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-2205183093-line-30)">
-</text><text class="terminal-2205183093-r1" x="0" y="776.4" textLength="951.6" clip-path="url(#terminal-2205183093-line-31)">&#160;&#160;&#160;&#160;check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;validates&#160;that&#160;a&#160;commit&#160;message&#160;matches&#160;the&#160;commitizen</text><text class="terminal-2205183093-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-2205183093-line-31)">
-</text><text class="terminal-2205183093-r1" x="0" y="800.8" textLength="366" clip-path="url(#terminal-2205183093-line-32)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;schema</text><text class="terminal-2205183093-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-2205183093-line-32)">
-</text><text class="terminal-2205183093-r1" x="0" y="825.2" textLength="902.8" clip-path="url(#terminal-2205183093-line-33)">&#160;&#160;&#160;&#160;version&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;get&#160;the&#160;version&#160;of&#160;the&#160;installed&#160;commitizen&#160;or&#160;the</text><text class="terminal-2205183093-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-2205183093-line-33)">
-</text><text class="terminal-2205183093-r1" x="0" y="849.6" textLength="488" clip-path="url(#terminal-2205183093-line-34)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;current&#160;project&#160;</text><text class="terminal-2205183093-r2" x="488" y="849.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-34)">(</text><text class="terminal-2205183093-r1" x="500.2" y="849.6" textLength="353.8" clip-path="url(#terminal-2205183093-line-34)">default:&#160;installed&#160;commitizen</text><text class="terminal-2205183093-r2" x="854" y="849.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-34)">)</text><text class="terminal-2205183093-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-2205183093-line-34)">
-</text><text class="terminal-2205183093-r1" x="976" y="874" textLength="12.2" clip-path="url(#terminal-2205183093-line-35)">
+    <g class="terminal-4198725382-matrix">
+    <text class="terminal-4198725382-r1" x="0" y="20" textLength="134.2" clip-path="url(#terminal-4198725382-line-0)">$&#160;cz&#160;--help</text><text class="terminal-4198725382-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-4198725382-line-0)">
+</text><text class="terminal-4198725382-r1" x="0" y="44.4" textLength="122" clip-path="url(#terminal-4198725382-line-1)">usage:&#160;cz&#160;</text><text class="terminal-4198725382-r2" x="122" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">[</text><text class="terminal-4198725382-r1" x="134.2" y="44.4" textLength="24.4" clip-path="url(#terminal-4198725382-line-1)">-h</text><text class="terminal-4198725382-r2" x="158.6" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">]</text><text class="terminal-4198725382-r2" x="183" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">[</text><text class="terminal-4198725382-r1" x="195.2" y="44.4" textLength="183" clip-path="url(#terminal-4198725382-line-1)">--config&#160;CONFIG</text><text class="terminal-4198725382-r2" x="378.2" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">]</text><text class="terminal-4198725382-r2" x="402.6" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">[</text><text class="terminal-4198725382-r1" x="414.8" y="44.4" textLength="85.4" clip-path="url(#terminal-4198725382-line-1)">--debug</text><text class="terminal-4198725382-r2" x="500.2" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">]</text><text class="terminal-4198725382-r2" x="524.6" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">[</text><text class="terminal-4198725382-r1" x="536.8" y="44.4" textLength="85.4" clip-path="url(#terminal-4198725382-line-1)">-n&#160;NAME</text><text class="terminal-4198725382-r2" x="622.2" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">]</text><text class="terminal-4198725382-r2" x="646.6" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">[</text><text class="terminal-4198725382-r1" x="658.8" y="44.4" textLength="146.4" clip-path="url(#terminal-4198725382-line-1)">-nr&#160;NO_RAISE</text><text class="terminal-4198725382-r2" x="805.2" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">]</text><text class="terminal-4198725382-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-1)">
+</text><text class="terminal-4198725382-r2" x="122" y="68.8" textLength="12.2" clip-path="url(#terminal-4198725382-line-2)">{</text><text class="terminal-4198725382-r1" x="134.2" y="68.8" textLength="829.6" clip-path="url(#terminal-4198725382-line-2)">init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version</text><text class="terminal-4198725382-r2" x="963.8" y="68.8" textLength="12.2" clip-path="url(#terminal-4198725382-line-2)">}</text><text class="terminal-4198725382-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-4198725382-line-2)">
+</text><text class="terminal-4198725382-r3" x="122" y="93.2" textLength="36.6" clip-path="url(#terminal-4198725382-line-3)">...</text><text class="terminal-4198725382-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-3)">
+</text><text class="terminal-4198725382-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-4)">
+</text><text class="terminal-4198725382-r1" x="0" y="142" textLength="707.6" clip-path="url(#terminal-4198725382-line-5)">Commitizen&#160;is&#160;a&#160;cli&#160;tool&#160;to&#160;generate&#160;conventional&#160;commits.</text><text class="terminal-4198725382-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-4198725382-line-5)">
+</text><text class="terminal-4198725382-r1" x="0" y="166.4" textLength="524.6" clip-path="url(#terminal-4198725382-line-6)">For&#160;more&#160;information&#160;about&#160;the&#160;topic&#160;go&#160;to&#160;</text><text class="terminal-4198725382-r4" x="524.6" y="166.4" textLength="390.4" clip-path="url(#terminal-4198725382-line-6)">https://conventionalcommits.org/</text><text class="terminal-4198725382-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-6)">
+</text><text class="terminal-4198725382-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-4198725382-line-7)">
+</text><text class="terminal-4198725382-r1" x="0" y="215.2" textLength="97.6" clip-path="url(#terminal-4198725382-line-8)">options:</text><text class="terminal-4198725382-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-8)">
+</text><text class="terminal-4198725382-r1" x="0" y="239.6" textLength="671" clip-path="url(#terminal-4198725382-line-9)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-4198725382-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-9)">
+</text><text class="terminal-4198725382-r1" x="0" y="264" textLength="658.8" clip-path="url(#terminal-4198725382-line-10)">&#160;&#160;--config&#160;CONFIG&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;path&#160;of&#160;configuration&#160;file</text><text class="terminal-4198725382-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-4198725382-line-10)">
+</text><text class="terminal-4198725382-r1" x="0" y="288.4" textLength="463.6" clip-path="url(#terminal-4198725382-line-11)">&#160;&#160;--debug&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;use&#160;debug&#160;mode</text><text class="terminal-4198725382-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-11)">
+</text><text class="terminal-4198725382-r1" x="0" y="312.8" textLength="597.8" clip-path="url(#terminal-4198725382-line-12)">&#160;&#160;-n&#160;NAME,&#160;--name&#160;NAME&#160;&#160;use&#160;the&#160;given&#160;commitizen&#160;</text><text class="terminal-4198725382-r2" x="597.8" y="312.8" textLength="12.2" clip-path="url(#terminal-4198725382-line-12)">(</text><text class="terminal-4198725382-r1" x="610" y="312.8" textLength="97.6" clip-path="url(#terminal-4198725382-line-12)">default:</text><text class="terminal-4198725382-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-4198725382-line-12)">
+</text><text class="terminal-4198725382-r1" x="0" y="337.2" textLength="573.4" clip-path="url(#terminal-4198725382-line-13)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;cz_conventional_commits</text><text class="terminal-4198725382-r2" x="573.4" y="337.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-13)">)</text><text class="terminal-4198725382-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-13)">
+</text><text class="terminal-4198725382-r1" x="0" y="361.6" textLength="427" clip-path="url(#terminal-4198725382-line-14)">&#160;&#160;-nr&#160;NO_RAISE,&#160;--no-raise&#160;NO_RAISE</text><text class="terminal-4198725382-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-14)">
+</text><text class="terminal-4198725382-r1" x="0" y="386" textLength="902.8" clip-path="url(#terminal-4198725382-line-15)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;comma&#160;separated&#160;error&#160;codes&#160;that&#160;won&#x27;t&#160;rise&#160;error,</text><text class="terminal-4198725382-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-4198725382-line-15)">
+</text><text class="terminal-4198725382-r1" x="0" y="410.4" textLength="439.2" clip-path="url(#terminal-4198725382-line-16)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;e.g:&#160;cz&#160;-nr&#160;</text><text class="terminal-4198725382-r5" x="439.2" y="410.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-16)">1</text><text class="terminal-4198725382-r1" x="451.4" y="410.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-16)">,</text><text class="terminal-4198725382-r5" x="463.6" y="410.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-16)">2</text><text class="terminal-4198725382-r1" x="475.8" y="410.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-16)">,</text><text class="terminal-4198725382-r5" x="488" y="410.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-16)">3</text><text class="terminal-4198725382-r1" x="500.2" y="410.4" textLength="231.8" clip-path="url(#terminal-4198725382-line-16)">&#160;bump.&#160;See&#160;codes&#160;at</text><text class="terminal-4198725382-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-16)">
+</text><text class="terminal-4198725382-r4" x="292.8" y="434.8" textLength="231.8" clip-path="url(#terminal-4198725382-line-17)">https://commitizen-</text><text class="terminal-4198725382-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-4198725382-line-17)">
+</text><text class="terminal-4198725382-r1" x="0" y="459.2" textLength="756.4" clip-path="url(#terminal-4198725382-line-18)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;tools.github.io/commitizen/exit_codes/</text><text class="terminal-4198725382-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-18)">
+</text><text class="terminal-4198725382-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-19)">
+</text><text class="terminal-4198725382-r1" x="0" y="508" textLength="109.8" clip-path="url(#terminal-4198725382-line-20)">commands:</text><text class="terminal-4198725382-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-4198725382-line-20)">
+</text><text class="terminal-4198725382-r2" x="24.4" y="532.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-21)">{</text><text class="terminal-4198725382-r1" x="36.6" y="532.4" textLength="829.6" clip-path="url(#terminal-4198725382-line-21)">init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version</text><text class="terminal-4198725382-r2" x="866.2" y="532.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-21)">}</text><text class="terminal-4198725382-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-21)">
+</text><text class="terminal-4198725382-r1" x="0" y="556.8" textLength="646.6" clip-path="url(#terminal-4198725382-line-22)">&#160;&#160;&#160;&#160;init&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;init&#160;commitizen&#160;configuration</text><text class="terminal-4198725382-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-4198725382-line-22)">
+</text><text class="terminal-4198725382-r1" x="0" y="581.2" textLength="134.2" clip-path="url(#terminal-4198725382-line-23)">&#160;&#160;&#160;&#160;commit&#160;</text><text class="terminal-4198725382-r2" x="134.2" y="581.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-23)">(</text><text class="terminal-4198725382-r1" x="146.4" y="581.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-23)">c</text><text class="terminal-4198725382-r2" x="158.6" y="581.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-23)">)</text><text class="terminal-4198725382-r1" x="170.8" y="581.2" textLength="329.4" clip-path="url(#terminal-4198725382-line-23)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;create&#160;new&#160;commit</text><text class="terminal-4198725382-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-23)">
+</text><text class="terminal-4198725382-r1" x="0" y="605.6" textLength="610" clip-path="url(#terminal-4198725382-line-24)">&#160;&#160;&#160;&#160;ls&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;available&#160;commitizens</text><text class="terminal-4198725382-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-24)">
+</text><text class="terminal-4198725382-r1" x="0" y="630" textLength="524.6" clip-path="url(#terminal-4198725382-line-25)">&#160;&#160;&#160;&#160;example&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;commit&#160;example</text><text class="terminal-4198725382-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-4198725382-line-25)">
+</text><text class="terminal-4198725382-r1" x="0" y="654.4" textLength="646.6" clip-path="url(#terminal-4198725382-line-26)">&#160;&#160;&#160;&#160;info&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;information&#160;about&#160;the&#160;cz</text><text class="terminal-4198725382-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-26)">
+</text><text class="terminal-4198725382-r1" x="0" y="678.8" textLength="512.4" clip-path="url(#terminal-4198725382-line-27)">&#160;&#160;&#160;&#160;schema&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;commit&#160;schema</text><text class="terminal-4198725382-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-4198725382-line-27)">
+</text><text class="terminal-4198725382-r1" x="0" y="703.2" textLength="805.2" clip-path="url(#terminal-4198725382-line-28)">&#160;&#160;&#160;&#160;bump&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;semantic&#160;version&#160;based&#160;on&#160;the&#160;git&#160;log</text><text class="terminal-4198725382-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-28)">
+</text><text class="terminal-4198725382-r1" x="0" y="727.6" textLength="170.8" clip-path="url(#terminal-4198725382-line-29)">&#160;&#160;&#160;&#160;changelog&#160;</text><text class="terminal-4198725382-r2" x="170.8" y="727.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-29)">(</text><text class="terminal-4198725382-r1" x="183" y="727.6" textLength="24.4" clip-path="url(#terminal-4198725382-line-29)">ch</text><text class="terminal-4198725382-r2" x="207.4" y="727.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-29)">)</text><text class="terminal-4198725382-r1" x="219.6" y="727.6" textLength="305" clip-path="url(#terminal-4198725382-line-29)">&#160;&#160;&#160;&#160;&#160;&#160;generate&#160;changelog&#160;</text><text class="terminal-4198725382-r2" x="524.6" y="727.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-29)">(</text><text class="terminal-4198725382-r1" x="536.8" y="727.6" textLength="329.4" clip-path="url(#terminal-4198725382-line-29)">note&#160;that&#160;it&#160;will&#160;overwrite</text><text class="terminal-4198725382-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-29)">
+</text><text class="terminal-4198725382-r1" x="0" y="752" textLength="451.4" clip-path="url(#terminal-4198725382-line-30)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;existing&#160;file</text><text class="terminal-4198725382-r2" x="451.4" y="752" textLength="12.2" clip-path="url(#terminal-4198725382-line-30)">)</text><text class="terminal-4198725382-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-4198725382-line-30)">
+</text><text class="terminal-4198725382-r1" x="0" y="776.4" textLength="951.6" clip-path="url(#terminal-4198725382-line-31)">&#160;&#160;&#160;&#160;check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;validates&#160;that&#160;a&#160;commit&#160;message&#160;matches&#160;the&#160;commitizen</text><text class="terminal-4198725382-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-4198725382-line-31)">
+</text><text class="terminal-4198725382-r1" x="0" y="800.8" textLength="366" clip-path="url(#terminal-4198725382-line-32)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;schema</text><text class="terminal-4198725382-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-4198725382-line-32)">
+</text><text class="terminal-4198725382-r1" x="0" y="825.2" textLength="902.8" clip-path="url(#terminal-4198725382-line-33)">&#160;&#160;&#160;&#160;version&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;get&#160;the&#160;version&#160;of&#160;the&#160;installed&#160;commitizen&#160;or&#160;the</text><text class="terminal-4198725382-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-4198725382-line-33)">
+</text><text class="terminal-4198725382-r1" x="0" y="849.6" textLength="488" clip-path="url(#terminal-4198725382-line-34)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;current&#160;project&#160;</text><text class="terminal-4198725382-r2" x="488" y="849.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-34)">(</text><text class="terminal-4198725382-r1" x="500.2" y="849.6" textLength="353.8" clip-path="url(#terminal-4198725382-line-34)">default:&#160;installed&#160;commitizen</text><text class="terminal-4198725382-r2" x="854" y="849.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-34)">)</text><text class="terminal-4198725382-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-4198725382-line-34)">
+</text><text class="terminal-4198725382-r1" x="976" y="874" textLength="12.2" clip-path="url(#terminal-4198725382-line-35)">
 </text>
     </g>
     </g>

--- a/docs/images/cli_help/cz_bump___help.svg
+++ b/docs/images/cli_help/cz_bump___help.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 994 2026.3999999999999" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 2099.6" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,362 +19,374 @@
         font-weight: 700;
     }
 
-    .terminal-3254289243-matrix {
+    .terminal-2232203-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3254289243-title {
+    .terminal-2232203-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3254289243-r1 { fill: #c5c8c6 }
-.terminal-3254289243-r2 { fill: #c5c8c6;font-weight: bold }
-.terminal-3254289243-r3 { fill: #68a0b3;font-weight: bold }
-.terminal-3254289243-r4 { fill: #98a84b }
+    .terminal-2232203-r1 { fill: #c5c8c6 }
+.terminal-2232203-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-2232203-r3 { fill: #68a0b3;font-weight: bold }
+.terminal-2232203-r4 { fill: #98a84b }
     </style>
 
     <defs>
-    <clipPath id="terminal-3254289243-clip-terminal">
-      <rect x="0" y="0" width="975.0" height="1975.3999999999999" />
+    <clipPath id="terminal-2232203-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="2048.6" />
     </clipPath>
-    <clipPath id="terminal-3254289243-line-0">
+    <clipPath id="terminal-2232203-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-1">
+<clipPath id="terminal-2232203-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-2">
+<clipPath id="terminal-2232203-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-3">
+<clipPath id="terminal-2232203-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-4">
+<clipPath id="terminal-2232203-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-5">
+<clipPath id="terminal-2232203-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-6">
+<clipPath id="terminal-2232203-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-7">
+<clipPath id="terminal-2232203-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-8">
+<clipPath id="terminal-2232203-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-9">
+<clipPath id="terminal-2232203-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-10">
+<clipPath id="terminal-2232203-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-11">
+<clipPath id="terminal-2232203-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-12">
+<clipPath id="terminal-2232203-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-13">
+<clipPath id="terminal-2232203-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-14">
+<clipPath id="terminal-2232203-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-15">
+<clipPath id="terminal-2232203-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-16">
+<clipPath id="terminal-2232203-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-17">
+<clipPath id="terminal-2232203-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-18">
+<clipPath id="terminal-2232203-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-19">
+<clipPath id="terminal-2232203-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-20">
+<clipPath id="terminal-2232203-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-21">
+<clipPath id="terminal-2232203-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-22">
+<clipPath id="terminal-2232203-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-23">
+<clipPath id="terminal-2232203-line-23">
     <rect x="0" y="562.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-24">
+<clipPath id="terminal-2232203-line-24">
     <rect x="0" y="587.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-25">
+<clipPath id="terminal-2232203-line-25">
     <rect x="0" y="611.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-26">
+<clipPath id="terminal-2232203-line-26">
     <rect x="0" y="635.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-27">
+<clipPath id="terminal-2232203-line-27">
     <rect x="0" y="660.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-28">
+<clipPath id="terminal-2232203-line-28">
     <rect x="0" y="684.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-29">
+<clipPath id="terminal-2232203-line-29">
     <rect x="0" y="709.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-30">
+<clipPath id="terminal-2232203-line-30">
     <rect x="0" y="733.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-31">
+<clipPath id="terminal-2232203-line-31">
     <rect x="0" y="757.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-32">
+<clipPath id="terminal-2232203-line-32">
     <rect x="0" y="782.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-33">
+<clipPath id="terminal-2232203-line-33">
     <rect x="0" y="806.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-34">
+<clipPath id="terminal-2232203-line-34">
     <rect x="0" y="831.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-35">
+<clipPath id="terminal-2232203-line-35">
     <rect x="0" y="855.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-36">
+<clipPath id="terminal-2232203-line-36">
     <rect x="0" y="879.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-37">
+<clipPath id="terminal-2232203-line-37">
     <rect x="0" y="904.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-38">
+<clipPath id="terminal-2232203-line-38">
     <rect x="0" y="928.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-39">
+<clipPath id="terminal-2232203-line-39">
     <rect x="0" y="953.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-40">
+<clipPath id="terminal-2232203-line-40">
     <rect x="0" y="977.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-41">
+<clipPath id="terminal-2232203-line-41">
     <rect x="0" y="1001.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-42">
+<clipPath id="terminal-2232203-line-42">
     <rect x="0" y="1026.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-43">
+<clipPath id="terminal-2232203-line-43">
     <rect x="0" y="1050.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-44">
+<clipPath id="terminal-2232203-line-44">
     <rect x="0" y="1075.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-45">
+<clipPath id="terminal-2232203-line-45">
     <rect x="0" y="1099.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-46">
+<clipPath id="terminal-2232203-line-46">
     <rect x="0" y="1123.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-47">
+<clipPath id="terminal-2232203-line-47">
     <rect x="0" y="1148.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-48">
+<clipPath id="terminal-2232203-line-48">
     <rect x="0" y="1172.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-49">
+<clipPath id="terminal-2232203-line-49">
     <rect x="0" y="1197.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-50">
+<clipPath id="terminal-2232203-line-50">
     <rect x="0" y="1221.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-51">
+<clipPath id="terminal-2232203-line-51">
     <rect x="0" y="1245.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-52">
+<clipPath id="terminal-2232203-line-52">
     <rect x="0" y="1270.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-53">
+<clipPath id="terminal-2232203-line-53">
     <rect x="0" y="1294.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-54">
+<clipPath id="terminal-2232203-line-54">
     <rect x="0" y="1319.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-55">
+<clipPath id="terminal-2232203-line-55">
     <rect x="0" y="1343.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-56">
+<clipPath id="terminal-2232203-line-56">
     <rect x="0" y="1367.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-57">
+<clipPath id="terminal-2232203-line-57">
     <rect x="0" y="1392.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-58">
+<clipPath id="terminal-2232203-line-58">
     <rect x="0" y="1416.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-59">
+<clipPath id="terminal-2232203-line-59">
     <rect x="0" y="1441.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-60">
+<clipPath id="terminal-2232203-line-60">
     <rect x="0" y="1465.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-61">
+<clipPath id="terminal-2232203-line-61">
     <rect x="0" y="1489.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-62">
+<clipPath id="terminal-2232203-line-62">
     <rect x="0" y="1514.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-63">
+<clipPath id="terminal-2232203-line-63">
     <rect x="0" y="1538.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-64">
+<clipPath id="terminal-2232203-line-64">
     <rect x="0" y="1563.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-65">
+<clipPath id="terminal-2232203-line-65">
     <rect x="0" y="1587.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-66">
+<clipPath id="terminal-2232203-line-66">
     <rect x="0" y="1611.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-67">
+<clipPath id="terminal-2232203-line-67">
     <rect x="0" y="1636.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-68">
+<clipPath id="terminal-2232203-line-68">
     <rect x="0" y="1660.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-69">
+<clipPath id="terminal-2232203-line-69">
     <rect x="0" y="1685.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-70">
+<clipPath id="terminal-2232203-line-70">
     <rect x="0" y="1709.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-71">
+<clipPath id="terminal-2232203-line-71">
     <rect x="0" y="1733.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-72">
+<clipPath id="terminal-2232203-line-72">
     <rect x="0" y="1758.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-73">
+<clipPath id="terminal-2232203-line-73">
     <rect x="0" y="1782.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-74">
+<clipPath id="terminal-2232203-line-74">
     <rect x="0" y="1807.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-75">
+<clipPath id="terminal-2232203-line-75">
     <rect x="0" y="1831.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-76">
+<clipPath id="terminal-2232203-line-76">
     <rect x="0" y="1855.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-77">
+<clipPath id="terminal-2232203-line-77">
     <rect x="0" y="1880.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-78">
+<clipPath id="terminal-2232203-line-78">
     <rect x="0" y="1904.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3254289243-line-79">
+<clipPath id="terminal-2232203-line-79">
     <rect x="0" y="1929.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2232203-line-80">
+    <rect x="0" y="1953.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2232203-line-81">
+    <rect x="0" y="1977.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2232203-line-82">
+    <rect x="0" y="2002.3" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="2024.4" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="2097.6" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3254289243-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2232203-clip-terminal)">
     
-    <g class="terminal-3254289243-matrix">
-    <text class="terminal-3254289243-r1" x="0" y="20" textLength="195.2" clip-path="url(#terminal-3254289243-line-0)">$&#160;cz&#160;bump&#160;--help</text><text class="terminal-3254289243-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3254289243-line-0)">
-</text><text class="terminal-3254289243-r1" x="0" y="44.4" textLength="183" clip-path="url(#terminal-3254289243-line-1)">usage:&#160;cz&#160;bump&#160;</text><text class="terminal-3254289243-r2" x="183" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">[</text><text class="terminal-3254289243-r1" x="195.2" y="44.4" textLength="24.4" clip-path="url(#terminal-3254289243-line-1)">-h</text><text class="terminal-3254289243-r2" x="219.6" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">]</text><text class="terminal-3254289243-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">[</text><text class="terminal-3254289243-r1" x="256.2" y="44.4" textLength="109.8" clip-path="url(#terminal-3254289243-line-1)">--dry-run</text><text class="terminal-3254289243-r2" x="366" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">]</text><text class="terminal-3254289243-r2" x="390.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">[</text><text class="terminal-3254289243-r1" x="402.6" y="44.4" textLength="146.4" clip-path="url(#terminal-3254289243-line-1)">--files-only</text><text class="terminal-3254289243-r2" x="549" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">]</text><text class="terminal-3254289243-r2" x="573.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">[</text><text class="terminal-3254289243-r1" x="585.6" y="44.4" textLength="183" clip-path="url(#terminal-3254289243-line-1)">--local-version</text><text class="terminal-3254289243-r2" x="768.6" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">]</text><text class="terminal-3254289243-r2" x="793" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">[</text><text class="terminal-3254289243-r1" x="805.2" y="44.4" textLength="134.2" clip-path="url(#terminal-3254289243-line-1)">--changelog</text><text class="terminal-3254289243-r2" x="939.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">]</text><text class="terminal-3254289243-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-1)">
-</text><text class="terminal-3254289243-r2" x="183" y="68.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-2)">[</text><text class="terminal-3254289243-r1" x="195.2" y="68.8" textLength="134.2" clip-path="url(#terminal-3254289243-line-2)">--no-verify</text><text class="terminal-3254289243-r2" x="329.4" y="68.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-2)">]</text><text class="terminal-3254289243-r2" x="353.8" y="68.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-2)">[</text><text class="terminal-3254289243-r1" x="366" y="68.8" textLength="61" clip-path="url(#terminal-3254289243-line-2)">--yes</text><text class="terminal-3254289243-r2" x="427" y="68.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-2)">]</text><text class="terminal-3254289243-r2" x="451.4" y="68.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-2)">[</text><text class="terminal-3254289243-r1" x="463.6" y="68.8" textLength="280.6" clip-path="url(#terminal-3254289243-line-2)">--tag-format&#160;TAG_FORMAT</text><text class="terminal-3254289243-r2" x="744.2" y="68.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-2)">]</text><text class="terminal-3254289243-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-2)">
-</text><text class="terminal-3254289243-r2" x="183" y="93.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-3)">[</text><text class="terminal-3254289243-r1" x="195.2" y="93.2" textLength="329.4" clip-path="url(#terminal-3254289243-line-3)">--bump-message&#160;BUMP_MESSAGE</text><text class="terminal-3254289243-r2" x="524.6" y="93.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-3)">]</text><text class="terminal-3254289243-r2" x="549" y="93.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-3)">[</text><text class="terminal-3254289243-r1" x="561.2" y="93.2" textLength="158.6" clip-path="url(#terminal-3254289243-line-3)">--prerelease&#160;</text><text class="terminal-3254289243-r2" x="719.8" y="93.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-3)">{</text><text class="terminal-3254289243-r1" x="732" y="93.2" textLength="158.6" clip-path="url(#terminal-3254289243-line-3)">alpha,beta,rc</text><text class="terminal-3254289243-r2" x="890.6" y="93.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-3)">}</text><text class="terminal-3254289243-r2" x="902.8" y="93.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-3)">]</text><text class="terminal-3254289243-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-3)">
-</text><text class="terminal-3254289243-r2" x="183" y="117.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-4)">[</text><text class="terminal-3254289243-r1" x="195.2" y="117.6" textLength="280.6" clip-path="url(#terminal-3254289243-line-4)">--devrelease&#160;DEVRELEASE</text><text class="terminal-3254289243-r2" x="475.8" y="117.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-4)">]</text><text class="terminal-3254289243-r2" x="500.2" y="117.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-4)">[</text><text class="terminal-3254289243-r1" x="512.4" y="117.6" textLength="146.4" clip-path="url(#terminal-3254289243-line-4)">--increment&#160;</text><text class="terminal-3254289243-r2" x="658.8" y="117.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-4)">{</text><text class="terminal-3254289243-r1" x="671" y="117.6" textLength="207.4" clip-path="url(#terminal-3254289243-line-4)">MAJOR,MINOR,PATCH</text><text class="terminal-3254289243-r2" x="878.4" y="117.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-4)">}</text><text class="terminal-3254289243-r2" x="890.6" y="117.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-4)">]</text><text class="terminal-3254289243-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-4)">
-</text><text class="terminal-3254289243-r2" x="183" y="142" textLength="12.2" clip-path="url(#terminal-3254289243-line-5)">[</text><text class="terminal-3254289243-r1" x="195.2" y="142" textLength="207.4" clip-path="url(#terminal-3254289243-line-5)">--increment-mode&#160;</text><text class="terminal-3254289243-r2" x="402.6" y="142" textLength="12.2" clip-path="url(#terminal-3254289243-line-5)">{</text><text class="terminal-3254289243-r1" x="414.8" y="142" textLength="146.4" clip-path="url(#terminal-3254289243-line-5)">linear,exact</text><text class="terminal-3254289243-r2" x="561.2" y="142" textLength="12.2" clip-path="url(#terminal-3254289243-line-5)">}</text><text class="terminal-3254289243-r2" x="573.4" y="142" textLength="12.2" clip-path="url(#terminal-3254289243-line-5)">]</text><text class="terminal-3254289243-r2" x="597.8" y="142" textLength="12.2" clip-path="url(#terminal-3254289243-line-5)">[</text><text class="terminal-3254289243-r1" x="610" y="142" textLength="231.8" clip-path="url(#terminal-3254289243-line-5)">--check-consistency</text><text class="terminal-3254289243-r2" x="841.8" y="142" textLength="12.2" clip-path="url(#terminal-3254289243-line-5)">]</text><text class="terminal-3254289243-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3254289243-line-5)">
-</text><text class="terminal-3254289243-r2" x="183" y="166.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-6)">[</text><text class="terminal-3254289243-r1" x="195.2" y="166.4" textLength="183" clip-path="url(#terminal-3254289243-line-6)">--annotated-tag</text><text class="terminal-3254289243-r2" x="378.2" y="166.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-6)">]</text><text class="terminal-3254289243-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-6)">
-</text><text class="terminal-3254289243-r2" x="183" y="190.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-7)">[</text><text class="terminal-3254289243-r1" x="195.2" y="190.8" textLength="549" clip-path="url(#terminal-3254289243-line-7)">--annotated-tag-message&#160;ANNOTATED_TAG_MESSAGE</text><text class="terminal-3254289243-r2" x="744.2" y="190.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-7)">]</text><text class="terminal-3254289243-r2" x="768.6" y="190.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-7)">[</text><text class="terminal-3254289243-r1" x="780.8" y="190.8" textLength="122" clip-path="url(#terminal-3254289243-line-7)">--gpg-sign</text><text class="terminal-3254289243-r2" x="902.8" y="190.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-7)">]</text><text class="terminal-3254289243-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-7)">
-</text><text class="terminal-3254289243-r2" x="183" y="215.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-8)">[</text><text class="terminal-3254289243-r1" x="195.2" y="215.2" textLength="256.2" clip-path="url(#terminal-3254289243-line-8)">--changelog-to-stdout</text><text class="terminal-3254289243-r2" x="451.4" y="215.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-8)">]</text><text class="terminal-3254289243-r2" x="475.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-8)">[</text><text class="terminal-3254289243-r1" x="488" y="215.2" textLength="268.4" clip-path="url(#terminal-3254289243-line-8)">--git-output-to-stderr</text><text class="terminal-3254289243-r2" x="756.4" y="215.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-8)">]</text><text class="terminal-3254289243-r2" x="780.8" y="215.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-8)">[</text><text class="terminal-3254289243-r1" x="793" y="215.2" textLength="85.4" clip-path="url(#terminal-3254289243-line-8)">--retry</text><text class="terminal-3254289243-r2" x="878.4" y="215.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-8)">]</text><text class="terminal-3254289243-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-8)">
-</text><text class="terminal-3254289243-r2" x="183" y="239.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-9)">[</text><text class="terminal-3254289243-r1" x="195.2" y="239.6" textLength="244" clip-path="url(#terminal-3254289243-line-9)">--major-version-zero</text><text class="terminal-3254289243-r2" x="439.2" y="239.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-9)">]</text><text class="terminal-3254289243-r2" x="463.6" y="239.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-9)">[</text><text class="terminal-3254289243-r1" x="475.8" y="239.6" textLength="231.8" clip-path="url(#terminal-3254289243-line-9)">--template&#160;TEMPLATE</text><text class="terminal-3254289243-r2" x="707.6" y="239.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-9)">]</text><text class="terminal-3254289243-r2" x="732" y="239.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-9)">[</text><text class="terminal-3254289243-r1" x="744.2" y="239.6" textLength="158.6" clip-path="url(#terminal-3254289243-line-9)">--extra&#160;EXTRA</text><text class="terminal-3254289243-r2" x="902.8" y="239.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-9)">]</text><text class="terminal-3254289243-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-9)">
-</text><text class="terminal-3254289243-r2" x="183" y="264" textLength="12.2" clip-path="url(#terminal-3254289243-line-10)">[</text><text class="terminal-3254289243-r1" x="195.2" y="264" textLength="256.2" clip-path="url(#terminal-3254289243-line-10)">--file-name&#160;FILE_NAME</text><text class="terminal-3254289243-r2" x="451.4" y="264" textLength="12.2" clip-path="url(#terminal-3254289243-line-10)">]</text><text class="terminal-3254289243-r2" x="475.8" y="264" textLength="12.2" clip-path="url(#terminal-3254289243-line-10)">[</text><text class="terminal-3254289243-r1" x="488" y="264" textLength="451.4" clip-path="url(#terminal-3254289243-line-10)">--prerelease-offset&#160;PRERELEASE_OFFSET</text><text class="terminal-3254289243-r2" x="939.4" y="264" textLength="12.2" clip-path="url(#terminal-3254289243-line-10)">]</text><text class="terminal-3254289243-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3254289243-line-10)">
-</text><text class="terminal-3254289243-r2" x="183" y="288.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-11)">[</text><text class="terminal-3254289243-r1" x="195.2" y="288.4" textLength="207.4" clip-path="url(#terminal-3254289243-line-11)">--version-scheme&#160;</text><text class="terminal-3254289243-r2" x="402.6" y="288.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-11)">{</text><text class="terminal-3254289243-r1" x="414.8" y="288.4" textLength="256.2" clip-path="url(#terminal-3254289243-line-11)">pep440,semver,semver2</text><text class="terminal-3254289243-r2" x="671" y="288.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-11)">}</text><text class="terminal-3254289243-r2" x="683.2" y="288.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-11)">]</text><text class="terminal-3254289243-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-11)">
-</text><text class="terminal-3254289243-r2" x="183" y="312.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-12)">[</text><text class="terminal-3254289243-r1" x="195.2" y="312.8" textLength="183" clip-path="url(#terminal-3254289243-line-12)">--version-type&#160;</text><text class="terminal-3254289243-r2" x="378.2" y="312.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-12)">{</text><text class="terminal-3254289243-r1" x="390.4" y="312.8" textLength="256.2" clip-path="url(#terminal-3254289243-line-12)">pep440,semver,semver2</text><text class="terminal-3254289243-r2" x="646.6" y="312.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-12)">}</text><text class="terminal-3254289243-r2" x="658.8" y="312.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-12)">]</text><text class="terminal-3254289243-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-12)">
-</text><text class="terminal-3254289243-r2" x="183" y="337.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-13)">[</text><text class="terminal-3254289243-r1" x="195.2" y="337.2" textLength="378.2" clip-path="url(#terminal-3254289243-line-13)">--build-metadata&#160;BUILD_METADATA</text><text class="terminal-3254289243-r2" x="573.4" y="337.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-13)">]</text><text class="terminal-3254289243-r2" x="597.8" y="337.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-13)">[</text><text class="terminal-3254289243-r1" x="610" y="337.2" textLength="122" clip-path="url(#terminal-3254289243-line-13)">--get-next</text><text class="terminal-3254289243-r2" x="732" y="337.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-13)">]</text><text class="terminal-3254289243-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-13)">
-</text><text class="terminal-3254289243-r2" x="183" y="361.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-14)">[</text><text class="terminal-3254289243-r1" x="195.2" y="361.6" textLength="170.8" clip-path="url(#terminal-3254289243-line-14)">MANUAL_VERSION</text><text class="terminal-3254289243-r2" x="366" y="361.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-14)">]</text><text class="terminal-3254289243-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-14)">
-</text><text class="terminal-3254289243-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3254289243-line-15)">
-</text><text class="terminal-3254289243-r1" x="0" y="410.4" textLength="512.4" clip-path="url(#terminal-3254289243-line-16)">bump&#160;semantic&#160;version&#160;based&#160;on&#160;the&#160;git&#160;log</text><text class="terminal-3254289243-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-16)">
-</text><text class="terminal-3254289243-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-17)">
-</text><text class="terminal-3254289243-r1" x="0" y="459.2" textLength="256.2" clip-path="url(#terminal-3254289243-line-18)">positional&#160;arguments:</text><text class="terminal-3254289243-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-18)">
-</text><text class="terminal-3254289243-r1" x="0" y="483.6" textLength="610" clip-path="url(#terminal-3254289243-line-19)">&#160;&#160;MANUAL_VERSION&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;to&#160;the&#160;given&#160;version&#160;</text><text class="terminal-3254289243-r2" x="610" y="483.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-19)">(</text><text class="terminal-3254289243-r1" x="622.2" y="483.6" textLength="61" clip-path="url(#terminal-3254289243-line-19)">e.g:&#160;</text><text class="terminal-3254289243-r3" x="683.2" y="483.6" textLength="36.6" clip-path="url(#terminal-3254289243-line-19)">1.5</text><text class="terminal-3254289243-r1" x="719.8" y="483.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-19)">.</text><text class="terminal-3254289243-r3" x="732" y="483.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-19)">3</text><text class="terminal-3254289243-r2" x="744.2" y="483.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-19)">)</text><text class="terminal-3254289243-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-19)">
-</text><text class="terminal-3254289243-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3254289243-line-20)">
-</text><text class="terminal-3254289243-r1" x="0" y="532.4" textLength="97.6" clip-path="url(#terminal-3254289243-line-21)">options:</text><text class="terminal-3254289243-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-21)">
-</text><text class="terminal-3254289243-r1" x="0" y="556.8" textLength="671" clip-path="url(#terminal-3254289243-line-22)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-3254289243-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-22)">
-</text><text class="terminal-3254289243-r1" x="0" y="581.2" textLength="915" clip-path="url(#terminal-3254289243-line-23)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;output&#160;to&#160;stdout,&#160;no&#160;commit,&#160;no&#160;modified&#160;files</text><text class="terminal-3254289243-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-23)">
-</text><text class="terminal-3254289243-r1" x="0" y="605.6" textLength="793" clip-path="url(#terminal-3254289243-line-24)">&#160;&#160;--files-only&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;version&#160;in&#160;the&#160;files&#160;from&#160;the&#160;config</text><text class="terminal-3254289243-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-24)">
-</text><text class="terminal-3254289243-r1" x="0" y="630" textLength="719.8" clip-path="url(#terminal-3254289243-line-25)">&#160;&#160;--local-version&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;only&#160;the&#160;local&#160;version&#160;portion</text><text class="terminal-3254289243-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-3254289243-line-25)">
-</text><text class="terminal-3254289243-r1" x="0" y="654.4" textLength="841.8" clip-path="url(#terminal-3254289243-line-26)">&#160;&#160;--changelog,&#160;-ch&#160;&#160;&#160;&#160;&#160;&#160;generate&#160;the&#160;changelog&#160;for&#160;the&#160;newest&#160;version</text><text class="terminal-3254289243-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-26)">
-</text><text class="terminal-3254289243-r1" x="0" y="678.8" textLength="902.8" clip-path="url(#terminal-3254289243-line-27)">&#160;&#160;--no-verify&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;this&#160;option&#160;bypasses&#160;the&#160;pre-commit&#160;and&#160;commit-msg</text><text class="terminal-3254289243-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-27)">
-</text><text class="terminal-3254289243-r1" x="0" y="703.2" textLength="353.8" clip-path="url(#terminal-3254289243-line-28)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;hooks</text><text class="terminal-3254289243-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-28)">
-</text><text class="terminal-3254289243-r1" x="0" y="727.6" textLength="719.8" clip-path="url(#terminal-3254289243-line-29)">&#160;&#160;--yes&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;accept&#160;automatically&#160;questions&#160;done</text><text class="terminal-3254289243-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-29)">
-</text><text class="terminal-3254289243-r1" x="0" y="752" textLength="305" clip-path="url(#terminal-3254289243-line-30)">&#160;&#160;--tag-format&#160;TAG_FORMAT</text><text class="terminal-3254289243-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-3254289243-line-30)">
-</text><text class="terminal-3254289243-r1" x="0" y="776.4" textLength="939.4" clip-path="url(#terminal-3254289243-line-31)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;format&#160;used&#160;to&#160;tag&#160;the&#160;commit&#160;and&#160;read&#160;it,&#160;use&#160;it</text><text class="terminal-3254289243-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-31)">
-</text><text class="terminal-3254289243-r1" x="0" y="800.8" textLength="866.2" clip-path="url(#terminal-3254289243-line-32)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;in&#160;existing&#160;projects,&#160;wrap&#160;around&#160;simple&#160;quotes</text><text class="terminal-3254289243-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-32)">
-</text><text class="terminal-3254289243-r1" x="0" y="825.2" textLength="353.8" clip-path="url(#terminal-3254289243-line-33)">&#160;&#160;--bump-message&#160;BUMP_MESSAGE</text><text class="terminal-3254289243-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-33)">
-</text><text class="terminal-3254289243-r1" x="0" y="849.6" textLength="902.8" clip-path="url(#terminal-3254289243-line-34)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;template&#160;used&#160;to&#160;create&#160;the&#160;release&#160;commit,&#160;useful</text><text class="terminal-3254289243-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-34)">
-</text><text class="terminal-3254289243-r1" x="0" y="874" textLength="536.8" clip-path="url(#terminal-3254289243-line-35)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;when&#160;working&#160;with&#160;CI</text><text class="terminal-3254289243-r1" x="976" y="874" textLength="12.2" clip-path="url(#terminal-3254289243-line-35)">
-</text><text class="terminal-3254289243-r1" x="0" y="898.4" textLength="244" clip-path="url(#terminal-3254289243-line-36)">&#160;&#160;--prerelease,&#160;-pr&#160;</text><text class="terminal-3254289243-r2" x="244" y="898.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-36)">{</text><text class="terminal-3254289243-r1" x="256.2" y="898.4" textLength="158.6" clip-path="url(#terminal-3254289243-line-36)">alpha,beta,rc</text><text class="terminal-3254289243-r2" x="414.8" y="898.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-36)">}</text><text class="terminal-3254289243-r1" x="976" y="898.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-36)">
-</text><text class="terminal-3254289243-r1" x="0" y="922.8" textLength="597.8" clip-path="url(#terminal-3254289243-line-37)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;choose&#160;type&#160;of&#160;prerelease</text><text class="terminal-3254289243-r1" x="976" y="922.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-37)">
-</text><text class="terminal-3254289243-r1" x="0" y="947.2" textLength="353.8" clip-path="url(#terminal-3254289243-line-38)">&#160;&#160;--devrelease,&#160;-d&#160;DEVRELEASE</text><text class="terminal-3254289243-r1" x="976" y="947.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-38)">
-</text><text class="terminal-3254289243-r1" x="0" y="971.6" textLength="841.8" clip-path="url(#terminal-3254289243-line-39)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;specify&#160;non-negative&#160;integer&#160;for&#160;dev.&#160;release</text><text class="terminal-3254289243-r1" x="976" y="971.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-39)">
-</text><text class="terminal-3254289243-r1" x="0" y="996" textLength="170.8" clip-path="url(#terminal-3254289243-line-40)">&#160;&#160;--increment&#160;</text><text class="terminal-3254289243-r2" x="170.8" y="996" textLength="12.2" clip-path="url(#terminal-3254289243-line-40)">{</text><text class="terminal-3254289243-r1" x="183" y="996" textLength="207.4" clip-path="url(#terminal-3254289243-line-40)">MAJOR,MINOR,PATCH</text><text class="terminal-3254289243-r2" x="390.4" y="996" textLength="12.2" clip-path="url(#terminal-3254289243-line-40)">}</text><text class="terminal-3254289243-r1" x="976" y="996" textLength="12.2" clip-path="url(#terminal-3254289243-line-40)">
-</text><text class="terminal-3254289243-r1" x="0" y="1020.4" textLength="756.4" clip-path="url(#terminal-3254289243-line-41)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;manually&#160;specify&#160;the&#160;desired&#160;increment</text><text class="terminal-3254289243-r1" x="976" y="1020.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-41)">
-</text><text class="terminal-3254289243-r1" x="0" y="1044.8" textLength="231.8" clip-path="url(#terminal-3254289243-line-42)">&#160;&#160;--increment-mode&#160;</text><text class="terminal-3254289243-r2" x="231.8" y="1044.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-42)">{</text><text class="terminal-3254289243-r1" x="244" y="1044.8" textLength="146.4" clip-path="url(#terminal-3254289243-line-42)">linear,exact</text><text class="terminal-3254289243-r2" x="390.4" y="1044.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-42)">}</text><text class="terminal-3254289243-r1" x="976" y="1044.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-42)">
-</text><text class="terminal-3254289243-r1" x="0" y="1069.2" textLength="902.8" clip-path="url(#terminal-3254289243-line-43)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;set&#160;the&#160;method&#160;by&#160;which&#160;the&#160;new&#160;version&#160;is&#160;chosen.</text><text class="terminal-3254289243-r1" x="976" y="1069.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-43)">
-</text><text class="terminal-3254289243-r4" x="292.8" y="1093.6" textLength="97.6" clip-path="url(#terminal-3254289243-line-44)">&#x27;linear&#x27;</text><text class="terminal-3254289243-r2" x="402.6" y="1093.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-44)">(</text><text class="terminal-3254289243-r1" x="414.8" y="1093.6" textLength="85.4" clip-path="url(#terminal-3254289243-line-44)">default</text><text class="terminal-3254289243-r2" x="500.2" y="1093.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-44)">)</text><text class="terminal-3254289243-r1" x="512.4" y="1093.6" textLength="414.8" clip-path="url(#terminal-3254289243-line-44)">&#160;guesses&#160;the&#160;next&#160;version&#160;based&#160;on</text><text class="terminal-3254289243-r1" x="976" y="1093.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-44)">
-</text><text class="terminal-3254289243-r1" x="0" y="1118" textLength="939.4" clip-path="url(#terminal-3254289243-line-45)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;typical&#160;linear&#160;version&#160;progression,&#160;such&#160;that&#160;bumping</text><text class="terminal-3254289243-r1" x="976" y="1118" textLength="12.2" clip-path="url(#terminal-3254289243-line-45)">
-</text><text class="terminal-3254289243-r1" x="0" y="1142.4" textLength="866.2" clip-path="url(#terminal-3254289243-line-46)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;of&#160;a&#160;pre-release&#160;with&#160;lower&#160;precedence&#160;than&#160;the</text><text class="terminal-3254289243-r1" x="976" y="1142.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-46)">
-</text><text class="terminal-3254289243-r1" x="0" y="1166.8" textLength="939.4" clip-path="url(#terminal-3254289243-line-47)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;current&#160;pre-release&#160;phase&#160;maintains&#160;the&#160;current&#160;phase</text><text class="terminal-3254289243-r1" x="976" y="1166.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-47)">
-</text><text class="terminal-3254289243-r1" x="0" y="1191.2" textLength="561.2" clip-path="url(#terminal-3254289243-line-48)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;of&#160;higher&#160;precedence.&#160;</text><text class="terminal-3254289243-r4" x="561.2" y="1191.2" textLength="85.4" clip-path="url(#terminal-3254289243-line-48)">&#x27;exact&#x27;</text><text class="terminal-3254289243-r1" x="646.6" y="1191.2" textLength="305" clip-path="url(#terminal-3254289243-line-48)">&#160;applies&#160;the&#160;changes&#160;that</text><text class="terminal-3254289243-r1" x="976" y="1191.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-48)">
-</text><text class="terminal-3254289243-r1" x="0" y="1215.6" textLength="536.8" clip-path="url(#terminal-3254289243-line-49)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;have&#160;been&#160;specified&#160;</text><text class="terminal-3254289243-r2" x="536.8" y="1215.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-49)">(</text><text class="terminal-3254289243-r1" x="549" y="1215.6" textLength="353.8" clip-path="url(#terminal-3254289243-line-49)">or&#160;determined&#160;from&#160;the&#160;commit</text><text class="terminal-3254289243-r1" x="976" y="1215.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-49)">
-</text><text class="terminal-3254289243-r1" x="0" y="1240" textLength="329.4" clip-path="url(#terminal-3254289243-line-50)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;log</text><text class="terminal-3254289243-r2" x="329.4" y="1240" textLength="12.2" clip-path="url(#terminal-3254289243-line-50)">)</text><text class="terminal-3254289243-r1" x="341.6" y="1240" textLength="585.6" clip-path="url(#terminal-3254289243-line-50)">&#160;without&#160;interpretation,&#160;such&#160;that&#160;the&#160;increment</text><text class="terminal-3254289243-r1" x="976" y="1240" textLength="12.2" clip-path="url(#terminal-3254289243-line-50)">
-</text><text class="terminal-3254289243-r1" x="0" y="1264.4" textLength="707.6" clip-path="url(#terminal-3254289243-line-51)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;and&#160;pre-release&#160;are&#160;always&#160;honored</text><text class="terminal-3254289243-r1" x="976" y="1264.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-51)">
-</text><text class="terminal-3254289243-r1" x="0" y="1288.8" textLength="317.2" clip-path="url(#terminal-3254289243-line-52)">&#160;&#160;--check-consistency,&#160;-cc</text><text class="terminal-3254289243-r1" x="976" y="1288.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-52)">
-</text><text class="terminal-3254289243-r1" x="0" y="1313.2" textLength="951.6" clip-path="url(#terminal-3254289243-line-53)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;check&#160;consistency&#160;among&#160;versions&#160;defined&#160;in&#160;commitizen</text><text class="terminal-3254289243-r1" x="976" y="1313.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-53)">
-</text><text class="terminal-3254289243-r1" x="0" y="1337.6" textLength="671" clip-path="url(#terminal-3254289243-line-54)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;configuration&#160;and&#160;version_files</text><text class="terminal-3254289243-r1" x="976" y="1337.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-54)">
-</text><text class="terminal-3254289243-r1" x="0" y="1362" textLength="866.2" clip-path="url(#terminal-3254289243-line-55)">&#160;&#160;--annotated-tag,&#160;-at&#160;&#160;create&#160;annotated&#160;tag&#160;instead&#160;of&#160;lightweight&#160;one</text><text class="terminal-3254289243-r1" x="976" y="1362" textLength="12.2" clip-path="url(#terminal-3254289243-line-55)">
-</text><text class="terminal-3254289243-r1" x="0" y="1386.4" textLength="646.6" clip-path="url(#terminal-3254289243-line-56)">&#160;&#160;--annotated-tag-message,&#160;-atm&#160;ANNOTATED_TAG_MESSAGE</text><text class="terminal-3254289243-r1" x="976" y="1386.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-56)">
-</text><text class="terminal-3254289243-r1" x="0" y="1410.8" textLength="634.4" clip-path="url(#terminal-3254289243-line-57)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;create&#160;annotated&#160;tag&#160;message</text><text class="terminal-3254289243-r1" x="976" y="1410.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-57)">
-</text><text class="terminal-3254289243-r1" x="0" y="1435.2" textLength="719.8" clip-path="url(#terminal-3254289243-line-58)">&#160;&#160;--gpg-sign,&#160;-s&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sign&#160;tag&#160;instead&#160;of&#160;lightweight&#160;one</text><text class="terminal-3254289243-r1" x="976" y="1435.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-58)">
-</text><text class="terminal-3254289243-r1" x="0" y="1459.6" textLength="280.6" clip-path="url(#terminal-3254289243-line-59)">&#160;&#160;--changelog-to-stdout</text><text class="terminal-3254289243-r1" x="976" y="1459.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-59)">
-</text><text class="terminal-3254289243-r1" x="0" y="1484" textLength="658.8" clip-path="url(#terminal-3254289243-line-60)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Output&#160;changelog&#160;to&#160;the&#160;stdout</text><text class="terminal-3254289243-r1" x="976" y="1484" textLength="12.2" clip-path="url(#terminal-3254289243-line-60)">
-</text><text class="terminal-3254289243-r1" x="0" y="1508.4" textLength="292.8" clip-path="url(#terminal-3254289243-line-61)">&#160;&#160;--git-output-to-stderr</text><text class="terminal-3254289243-r1" x="976" y="1508.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-61)">
-</text><text class="terminal-3254289243-r1" x="0" y="1532.8" textLength="646.6" clip-path="url(#terminal-3254289243-line-62)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Redirect&#160;git&#160;output&#160;to&#160;stderr</text><text class="terminal-3254289243-r1" x="976" y="1532.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-62)">
-</text><text class="terminal-3254289243-r1" x="0" y="1557.2" textLength="744.2" clip-path="url(#terminal-3254289243-line-63)">&#160;&#160;--retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;retry&#160;commit&#160;if&#160;it&#160;fails&#160;the&#160;1st&#160;time</text><text class="terminal-3254289243-r1" x="976" y="1557.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-63)">
-</text><text class="terminal-3254289243-r1" x="0" y="1581.6" textLength="939.4" clip-path="url(#terminal-3254289243-line-64)">&#160;&#160;--major-version-zero&#160;&#160;keep&#160;major&#160;version&#160;at&#160;zero,&#160;even&#160;for&#160;breaking&#160;changes</text><text class="terminal-3254289243-r1" x="976" y="1581.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-64)">
-</text><text class="terminal-3254289243-r1" x="0" y="1606" textLength="305" clip-path="url(#terminal-3254289243-line-65)">&#160;&#160;--template,&#160;-t&#160;TEMPLATE</text><text class="terminal-3254289243-r1" x="976" y="1606" textLength="12.2" clip-path="url(#terminal-3254289243-line-65)">
-</text><text class="terminal-3254289243-r1" x="0" y="1630.4" textLength="646.6" clip-path="url(#terminal-3254289243-line-66)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;changelog&#160;template&#160;file&#160;name&#160;</text><text class="terminal-3254289243-r2" x="646.6" y="1630.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-66)">(</text><text class="terminal-3254289243-r1" x="658.8" y="1630.4" textLength="280.6" clip-path="url(#terminal-3254289243-line-66)">relative&#160;to&#160;the&#160;current</text><text class="terminal-3254289243-r1" x="976" y="1630.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-66)">
-</text><text class="terminal-3254289243-r1" x="0" y="1654.8" textLength="500.2" clip-path="url(#terminal-3254289243-line-67)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;working&#160;directory</text><text class="terminal-3254289243-r2" x="500.2" y="1654.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-67)">)</text><text class="terminal-3254289243-r1" x="976" y="1654.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-67)">
-</text><text class="terminal-3254289243-r1" x="0" y="1679.2" textLength="622.2" clip-path="url(#terminal-3254289243-line-68)">&#160;&#160;--extra,&#160;-e&#160;EXTRA&#160;&#160;&#160;&#160;&#160;a&#160;changelog&#160;extra&#160;variable&#160;</text><text class="terminal-3254289243-r2" x="622.2" y="1679.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-68)">(</text><text class="terminal-3254289243-r1" x="634.4" y="1679.2" textLength="146.4" clip-path="url(#terminal-3254289243-line-68)">in&#160;the&#160;form&#160;</text><text class="terminal-3254289243-r4" x="780.8" y="1679.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-68)">&#x27;</text><text class="terminal-3254289243-r4" x="793" y="1679.2" textLength="36.6" clip-path="url(#terminal-3254289243-line-68)">key</text><text class="terminal-3254289243-r4" x="829.6" y="1679.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-68)">=</text><text class="terminal-3254289243-r4" x="841.8" y="1679.2" textLength="61" clip-path="url(#terminal-3254289243-line-68)">value</text><text class="terminal-3254289243-r4" x="902.8" y="1679.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-68)">&#x27;</text><text class="terminal-3254289243-r2" x="915" y="1679.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-68)">)</text><text class="terminal-3254289243-r1" x="976" y="1679.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-68)">
-</text><text class="terminal-3254289243-r1" x="0" y="1703.6" textLength="280.6" clip-path="url(#terminal-3254289243-line-69)">&#160;&#160;--file-name&#160;FILE_NAME</text><text class="terminal-3254289243-r1" x="976" y="1703.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-69)">
-</text><text class="terminal-3254289243-r1" x="0" y="1728" textLength="573.4" clip-path="url(#terminal-3254289243-line-70)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;file&#160;name&#160;of&#160;changelog&#160;</text><text class="terminal-3254289243-r2" x="573.4" y="1728" textLength="12.2" clip-path="url(#terminal-3254289243-line-70)">(</text><text class="terminal-3254289243-r1" x="585.6" y="1728" textLength="109.8" clip-path="url(#terminal-3254289243-line-70)">default:&#160;</text><text class="terminal-3254289243-r4" x="695.4" y="1728" textLength="170.8" clip-path="url(#terminal-3254289243-line-70)">&#x27;CHANGELOG.md&#x27;</text><text class="terminal-3254289243-r2" x="866.2" y="1728" textLength="12.2" clip-path="url(#terminal-3254289243-line-70)">)</text><text class="terminal-3254289243-r1" x="976" y="1728" textLength="12.2" clip-path="url(#terminal-3254289243-line-70)">
-</text><text class="terminal-3254289243-r1" x="0" y="1752.4" textLength="475.8" clip-path="url(#terminal-3254289243-line-71)">&#160;&#160;--prerelease-offset&#160;PRERELEASE_OFFSET</text><text class="terminal-3254289243-r1" x="976" y="1752.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-71)">
-</text><text class="terminal-3254289243-r1" x="0" y="1776.8" textLength="719.8" clip-path="url(#terminal-3254289243-line-72)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;start&#160;pre-releases&#160;with&#160;this&#160;offset</text><text class="terminal-3254289243-r1" x="976" y="1776.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-72)">
-</text><text class="terminal-3254289243-r1" x="0" y="1801.2" textLength="231.8" clip-path="url(#terminal-3254289243-line-73)">&#160;&#160;--version-scheme&#160;</text><text class="terminal-3254289243-r2" x="231.8" y="1801.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-73)">{</text><text class="terminal-3254289243-r1" x="244" y="1801.2" textLength="256.2" clip-path="url(#terminal-3254289243-line-73)">pep440,semver,semver2</text><text class="terminal-3254289243-r2" x="500.2" y="1801.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-73)">}</text><text class="terminal-3254289243-r1" x="976" y="1801.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-73)">
-</text><text class="terminal-3254289243-r1" x="0" y="1825.6" textLength="549" clip-path="url(#terminal-3254289243-line-74)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;choose&#160;version&#160;scheme</text><text class="terminal-3254289243-r1" x="976" y="1825.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-74)">
-</text><text class="terminal-3254289243-r1" x="0" y="1850" textLength="207.4" clip-path="url(#terminal-3254289243-line-75)">&#160;&#160;--version-type&#160;</text><text class="terminal-3254289243-r2" x="207.4" y="1850" textLength="12.2" clip-path="url(#terminal-3254289243-line-75)">{</text><text class="terminal-3254289243-r1" x="219.6" y="1850" textLength="256.2" clip-path="url(#terminal-3254289243-line-75)">pep440,semver,semver2</text><text class="terminal-3254289243-r2" x="475.8" y="1850" textLength="12.2" clip-path="url(#terminal-3254289243-line-75)">}</text><text class="terminal-3254289243-r1" x="976" y="1850" textLength="12.2" clip-path="url(#terminal-3254289243-line-75)">
-</text><text class="terminal-3254289243-r1" x="0" y="1874.4" textLength="683.2" clip-path="url(#terminal-3254289243-line-76)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Deprecated,&#160;use&#160;--version-scheme</text><text class="terminal-3254289243-r1" x="976" y="1874.4" textLength="12.2" clip-path="url(#terminal-3254289243-line-76)">
-</text><text class="terminal-3254289243-r1" x="0" y="1898.8" textLength="402.6" clip-path="url(#terminal-3254289243-line-77)">&#160;&#160;--build-metadata&#160;BUILD_METADATA</text><text class="terminal-3254289243-r1" x="976" y="1898.8" textLength="12.2" clip-path="url(#terminal-3254289243-line-77)">
-</text><text class="terminal-3254289243-r1" x="0" y="1923.2" textLength="915" clip-path="url(#terminal-3254289243-line-78)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Add&#160;additional&#160;build-metadata&#160;to&#160;the&#160;version-number</text><text class="terminal-3254289243-r1" x="976" y="1923.2" textLength="12.2" clip-path="url(#terminal-3254289243-line-78)">
-</text><text class="terminal-3254289243-r1" x="0" y="1947.6" textLength="854" clip-path="url(#terminal-3254289243-line-79)">&#160;&#160;--get-next&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Determine&#160;the&#160;next&#160;version&#160;and&#160;write&#160;to&#160;stdout</text><text class="terminal-3254289243-r1" x="976" y="1947.6" textLength="12.2" clip-path="url(#terminal-3254289243-line-79)">
-</text><text class="terminal-3254289243-r1" x="976" y="1972" textLength="12.2" clip-path="url(#terminal-3254289243-line-80)">
+    <g class="terminal-2232203-matrix">
+    <text class="terminal-2232203-r1" x="0" y="20" textLength="195.2" clip-path="url(#terminal-2232203-line-0)">$&#160;cz&#160;bump&#160;--help</text><text class="terminal-2232203-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2232203-line-0)">
+</text><text class="terminal-2232203-r1" x="0" y="44.4" textLength="183" clip-path="url(#terminal-2232203-line-1)">usage:&#160;cz&#160;bump&#160;</text><text class="terminal-2232203-r2" x="183" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">[</text><text class="terminal-2232203-r1" x="195.2" y="44.4" textLength="24.4" clip-path="url(#terminal-2232203-line-1)">-h</text><text class="terminal-2232203-r2" x="219.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">]</text><text class="terminal-2232203-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">[</text><text class="terminal-2232203-r1" x="256.2" y="44.4" textLength="109.8" clip-path="url(#terminal-2232203-line-1)">--dry-run</text><text class="terminal-2232203-r2" x="366" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">]</text><text class="terminal-2232203-r2" x="390.4" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">[</text><text class="terminal-2232203-r1" x="402.6" y="44.4" textLength="146.4" clip-path="url(#terminal-2232203-line-1)">--files-only</text><text class="terminal-2232203-r2" x="549" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">]</text><text class="terminal-2232203-r2" x="573.4" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">[</text><text class="terminal-2232203-r1" x="585.6" y="44.4" textLength="183" clip-path="url(#terminal-2232203-line-1)">--local-version</text><text class="terminal-2232203-r2" x="768.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">]</text><text class="terminal-2232203-r2" x="793" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">[</text><text class="terminal-2232203-r1" x="805.2" y="44.4" textLength="134.2" clip-path="url(#terminal-2232203-line-1)">--changelog</text><text class="terminal-2232203-r2" x="939.4" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">]</text><text class="terminal-2232203-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2232203-line-1)">
+</text><text class="terminal-2232203-r2" x="183" y="68.8" textLength="12.2" clip-path="url(#terminal-2232203-line-2)">[</text><text class="terminal-2232203-r1" x="195.2" y="68.8" textLength="134.2" clip-path="url(#terminal-2232203-line-2)">--no-verify</text><text class="terminal-2232203-r2" x="329.4" y="68.8" textLength="12.2" clip-path="url(#terminal-2232203-line-2)">]</text><text class="terminal-2232203-r2" x="353.8" y="68.8" textLength="12.2" clip-path="url(#terminal-2232203-line-2)">[</text><text class="terminal-2232203-r1" x="366" y="68.8" textLength="61" clip-path="url(#terminal-2232203-line-2)">--yes</text><text class="terminal-2232203-r2" x="427" y="68.8" textLength="12.2" clip-path="url(#terminal-2232203-line-2)">]</text><text class="terminal-2232203-r2" x="451.4" y="68.8" textLength="12.2" clip-path="url(#terminal-2232203-line-2)">[</text><text class="terminal-2232203-r1" x="463.6" y="68.8" textLength="280.6" clip-path="url(#terminal-2232203-line-2)">--tag-format&#160;TAG_FORMAT</text><text class="terminal-2232203-r2" x="744.2" y="68.8" textLength="12.2" clip-path="url(#terminal-2232203-line-2)">]</text><text class="terminal-2232203-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2232203-line-2)">
+</text><text class="terminal-2232203-r2" x="183" y="93.2" textLength="12.2" clip-path="url(#terminal-2232203-line-3)">[</text><text class="terminal-2232203-r1" x="195.2" y="93.2" textLength="329.4" clip-path="url(#terminal-2232203-line-3)">--bump-message&#160;BUMP_MESSAGE</text><text class="terminal-2232203-r2" x="524.6" y="93.2" textLength="12.2" clip-path="url(#terminal-2232203-line-3)">]</text><text class="terminal-2232203-r2" x="549" y="93.2" textLength="12.2" clip-path="url(#terminal-2232203-line-3)">[</text><text class="terminal-2232203-r1" x="561.2" y="93.2" textLength="158.6" clip-path="url(#terminal-2232203-line-3)">--prerelease&#160;</text><text class="terminal-2232203-r2" x="719.8" y="93.2" textLength="12.2" clip-path="url(#terminal-2232203-line-3)">{</text><text class="terminal-2232203-r1" x="732" y="93.2" textLength="158.6" clip-path="url(#terminal-2232203-line-3)">alpha,beta,rc</text><text class="terminal-2232203-r2" x="890.6" y="93.2" textLength="12.2" clip-path="url(#terminal-2232203-line-3)">}</text><text class="terminal-2232203-r2" x="902.8" y="93.2" textLength="12.2" clip-path="url(#terminal-2232203-line-3)">]</text><text class="terminal-2232203-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2232203-line-3)">
+</text><text class="terminal-2232203-r2" x="183" y="117.6" textLength="12.2" clip-path="url(#terminal-2232203-line-4)">[</text><text class="terminal-2232203-r1" x="195.2" y="117.6" textLength="280.6" clip-path="url(#terminal-2232203-line-4)">--devrelease&#160;DEVRELEASE</text><text class="terminal-2232203-r2" x="475.8" y="117.6" textLength="12.2" clip-path="url(#terminal-2232203-line-4)">]</text><text class="terminal-2232203-r2" x="500.2" y="117.6" textLength="12.2" clip-path="url(#terminal-2232203-line-4)">[</text><text class="terminal-2232203-r1" x="512.4" y="117.6" textLength="146.4" clip-path="url(#terminal-2232203-line-4)">--increment&#160;</text><text class="terminal-2232203-r2" x="658.8" y="117.6" textLength="12.2" clip-path="url(#terminal-2232203-line-4)">{</text><text class="terminal-2232203-r1" x="671" y="117.6" textLength="207.4" clip-path="url(#terminal-2232203-line-4)">MAJOR,MINOR,PATCH</text><text class="terminal-2232203-r2" x="878.4" y="117.6" textLength="12.2" clip-path="url(#terminal-2232203-line-4)">}</text><text class="terminal-2232203-r2" x="890.6" y="117.6" textLength="12.2" clip-path="url(#terminal-2232203-line-4)">]</text><text class="terminal-2232203-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2232203-line-4)">
+</text><text class="terminal-2232203-r2" x="183" y="142" textLength="12.2" clip-path="url(#terminal-2232203-line-5)">[</text><text class="terminal-2232203-r1" x="195.2" y="142" textLength="207.4" clip-path="url(#terminal-2232203-line-5)">--increment-mode&#160;</text><text class="terminal-2232203-r2" x="402.6" y="142" textLength="12.2" clip-path="url(#terminal-2232203-line-5)">{</text><text class="terminal-2232203-r1" x="414.8" y="142" textLength="146.4" clip-path="url(#terminal-2232203-line-5)">linear,exact</text><text class="terminal-2232203-r2" x="561.2" y="142" textLength="12.2" clip-path="url(#terminal-2232203-line-5)">}</text><text class="terminal-2232203-r2" x="573.4" y="142" textLength="12.2" clip-path="url(#terminal-2232203-line-5)">]</text><text class="terminal-2232203-r2" x="597.8" y="142" textLength="12.2" clip-path="url(#terminal-2232203-line-5)">[</text><text class="terminal-2232203-r1" x="610" y="142" textLength="231.8" clip-path="url(#terminal-2232203-line-5)">--check-consistency</text><text class="terminal-2232203-r2" x="841.8" y="142" textLength="12.2" clip-path="url(#terminal-2232203-line-5)">]</text><text class="terminal-2232203-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2232203-line-5)">
+</text><text class="terminal-2232203-r2" x="183" y="166.4" textLength="12.2" clip-path="url(#terminal-2232203-line-6)">[</text><text class="terminal-2232203-r1" x="195.2" y="166.4" textLength="183" clip-path="url(#terminal-2232203-line-6)">--annotated-tag</text><text class="terminal-2232203-r2" x="378.2" y="166.4" textLength="12.2" clip-path="url(#terminal-2232203-line-6)">]</text><text class="terminal-2232203-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2232203-line-6)">
+</text><text class="terminal-2232203-r2" x="183" y="190.8" textLength="12.2" clip-path="url(#terminal-2232203-line-7)">[</text><text class="terminal-2232203-r1" x="195.2" y="190.8" textLength="549" clip-path="url(#terminal-2232203-line-7)">--annotated-tag-message&#160;ANNOTATED_TAG_MESSAGE</text><text class="terminal-2232203-r2" x="744.2" y="190.8" textLength="12.2" clip-path="url(#terminal-2232203-line-7)">]</text><text class="terminal-2232203-r2" x="768.6" y="190.8" textLength="12.2" clip-path="url(#terminal-2232203-line-7)">[</text><text class="terminal-2232203-r1" x="780.8" y="190.8" textLength="122" clip-path="url(#terminal-2232203-line-7)">--gpg-sign</text><text class="terminal-2232203-r2" x="902.8" y="190.8" textLength="12.2" clip-path="url(#terminal-2232203-line-7)">]</text><text class="terminal-2232203-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2232203-line-7)">
+</text><text class="terminal-2232203-r2" x="183" y="215.2" textLength="12.2" clip-path="url(#terminal-2232203-line-8)">[</text><text class="terminal-2232203-r1" x="195.2" y="215.2" textLength="256.2" clip-path="url(#terminal-2232203-line-8)">--changelog-to-stdout</text><text class="terminal-2232203-r2" x="451.4" y="215.2" textLength="12.2" clip-path="url(#terminal-2232203-line-8)">]</text><text class="terminal-2232203-r2" x="475.8" y="215.2" textLength="12.2" clip-path="url(#terminal-2232203-line-8)">[</text><text class="terminal-2232203-r1" x="488" y="215.2" textLength="268.4" clip-path="url(#terminal-2232203-line-8)">--git-output-to-stderr</text><text class="terminal-2232203-r2" x="756.4" y="215.2" textLength="12.2" clip-path="url(#terminal-2232203-line-8)">]</text><text class="terminal-2232203-r2" x="780.8" y="215.2" textLength="12.2" clip-path="url(#terminal-2232203-line-8)">[</text><text class="terminal-2232203-r1" x="793" y="215.2" textLength="85.4" clip-path="url(#terminal-2232203-line-8)">--retry</text><text class="terminal-2232203-r2" x="878.4" y="215.2" textLength="12.2" clip-path="url(#terminal-2232203-line-8)">]</text><text class="terminal-2232203-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2232203-line-8)">
+</text><text class="terminal-2232203-r2" x="183" y="239.6" textLength="12.2" clip-path="url(#terminal-2232203-line-9)">[</text><text class="terminal-2232203-r1" x="195.2" y="239.6" textLength="244" clip-path="url(#terminal-2232203-line-9)">--major-version-zero</text><text class="terminal-2232203-r2" x="439.2" y="239.6" textLength="12.2" clip-path="url(#terminal-2232203-line-9)">]</text><text class="terminal-2232203-r2" x="463.6" y="239.6" textLength="12.2" clip-path="url(#terminal-2232203-line-9)">[</text><text class="terminal-2232203-r1" x="475.8" y="239.6" textLength="231.8" clip-path="url(#terminal-2232203-line-9)">--template&#160;TEMPLATE</text><text class="terminal-2232203-r2" x="707.6" y="239.6" textLength="12.2" clip-path="url(#terminal-2232203-line-9)">]</text><text class="terminal-2232203-r2" x="732" y="239.6" textLength="12.2" clip-path="url(#terminal-2232203-line-9)">[</text><text class="terminal-2232203-r1" x="744.2" y="239.6" textLength="158.6" clip-path="url(#terminal-2232203-line-9)">--extra&#160;EXTRA</text><text class="terminal-2232203-r2" x="902.8" y="239.6" textLength="12.2" clip-path="url(#terminal-2232203-line-9)">]</text><text class="terminal-2232203-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2232203-line-9)">
+</text><text class="terminal-2232203-r2" x="183" y="264" textLength="12.2" clip-path="url(#terminal-2232203-line-10)">[</text><text class="terminal-2232203-r1" x="195.2" y="264" textLength="256.2" clip-path="url(#terminal-2232203-line-10)">--file-name&#160;FILE_NAME</text><text class="terminal-2232203-r2" x="451.4" y="264" textLength="12.2" clip-path="url(#terminal-2232203-line-10)">]</text><text class="terminal-2232203-r2" x="475.8" y="264" textLength="12.2" clip-path="url(#terminal-2232203-line-10)">[</text><text class="terminal-2232203-r1" x="488" y="264" textLength="451.4" clip-path="url(#terminal-2232203-line-10)">--prerelease-offset&#160;PRERELEASE_OFFSET</text><text class="terminal-2232203-r2" x="939.4" y="264" textLength="12.2" clip-path="url(#terminal-2232203-line-10)">]</text><text class="terminal-2232203-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2232203-line-10)">
+</text><text class="terminal-2232203-r2" x="183" y="288.4" textLength="12.2" clip-path="url(#terminal-2232203-line-11)">[</text><text class="terminal-2232203-r1" x="195.2" y="288.4" textLength="207.4" clip-path="url(#terminal-2232203-line-11)">--version-scheme&#160;</text><text class="terminal-2232203-r2" x="402.6" y="288.4" textLength="12.2" clip-path="url(#terminal-2232203-line-11)">{</text><text class="terminal-2232203-r1" x="414.8" y="288.4" textLength="256.2" clip-path="url(#terminal-2232203-line-11)">pep440,semver,semver2</text><text class="terminal-2232203-r2" x="671" y="288.4" textLength="12.2" clip-path="url(#terminal-2232203-line-11)">}</text><text class="terminal-2232203-r2" x="683.2" y="288.4" textLength="12.2" clip-path="url(#terminal-2232203-line-11)">]</text><text class="terminal-2232203-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2232203-line-11)">
+</text><text class="terminal-2232203-r2" x="183" y="312.8" textLength="12.2" clip-path="url(#terminal-2232203-line-12)">[</text><text class="terminal-2232203-r1" x="195.2" y="312.8" textLength="183" clip-path="url(#terminal-2232203-line-12)">--version-type&#160;</text><text class="terminal-2232203-r2" x="378.2" y="312.8" textLength="12.2" clip-path="url(#terminal-2232203-line-12)">{</text><text class="terminal-2232203-r1" x="390.4" y="312.8" textLength="256.2" clip-path="url(#terminal-2232203-line-12)">pep440,semver,semver2</text><text class="terminal-2232203-r2" x="646.6" y="312.8" textLength="12.2" clip-path="url(#terminal-2232203-line-12)">}</text><text class="terminal-2232203-r2" x="658.8" y="312.8" textLength="12.2" clip-path="url(#terminal-2232203-line-12)">]</text><text class="terminal-2232203-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2232203-line-12)">
+</text><text class="terminal-2232203-r2" x="183" y="337.2" textLength="12.2" clip-path="url(#terminal-2232203-line-13)">[</text><text class="terminal-2232203-r1" x="195.2" y="337.2" textLength="378.2" clip-path="url(#terminal-2232203-line-13)">--build-metadata&#160;BUILD_METADATA</text><text class="terminal-2232203-r2" x="573.4" y="337.2" textLength="12.2" clip-path="url(#terminal-2232203-line-13)">]</text><text class="terminal-2232203-r2" x="597.8" y="337.2" textLength="12.2" clip-path="url(#terminal-2232203-line-13)">[</text><text class="terminal-2232203-r1" x="610" y="337.2" textLength="122" clip-path="url(#terminal-2232203-line-13)">--get-next</text><text class="terminal-2232203-r2" x="732" y="337.2" textLength="12.2" clip-path="url(#terminal-2232203-line-13)">]</text><text class="terminal-2232203-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2232203-line-13)">
+</text><text class="terminal-2232203-r2" x="183" y="361.6" textLength="12.2" clip-path="url(#terminal-2232203-line-14)">[</text><text class="terminal-2232203-r1" x="195.2" y="361.6" textLength="207.4" clip-path="url(#terminal-2232203-line-14)">--allow-no-commit</text><text class="terminal-2232203-r2" x="402.6" y="361.6" textLength="12.2" clip-path="url(#terminal-2232203-line-14)">]</text><text class="terminal-2232203-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2232203-line-14)">
+</text><text class="terminal-2232203-r2" x="183" y="386" textLength="12.2" clip-path="url(#terminal-2232203-line-15)">[</text><text class="terminal-2232203-r1" x="195.2" y="386" textLength="170.8" clip-path="url(#terminal-2232203-line-15)">MANUAL_VERSION</text><text class="terminal-2232203-r2" x="366" y="386" textLength="12.2" clip-path="url(#terminal-2232203-line-15)">]</text><text class="terminal-2232203-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2232203-line-15)">
+</text><text class="terminal-2232203-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2232203-line-16)">
+</text><text class="terminal-2232203-r1" x="0" y="434.8" textLength="512.4" clip-path="url(#terminal-2232203-line-17)">bump&#160;semantic&#160;version&#160;based&#160;on&#160;the&#160;git&#160;log</text><text class="terminal-2232203-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2232203-line-17)">
+</text><text class="terminal-2232203-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2232203-line-18)">
+</text><text class="terminal-2232203-r1" x="0" y="483.6" textLength="256.2" clip-path="url(#terminal-2232203-line-19)">positional&#160;arguments:</text><text class="terminal-2232203-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2232203-line-19)">
+</text><text class="terminal-2232203-r1" x="0" y="508" textLength="610" clip-path="url(#terminal-2232203-line-20)">&#160;&#160;MANUAL_VERSION&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;to&#160;the&#160;given&#160;version&#160;</text><text class="terminal-2232203-r2" x="610" y="508" textLength="12.2" clip-path="url(#terminal-2232203-line-20)">(</text><text class="terminal-2232203-r1" x="622.2" y="508" textLength="61" clip-path="url(#terminal-2232203-line-20)">e.g:&#160;</text><text class="terminal-2232203-r3" x="683.2" y="508" textLength="36.6" clip-path="url(#terminal-2232203-line-20)">1.5</text><text class="terminal-2232203-r1" x="719.8" y="508" textLength="12.2" clip-path="url(#terminal-2232203-line-20)">.</text><text class="terminal-2232203-r3" x="732" y="508" textLength="12.2" clip-path="url(#terminal-2232203-line-20)">3</text><text class="terminal-2232203-r2" x="744.2" y="508" textLength="12.2" clip-path="url(#terminal-2232203-line-20)">)</text><text class="terminal-2232203-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2232203-line-20)">
+</text><text class="terminal-2232203-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2232203-line-21)">
+</text><text class="terminal-2232203-r1" x="0" y="556.8" textLength="97.6" clip-path="url(#terminal-2232203-line-22)">options:</text><text class="terminal-2232203-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2232203-line-22)">
+</text><text class="terminal-2232203-r1" x="0" y="581.2" textLength="671" clip-path="url(#terminal-2232203-line-23)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-2232203-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-2232203-line-23)">
+</text><text class="terminal-2232203-r1" x="0" y="605.6" textLength="915" clip-path="url(#terminal-2232203-line-24)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;output&#160;to&#160;stdout,&#160;no&#160;commit,&#160;no&#160;modified&#160;files</text><text class="terminal-2232203-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-2232203-line-24)">
+</text><text class="terminal-2232203-r1" x="0" y="630" textLength="793" clip-path="url(#terminal-2232203-line-25)">&#160;&#160;--files-only&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;version&#160;in&#160;the&#160;files&#160;from&#160;the&#160;config</text><text class="terminal-2232203-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-2232203-line-25)">
+</text><text class="terminal-2232203-r1" x="0" y="654.4" textLength="719.8" clip-path="url(#terminal-2232203-line-26)">&#160;&#160;--local-version&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;only&#160;the&#160;local&#160;version&#160;portion</text><text class="terminal-2232203-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-2232203-line-26)">
+</text><text class="terminal-2232203-r1" x="0" y="678.8" textLength="841.8" clip-path="url(#terminal-2232203-line-27)">&#160;&#160;--changelog,&#160;-ch&#160;&#160;&#160;&#160;&#160;&#160;generate&#160;the&#160;changelog&#160;for&#160;the&#160;newest&#160;version</text><text class="terminal-2232203-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-2232203-line-27)">
+</text><text class="terminal-2232203-r1" x="0" y="703.2" textLength="902.8" clip-path="url(#terminal-2232203-line-28)">&#160;&#160;--no-verify&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;this&#160;option&#160;bypasses&#160;the&#160;pre-commit&#160;and&#160;commit-msg</text><text class="terminal-2232203-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-2232203-line-28)">
+</text><text class="terminal-2232203-r1" x="0" y="727.6" textLength="353.8" clip-path="url(#terminal-2232203-line-29)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;hooks</text><text class="terminal-2232203-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-2232203-line-29)">
+</text><text class="terminal-2232203-r1" x="0" y="752" textLength="719.8" clip-path="url(#terminal-2232203-line-30)">&#160;&#160;--yes&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;accept&#160;automatically&#160;questions&#160;done</text><text class="terminal-2232203-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-2232203-line-30)">
+</text><text class="terminal-2232203-r1" x="0" y="776.4" textLength="305" clip-path="url(#terminal-2232203-line-31)">&#160;&#160;--tag-format&#160;TAG_FORMAT</text><text class="terminal-2232203-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-2232203-line-31)">
+</text><text class="terminal-2232203-r1" x="0" y="800.8" textLength="939.4" clip-path="url(#terminal-2232203-line-32)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;format&#160;used&#160;to&#160;tag&#160;the&#160;commit&#160;and&#160;read&#160;it,&#160;use&#160;it</text><text class="terminal-2232203-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-2232203-line-32)">
+</text><text class="terminal-2232203-r1" x="0" y="825.2" textLength="866.2" clip-path="url(#terminal-2232203-line-33)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;in&#160;existing&#160;projects,&#160;wrap&#160;around&#160;simple&#160;quotes</text><text class="terminal-2232203-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-2232203-line-33)">
+</text><text class="terminal-2232203-r1" x="0" y="849.6" textLength="353.8" clip-path="url(#terminal-2232203-line-34)">&#160;&#160;--bump-message&#160;BUMP_MESSAGE</text><text class="terminal-2232203-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-2232203-line-34)">
+</text><text class="terminal-2232203-r1" x="0" y="874" textLength="902.8" clip-path="url(#terminal-2232203-line-35)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;template&#160;used&#160;to&#160;create&#160;the&#160;release&#160;commit,&#160;useful</text><text class="terminal-2232203-r1" x="976" y="874" textLength="12.2" clip-path="url(#terminal-2232203-line-35)">
+</text><text class="terminal-2232203-r1" x="0" y="898.4" textLength="536.8" clip-path="url(#terminal-2232203-line-36)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;when&#160;working&#160;with&#160;CI</text><text class="terminal-2232203-r1" x="976" y="898.4" textLength="12.2" clip-path="url(#terminal-2232203-line-36)">
+</text><text class="terminal-2232203-r1" x="0" y="922.8" textLength="183" clip-path="url(#terminal-2232203-line-37)">&#160;&#160;--prerelease&#160;</text><text class="terminal-2232203-r2" x="183" y="922.8" textLength="12.2" clip-path="url(#terminal-2232203-line-37)">{</text><text class="terminal-2232203-r1" x="195.2" y="922.8" textLength="158.6" clip-path="url(#terminal-2232203-line-37)">alpha,beta,rc</text><text class="terminal-2232203-r2" x="353.8" y="922.8" textLength="12.2" clip-path="url(#terminal-2232203-line-37)">}</text><text class="terminal-2232203-r1" x="366" y="922.8" textLength="73.2" clip-path="url(#terminal-2232203-line-37)">,&#160;-pr&#160;</text><text class="terminal-2232203-r2" x="439.2" y="922.8" textLength="12.2" clip-path="url(#terminal-2232203-line-37)">{</text><text class="terminal-2232203-r1" x="451.4" y="922.8" textLength="158.6" clip-path="url(#terminal-2232203-line-37)">alpha,beta,rc</text><text class="terminal-2232203-r2" x="610" y="922.8" textLength="12.2" clip-path="url(#terminal-2232203-line-37)">}</text><text class="terminal-2232203-r1" x="976" y="922.8" textLength="12.2" clip-path="url(#terminal-2232203-line-37)">
+</text><text class="terminal-2232203-r1" x="0" y="947.2" textLength="597.8" clip-path="url(#terminal-2232203-line-38)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;choose&#160;type&#160;of&#160;prerelease</text><text class="terminal-2232203-r1" x="976" y="947.2" textLength="12.2" clip-path="url(#terminal-2232203-line-38)">
+</text><text class="terminal-2232203-r1" x="0" y="971.6" textLength="488" clip-path="url(#terminal-2232203-line-39)">&#160;&#160;--devrelease&#160;DEVRELEASE,&#160;-d&#160;DEVRELEASE</text><text class="terminal-2232203-r1" x="976" y="971.6" textLength="12.2" clip-path="url(#terminal-2232203-line-39)">
+</text><text class="terminal-2232203-r1" x="0" y="996" textLength="841.8" clip-path="url(#terminal-2232203-line-40)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;specify&#160;non-negative&#160;integer&#160;for&#160;dev.&#160;release</text><text class="terminal-2232203-r1" x="976" y="996" textLength="12.2" clip-path="url(#terminal-2232203-line-40)">
+</text><text class="terminal-2232203-r1" x="0" y="1020.4" textLength="170.8" clip-path="url(#terminal-2232203-line-41)">&#160;&#160;--increment&#160;</text><text class="terminal-2232203-r2" x="170.8" y="1020.4" textLength="12.2" clip-path="url(#terminal-2232203-line-41)">{</text><text class="terminal-2232203-r1" x="183" y="1020.4" textLength="207.4" clip-path="url(#terminal-2232203-line-41)">MAJOR,MINOR,PATCH</text><text class="terminal-2232203-r2" x="390.4" y="1020.4" textLength="12.2" clip-path="url(#terminal-2232203-line-41)">}</text><text class="terminal-2232203-r1" x="976" y="1020.4" textLength="12.2" clip-path="url(#terminal-2232203-line-41)">
+</text><text class="terminal-2232203-r1" x="0" y="1044.8" textLength="756.4" clip-path="url(#terminal-2232203-line-42)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;manually&#160;specify&#160;the&#160;desired&#160;increment</text><text class="terminal-2232203-r1" x="976" y="1044.8" textLength="12.2" clip-path="url(#terminal-2232203-line-42)">
+</text><text class="terminal-2232203-r1" x="0" y="1069.2" textLength="231.8" clip-path="url(#terminal-2232203-line-43)">&#160;&#160;--increment-mode&#160;</text><text class="terminal-2232203-r2" x="231.8" y="1069.2" textLength="12.2" clip-path="url(#terminal-2232203-line-43)">{</text><text class="terminal-2232203-r1" x="244" y="1069.2" textLength="146.4" clip-path="url(#terminal-2232203-line-43)">linear,exact</text><text class="terminal-2232203-r2" x="390.4" y="1069.2" textLength="12.2" clip-path="url(#terminal-2232203-line-43)">}</text><text class="terminal-2232203-r1" x="976" y="1069.2" textLength="12.2" clip-path="url(#terminal-2232203-line-43)">
+</text><text class="terminal-2232203-r1" x="0" y="1093.6" textLength="902.8" clip-path="url(#terminal-2232203-line-44)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;set&#160;the&#160;method&#160;by&#160;which&#160;the&#160;new&#160;version&#160;is&#160;chosen.</text><text class="terminal-2232203-r1" x="976" y="1093.6" textLength="12.2" clip-path="url(#terminal-2232203-line-44)">
+</text><text class="terminal-2232203-r4" x="292.8" y="1118" textLength="97.6" clip-path="url(#terminal-2232203-line-45)">&#x27;linear&#x27;</text><text class="terminal-2232203-r2" x="402.6" y="1118" textLength="12.2" clip-path="url(#terminal-2232203-line-45)">(</text><text class="terminal-2232203-r1" x="414.8" y="1118" textLength="85.4" clip-path="url(#terminal-2232203-line-45)">default</text><text class="terminal-2232203-r2" x="500.2" y="1118" textLength="12.2" clip-path="url(#terminal-2232203-line-45)">)</text><text class="terminal-2232203-r1" x="512.4" y="1118" textLength="414.8" clip-path="url(#terminal-2232203-line-45)">&#160;guesses&#160;the&#160;next&#160;version&#160;based&#160;on</text><text class="terminal-2232203-r1" x="976" y="1118" textLength="12.2" clip-path="url(#terminal-2232203-line-45)">
+</text><text class="terminal-2232203-r1" x="0" y="1142.4" textLength="939.4" clip-path="url(#terminal-2232203-line-46)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;typical&#160;linear&#160;version&#160;progression,&#160;such&#160;that&#160;bumping</text><text class="terminal-2232203-r1" x="976" y="1142.4" textLength="12.2" clip-path="url(#terminal-2232203-line-46)">
+</text><text class="terminal-2232203-r1" x="0" y="1166.8" textLength="866.2" clip-path="url(#terminal-2232203-line-47)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;of&#160;a&#160;pre-release&#160;with&#160;lower&#160;precedence&#160;than&#160;the</text><text class="terminal-2232203-r1" x="976" y="1166.8" textLength="12.2" clip-path="url(#terminal-2232203-line-47)">
+</text><text class="terminal-2232203-r1" x="0" y="1191.2" textLength="939.4" clip-path="url(#terminal-2232203-line-48)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;current&#160;pre-release&#160;phase&#160;maintains&#160;the&#160;current&#160;phase</text><text class="terminal-2232203-r1" x="976" y="1191.2" textLength="12.2" clip-path="url(#terminal-2232203-line-48)">
+</text><text class="terminal-2232203-r1" x="0" y="1215.6" textLength="561.2" clip-path="url(#terminal-2232203-line-49)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;of&#160;higher&#160;precedence.&#160;</text><text class="terminal-2232203-r4" x="561.2" y="1215.6" textLength="85.4" clip-path="url(#terminal-2232203-line-49)">&#x27;exact&#x27;</text><text class="terminal-2232203-r1" x="646.6" y="1215.6" textLength="305" clip-path="url(#terminal-2232203-line-49)">&#160;applies&#160;the&#160;changes&#160;that</text><text class="terminal-2232203-r1" x="976" y="1215.6" textLength="12.2" clip-path="url(#terminal-2232203-line-49)">
+</text><text class="terminal-2232203-r1" x="0" y="1240" textLength="536.8" clip-path="url(#terminal-2232203-line-50)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;have&#160;been&#160;specified&#160;</text><text class="terminal-2232203-r2" x="536.8" y="1240" textLength="12.2" clip-path="url(#terminal-2232203-line-50)">(</text><text class="terminal-2232203-r1" x="549" y="1240" textLength="353.8" clip-path="url(#terminal-2232203-line-50)">or&#160;determined&#160;from&#160;the&#160;commit</text><text class="terminal-2232203-r1" x="976" y="1240" textLength="12.2" clip-path="url(#terminal-2232203-line-50)">
+</text><text class="terminal-2232203-r1" x="0" y="1264.4" textLength="329.4" clip-path="url(#terminal-2232203-line-51)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;log</text><text class="terminal-2232203-r2" x="329.4" y="1264.4" textLength="12.2" clip-path="url(#terminal-2232203-line-51)">)</text><text class="terminal-2232203-r1" x="341.6" y="1264.4" textLength="585.6" clip-path="url(#terminal-2232203-line-51)">&#160;without&#160;interpretation,&#160;such&#160;that&#160;the&#160;increment</text><text class="terminal-2232203-r1" x="976" y="1264.4" textLength="12.2" clip-path="url(#terminal-2232203-line-51)">
+</text><text class="terminal-2232203-r1" x="0" y="1288.8" textLength="707.6" clip-path="url(#terminal-2232203-line-52)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;and&#160;pre-release&#160;are&#160;always&#160;honored</text><text class="terminal-2232203-r1" x="976" y="1288.8" textLength="12.2" clip-path="url(#terminal-2232203-line-52)">
+</text><text class="terminal-2232203-r1" x="0" y="1313.2" textLength="317.2" clip-path="url(#terminal-2232203-line-53)">&#160;&#160;--check-consistency,&#160;-cc</text><text class="terminal-2232203-r1" x="976" y="1313.2" textLength="12.2" clip-path="url(#terminal-2232203-line-53)">
+</text><text class="terminal-2232203-r1" x="0" y="1337.6" textLength="951.6" clip-path="url(#terminal-2232203-line-54)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;check&#160;consistency&#160;among&#160;versions&#160;defined&#160;in&#160;commitizen</text><text class="terminal-2232203-r1" x="976" y="1337.6" textLength="12.2" clip-path="url(#terminal-2232203-line-54)">
+</text><text class="terminal-2232203-r1" x="0" y="1362" textLength="671" clip-path="url(#terminal-2232203-line-55)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;configuration&#160;and&#160;version_files</text><text class="terminal-2232203-r1" x="976" y="1362" textLength="12.2" clip-path="url(#terminal-2232203-line-55)">
+</text><text class="terminal-2232203-r1" x="0" y="1386.4" textLength="866.2" clip-path="url(#terminal-2232203-line-56)">&#160;&#160;--annotated-tag,&#160;-at&#160;&#160;create&#160;annotated&#160;tag&#160;instead&#160;of&#160;lightweight&#160;one</text><text class="terminal-2232203-r1" x="976" y="1386.4" textLength="12.2" clip-path="url(#terminal-2232203-line-56)">
+</text><text class="terminal-2232203-r1" x="0" y="1410.8" textLength="915" clip-path="url(#terminal-2232203-line-57)">&#160;&#160;--annotated-tag-message&#160;ANNOTATED_TAG_MESSAGE,&#160;-atm&#160;ANNOTATED_TAG_MESSAGE</text><text class="terminal-2232203-r1" x="976" y="1410.8" textLength="12.2" clip-path="url(#terminal-2232203-line-57)">
+</text><text class="terminal-2232203-r1" x="0" y="1435.2" textLength="634.4" clip-path="url(#terminal-2232203-line-58)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;create&#160;annotated&#160;tag&#160;message</text><text class="terminal-2232203-r1" x="976" y="1435.2" textLength="12.2" clip-path="url(#terminal-2232203-line-58)">
+</text><text class="terminal-2232203-r1" x="0" y="1459.6" textLength="719.8" clip-path="url(#terminal-2232203-line-59)">&#160;&#160;--gpg-sign,&#160;-s&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sign&#160;tag&#160;instead&#160;of&#160;lightweight&#160;one</text><text class="terminal-2232203-r1" x="976" y="1459.6" textLength="12.2" clip-path="url(#terminal-2232203-line-59)">
+</text><text class="terminal-2232203-r1" x="0" y="1484" textLength="280.6" clip-path="url(#terminal-2232203-line-60)">&#160;&#160;--changelog-to-stdout</text><text class="terminal-2232203-r1" x="976" y="1484" textLength="12.2" clip-path="url(#terminal-2232203-line-60)">
+</text><text class="terminal-2232203-r1" x="0" y="1508.4" textLength="658.8" clip-path="url(#terminal-2232203-line-61)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Output&#160;changelog&#160;to&#160;the&#160;stdout</text><text class="terminal-2232203-r1" x="976" y="1508.4" textLength="12.2" clip-path="url(#terminal-2232203-line-61)">
+</text><text class="terminal-2232203-r1" x="0" y="1532.8" textLength="292.8" clip-path="url(#terminal-2232203-line-62)">&#160;&#160;--git-output-to-stderr</text><text class="terminal-2232203-r1" x="976" y="1532.8" textLength="12.2" clip-path="url(#terminal-2232203-line-62)">
+</text><text class="terminal-2232203-r1" x="0" y="1557.2" textLength="646.6" clip-path="url(#terminal-2232203-line-63)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Redirect&#160;git&#160;output&#160;to&#160;stderr</text><text class="terminal-2232203-r1" x="976" y="1557.2" textLength="12.2" clip-path="url(#terminal-2232203-line-63)">
+</text><text class="terminal-2232203-r1" x="0" y="1581.6" textLength="744.2" clip-path="url(#terminal-2232203-line-64)">&#160;&#160;--retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;retry&#160;commit&#160;if&#160;it&#160;fails&#160;the&#160;1st&#160;time</text><text class="terminal-2232203-r1" x="976" y="1581.6" textLength="12.2" clip-path="url(#terminal-2232203-line-64)">
+</text><text class="terminal-2232203-r1" x="0" y="1606" textLength="939.4" clip-path="url(#terminal-2232203-line-65)">&#160;&#160;--major-version-zero&#160;&#160;keep&#160;major&#160;version&#160;at&#160;zero,&#160;even&#160;for&#160;breaking&#160;changes</text><text class="terminal-2232203-r1" x="976" y="1606" textLength="12.2" clip-path="url(#terminal-2232203-line-65)">
+</text><text class="terminal-2232203-r1" x="0" y="1630.4" textLength="414.8" clip-path="url(#terminal-2232203-line-66)">&#160;&#160;--template&#160;TEMPLATE,&#160;-t&#160;TEMPLATE</text><text class="terminal-2232203-r1" x="976" y="1630.4" textLength="12.2" clip-path="url(#terminal-2232203-line-66)">
+</text><text class="terminal-2232203-r1" x="0" y="1654.8" textLength="646.6" clip-path="url(#terminal-2232203-line-67)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;changelog&#160;template&#160;file&#160;name&#160;</text><text class="terminal-2232203-r2" x="646.6" y="1654.8" textLength="12.2" clip-path="url(#terminal-2232203-line-67)">(</text><text class="terminal-2232203-r1" x="658.8" y="1654.8" textLength="280.6" clip-path="url(#terminal-2232203-line-67)">relative&#160;to&#160;the&#160;current</text><text class="terminal-2232203-r1" x="976" y="1654.8" textLength="12.2" clip-path="url(#terminal-2232203-line-67)">
+</text><text class="terminal-2232203-r1" x="0" y="1679.2" textLength="500.2" clip-path="url(#terminal-2232203-line-68)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;working&#160;directory</text><text class="terminal-2232203-r2" x="500.2" y="1679.2" textLength="12.2" clip-path="url(#terminal-2232203-line-68)">)</text><text class="terminal-2232203-r1" x="976" y="1679.2" textLength="12.2" clip-path="url(#terminal-2232203-line-68)">
+</text><text class="terminal-2232203-r1" x="0" y="1703.6" textLength="305" clip-path="url(#terminal-2232203-line-69)">&#160;&#160;--extra&#160;EXTRA,&#160;-e&#160;EXTRA</text><text class="terminal-2232203-r1" x="976" y="1703.6" textLength="12.2" clip-path="url(#terminal-2232203-line-69)">
+</text><text class="terminal-2232203-r1" x="0" y="1728" textLength="622.2" clip-path="url(#terminal-2232203-line-70)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;a&#160;changelog&#160;extra&#160;variable&#160;</text><text class="terminal-2232203-r2" x="622.2" y="1728" textLength="12.2" clip-path="url(#terminal-2232203-line-70)">(</text><text class="terminal-2232203-r1" x="634.4" y="1728" textLength="146.4" clip-path="url(#terminal-2232203-line-70)">in&#160;the&#160;form&#160;</text><text class="terminal-2232203-r4" x="780.8" y="1728" textLength="12.2" clip-path="url(#terminal-2232203-line-70)">&#x27;</text><text class="terminal-2232203-r4" x="793" y="1728" textLength="36.6" clip-path="url(#terminal-2232203-line-70)">key</text><text class="terminal-2232203-r4" x="829.6" y="1728" textLength="12.2" clip-path="url(#terminal-2232203-line-70)">=</text><text class="terminal-2232203-r4" x="841.8" y="1728" textLength="61" clip-path="url(#terminal-2232203-line-70)">value</text><text class="terminal-2232203-r4" x="902.8" y="1728" textLength="12.2" clip-path="url(#terminal-2232203-line-70)">&#x27;</text><text class="terminal-2232203-r2" x="915" y="1728" textLength="12.2" clip-path="url(#terminal-2232203-line-70)">)</text><text class="terminal-2232203-r1" x="976" y="1728" textLength="12.2" clip-path="url(#terminal-2232203-line-70)">
+</text><text class="terminal-2232203-r1" x="0" y="1752.4" textLength="280.6" clip-path="url(#terminal-2232203-line-71)">&#160;&#160;--file-name&#160;FILE_NAME</text><text class="terminal-2232203-r1" x="976" y="1752.4" textLength="12.2" clip-path="url(#terminal-2232203-line-71)">
+</text><text class="terminal-2232203-r1" x="0" y="1776.8" textLength="573.4" clip-path="url(#terminal-2232203-line-72)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;file&#160;name&#160;of&#160;changelog&#160;</text><text class="terminal-2232203-r2" x="573.4" y="1776.8" textLength="12.2" clip-path="url(#terminal-2232203-line-72)">(</text><text class="terminal-2232203-r1" x="585.6" y="1776.8" textLength="109.8" clip-path="url(#terminal-2232203-line-72)">default:&#160;</text><text class="terminal-2232203-r4" x="695.4" y="1776.8" textLength="170.8" clip-path="url(#terminal-2232203-line-72)">&#x27;CHANGELOG.md&#x27;</text><text class="terminal-2232203-r2" x="866.2" y="1776.8" textLength="12.2" clip-path="url(#terminal-2232203-line-72)">)</text><text class="terminal-2232203-r1" x="976" y="1776.8" textLength="12.2" clip-path="url(#terminal-2232203-line-72)">
+</text><text class="terminal-2232203-r1" x="0" y="1801.2" textLength="475.8" clip-path="url(#terminal-2232203-line-73)">&#160;&#160;--prerelease-offset&#160;PRERELEASE_OFFSET</text><text class="terminal-2232203-r1" x="976" y="1801.2" textLength="12.2" clip-path="url(#terminal-2232203-line-73)">
+</text><text class="terminal-2232203-r1" x="0" y="1825.6" textLength="719.8" clip-path="url(#terminal-2232203-line-74)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;start&#160;pre-releases&#160;with&#160;this&#160;offset</text><text class="terminal-2232203-r1" x="976" y="1825.6" textLength="12.2" clip-path="url(#terminal-2232203-line-74)">
+</text><text class="terminal-2232203-r1" x="0" y="1850" textLength="231.8" clip-path="url(#terminal-2232203-line-75)">&#160;&#160;--version-scheme&#160;</text><text class="terminal-2232203-r2" x="231.8" y="1850" textLength="12.2" clip-path="url(#terminal-2232203-line-75)">{</text><text class="terminal-2232203-r1" x="244" y="1850" textLength="256.2" clip-path="url(#terminal-2232203-line-75)">pep440,semver,semver2</text><text class="terminal-2232203-r2" x="500.2" y="1850" textLength="12.2" clip-path="url(#terminal-2232203-line-75)">}</text><text class="terminal-2232203-r1" x="976" y="1850" textLength="12.2" clip-path="url(#terminal-2232203-line-75)">
+</text><text class="terminal-2232203-r1" x="0" y="1874.4" textLength="549" clip-path="url(#terminal-2232203-line-76)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;choose&#160;version&#160;scheme</text><text class="terminal-2232203-r1" x="976" y="1874.4" textLength="12.2" clip-path="url(#terminal-2232203-line-76)">
+</text><text class="terminal-2232203-r1" x="0" y="1898.8" textLength="207.4" clip-path="url(#terminal-2232203-line-77)">&#160;&#160;--version-type&#160;</text><text class="terminal-2232203-r2" x="207.4" y="1898.8" textLength="12.2" clip-path="url(#terminal-2232203-line-77)">{</text><text class="terminal-2232203-r1" x="219.6" y="1898.8" textLength="256.2" clip-path="url(#terminal-2232203-line-77)">pep440,semver,semver2</text><text class="terminal-2232203-r2" x="475.8" y="1898.8" textLength="12.2" clip-path="url(#terminal-2232203-line-77)">}</text><text class="terminal-2232203-r1" x="976" y="1898.8" textLength="12.2" clip-path="url(#terminal-2232203-line-77)">
+</text><text class="terminal-2232203-r1" x="0" y="1923.2" textLength="683.2" clip-path="url(#terminal-2232203-line-78)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Deprecated,&#160;use&#160;--version-scheme</text><text class="terminal-2232203-r1" x="976" y="1923.2" textLength="12.2" clip-path="url(#terminal-2232203-line-78)">
+</text><text class="terminal-2232203-r1" x="0" y="1947.6" textLength="402.6" clip-path="url(#terminal-2232203-line-79)">&#160;&#160;--build-metadata&#160;BUILD_METADATA</text><text class="terminal-2232203-r1" x="976" y="1947.6" textLength="12.2" clip-path="url(#terminal-2232203-line-79)">
+</text><text class="terminal-2232203-r1" x="0" y="1972" textLength="915" clip-path="url(#terminal-2232203-line-80)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Add&#160;additional&#160;build-metadata&#160;to&#160;the&#160;version-number</text><text class="terminal-2232203-r1" x="976" y="1972" textLength="12.2" clip-path="url(#terminal-2232203-line-80)">
+</text><text class="terminal-2232203-r1" x="0" y="1996.4" textLength="854" clip-path="url(#terminal-2232203-line-81)">&#160;&#160;--get-next&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Determine&#160;the&#160;next&#160;version&#160;and&#160;write&#160;to&#160;stdout</text><text class="terminal-2232203-r1" x="976" y="1996.4" textLength="12.2" clip-path="url(#terminal-2232203-line-81)">
+</text><text class="terminal-2232203-r1" x="0" y="2020.8" textLength="744.2" clip-path="url(#terminal-2232203-line-82)">&#160;&#160;--allow-no-commit&#160;&#160;&#160;&#160;&#160;bump&#160;version&#160;without&#160;eligible&#160;commits</text><text class="terminal-2232203-r1" x="976" y="2020.8" textLength="12.2" clip-path="url(#terminal-2232203-line-82)">
+</text><text class="terminal-2232203-r1" x="976" y="2045.2" textLength="12.2" clip-path="url(#terminal-2232203-line-83)">
 </text>
     </g>
     </g>

--- a/docs/images/cli_help/cz_changelog___help.svg
+++ b/docs/images/cli_help/cz_changelog___help.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 994 1050.4" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 1074.8" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,202 +19,206 @@
         font-weight: 700;
     }
 
-    .terminal-1106739011-matrix {
+    .terminal-2035912735-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-1106739011-title {
+    .terminal-2035912735-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-1106739011-r1 { fill: #c5c8c6 }
-.terminal-1106739011-r2 { fill: #c5c8c6;font-weight: bold }
-.terminal-1106739011-r3 { fill: #68a0b3;font-weight: bold }
-.terminal-1106739011-r4 { fill: #98a84b }
+    .terminal-2035912735-r1 { fill: #c5c8c6 }
+.terminal-2035912735-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-2035912735-r3 { fill: #68a0b3;font-weight: bold }
+.terminal-2035912735-r4 { fill: #98a84b }
     </style>
 
     <defs>
-    <clipPath id="terminal-1106739011-clip-terminal">
-      <rect x="0" y="0" width="975.0" height="999.4" />
+    <clipPath id="terminal-2035912735-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="1023.8" />
     </clipPath>
-    <clipPath id="terminal-1106739011-line-0">
+    <clipPath id="terminal-2035912735-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-1">
+<clipPath id="terminal-2035912735-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-2">
+<clipPath id="terminal-2035912735-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-3">
+<clipPath id="terminal-2035912735-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-4">
+<clipPath id="terminal-2035912735-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-5">
+<clipPath id="terminal-2035912735-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-6">
+<clipPath id="terminal-2035912735-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-7">
+<clipPath id="terminal-2035912735-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-8">
+<clipPath id="terminal-2035912735-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-9">
+<clipPath id="terminal-2035912735-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-10">
+<clipPath id="terminal-2035912735-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-11">
+<clipPath id="terminal-2035912735-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-12">
+<clipPath id="terminal-2035912735-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-13">
+<clipPath id="terminal-2035912735-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-14">
+<clipPath id="terminal-2035912735-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-15">
+<clipPath id="terminal-2035912735-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-16">
+<clipPath id="terminal-2035912735-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-17">
+<clipPath id="terminal-2035912735-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-18">
+<clipPath id="terminal-2035912735-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-19">
+<clipPath id="terminal-2035912735-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-20">
+<clipPath id="terminal-2035912735-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-21">
+<clipPath id="terminal-2035912735-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-22">
+<clipPath id="terminal-2035912735-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-23">
+<clipPath id="terminal-2035912735-line-23">
     <rect x="0" y="562.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-24">
+<clipPath id="terminal-2035912735-line-24">
     <rect x="0" y="587.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-25">
+<clipPath id="terminal-2035912735-line-25">
     <rect x="0" y="611.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-26">
+<clipPath id="terminal-2035912735-line-26">
     <rect x="0" y="635.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-27">
+<clipPath id="terminal-2035912735-line-27">
     <rect x="0" y="660.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-28">
+<clipPath id="terminal-2035912735-line-28">
     <rect x="0" y="684.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-29">
+<clipPath id="terminal-2035912735-line-29">
     <rect x="0" y="709.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-30">
+<clipPath id="terminal-2035912735-line-30">
     <rect x="0" y="733.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-31">
+<clipPath id="terminal-2035912735-line-31">
     <rect x="0" y="757.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-32">
+<clipPath id="terminal-2035912735-line-32">
     <rect x="0" y="782.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-33">
+<clipPath id="terminal-2035912735-line-33">
     <rect x="0" y="806.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-34">
+<clipPath id="terminal-2035912735-line-34">
     <rect x="0" y="831.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-35">
+<clipPath id="terminal-2035912735-line-35">
     <rect x="0" y="855.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-36">
+<clipPath id="terminal-2035912735-line-36">
     <rect x="0" y="879.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-37">
+<clipPath id="terminal-2035912735-line-37">
     <rect x="0" y="904.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-38">
+<clipPath id="terminal-2035912735-line-38">
     <rect x="0" y="928.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1106739011-line-39">
+<clipPath id="terminal-2035912735-line-39">
     <rect x="0" y="953.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2035912735-line-40">
+    <rect x="0" y="977.5" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="1048.4" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="1072.8" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-1106739011-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2035912735-clip-terminal)">
     
-    <g class="terminal-1106739011-matrix">
-    <text class="terminal-1106739011-r1" x="0" y="20" textLength="256.2" clip-path="url(#terminal-1106739011-line-0)">$&#160;cz&#160;changelog&#160;--help</text><text class="terminal-1106739011-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1106739011-line-0)">
-</text><text class="terminal-1106739011-r1" x="0" y="44.4" textLength="244" clip-path="url(#terminal-1106739011-line-1)">usage:&#160;cz&#160;changelog&#160;</text><text class="terminal-1106739011-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-1)">[</text><text class="terminal-1106739011-r1" x="256.2" y="44.4" textLength="24.4" clip-path="url(#terminal-1106739011-line-1)">-h</text><text class="terminal-1106739011-r2" x="280.6" y="44.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-1)">]</text><text class="terminal-1106739011-r2" x="305" y="44.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-1)">[</text><text class="terminal-1106739011-r1" x="317.2" y="44.4" textLength="109.8" clip-path="url(#terminal-1106739011-line-1)">--dry-run</text><text class="terminal-1106739011-r2" x="427" y="44.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-1)">]</text><text class="terminal-1106739011-r2" x="451.4" y="44.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-1)">[</text><text class="terminal-1106739011-r1" x="463.6" y="44.4" textLength="256.2" clip-path="url(#terminal-1106739011-line-1)">--file-name&#160;FILE_NAME</text><text class="terminal-1106739011-r2" x="719.8" y="44.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-1)">]</text><text class="terminal-1106739011-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-1)">
-</text><text class="terminal-1106739011-r2" x="244" y="68.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-2)">[</text><text class="terminal-1106739011-r1" x="256.2" y="68.8" textLength="475.8" clip-path="url(#terminal-1106739011-line-2)">--unreleased-version&#160;UNRELEASED_VERSION</text><text class="terminal-1106739011-r2" x="732" y="68.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-2)">]</text><text class="terminal-1106739011-r2" x="756.4" y="68.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-2)">[</text><text class="terminal-1106739011-r1" x="768.6" y="68.8" textLength="158.6" clip-path="url(#terminal-1106739011-line-2)">--incremental</text><text class="terminal-1106739011-r2" x="927.2" y="68.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-2)">]</text><text class="terminal-1106739011-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-2)">
-</text><text class="terminal-1106739011-r2" x="244" y="93.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-3)">[</text><text class="terminal-1106739011-r1" x="256.2" y="93.2" textLength="256.2" clip-path="url(#terminal-1106739011-line-3)">--start-rev&#160;START_REV</text><text class="terminal-1106739011-r2" x="512.4" y="93.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-3)">]</text><text class="terminal-1106739011-r2" x="536.8" y="93.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-3)">[</text><text class="terminal-1106739011-r1" x="549" y="93.2" textLength="219.6" clip-path="url(#terminal-1106739011-line-3)">--merge-prerelease</text><text class="terminal-1106739011-r2" x="768.6" y="93.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-3)">]</text><text class="terminal-1106739011-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-3)">
-</text><text class="terminal-1106739011-r2" x="244" y="117.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-4)">[</text><text class="terminal-1106739011-r1" x="256.2" y="117.6" textLength="207.4" clip-path="url(#terminal-1106739011-line-4)">--version-scheme&#160;</text><text class="terminal-1106739011-r2" x="463.6" y="117.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-4)">{</text><text class="terminal-1106739011-r1" x="475.8" y="117.6" textLength="256.2" clip-path="url(#terminal-1106739011-line-4)">pep440,semver,semver2</text><text class="terminal-1106739011-r2" x="732" y="117.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-4)">}</text><text class="terminal-1106739011-r2" x="744.2" y="117.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-4)">]</text><text class="terminal-1106739011-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-4)">
-</text><text class="terminal-1106739011-r2" x="244" y="142" textLength="12.2" clip-path="url(#terminal-1106739011-line-5)">[</text><text class="terminal-1106739011-r1" x="256.2" y="142" textLength="402.6" clip-path="url(#terminal-1106739011-line-5)">--export-template&#160;EXPORT_TEMPLATE</text><text class="terminal-1106739011-r2" x="658.8" y="142" textLength="12.2" clip-path="url(#terminal-1106739011-line-5)">]</text><text class="terminal-1106739011-r2" x="683.2" y="142" textLength="12.2" clip-path="url(#terminal-1106739011-line-5)">[</text><text class="terminal-1106739011-r1" x="695.4" y="142" textLength="231.8" clip-path="url(#terminal-1106739011-line-5)">--template&#160;TEMPLATE</text><text class="terminal-1106739011-r2" x="927.2" y="142" textLength="12.2" clip-path="url(#terminal-1106739011-line-5)">]</text><text class="terminal-1106739011-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1106739011-line-5)">
-</text><text class="terminal-1106739011-r2" x="244" y="166.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-6)">[</text><text class="terminal-1106739011-r1" x="256.2" y="166.4" textLength="158.6" clip-path="url(#terminal-1106739011-line-6)">--extra&#160;EXTRA</text><text class="terminal-1106739011-r2" x="414.8" y="166.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-6)">]</text><text class="terminal-1106739011-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-6)">
-</text><text class="terminal-1106739011-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-7)">
-</text><text class="terminal-1106739011-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-8)">
-</text><text class="terminal-1106739011-r1" x="0" y="239.6" textLength="231.8" clip-path="url(#terminal-1106739011-line-9)">generate&#160;changelog&#160;</text><text class="terminal-1106739011-r2" x="231.8" y="239.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-9)">(</text><text class="terminal-1106739011-r1" x="244" y="239.6" textLength="500.2" clip-path="url(#terminal-1106739011-line-9)">note&#160;that&#160;it&#160;will&#160;overwrite&#160;existing&#160;file</text><text class="terminal-1106739011-r2" x="744.2" y="239.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-9)">)</text><text class="terminal-1106739011-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-9)">
-</text><text class="terminal-1106739011-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1106739011-line-10)">
-</text><text class="terminal-1106739011-r1" x="0" y="288.4" textLength="256.2" clip-path="url(#terminal-1106739011-line-11)">positional&#160;arguments:</text><text class="terminal-1106739011-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-11)">
-</text><text class="terminal-1106739011-r1" x="0" y="312.8" textLength="805.2" clip-path="url(#terminal-1106739011-line-12)">&#160;&#160;rev_range&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;generates&#160;changelog&#160;for&#160;the&#160;given&#160;version&#160;</text><text class="terminal-1106739011-r2" x="805.2" y="312.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-12)">(</text><text class="terminal-1106739011-r1" x="817.4" y="312.8" textLength="61" clip-path="url(#terminal-1106739011-line-12)">e.g:&#160;</text><text class="terminal-1106739011-r3" x="878.4" y="312.8" textLength="36.6" clip-path="url(#terminal-1106739011-line-12)">1.5</text><text class="terminal-1106739011-r1" x="915" y="312.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-12)">.</text><text class="terminal-1106739011-r3" x="927.2" y="312.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-12)">3</text><text class="terminal-1106739011-r2" x="939.4" y="312.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-12)">)</text><text class="terminal-1106739011-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-12)">
-</text><text class="terminal-1106739011-r1" x="0" y="337.2" textLength="500.2" clip-path="url(#terminal-1106739011-line-13)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;or&#160;version&#160;range&#160;</text><text class="terminal-1106739011-r2" x="500.2" y="337.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-13)">(</text><text class="terminal-1106739011-r1" x="512.4" y="337.2" textLength="61" clip-path="url(#terminal-1106739011-line-13)">e.g:&#160;</text><text class="terminal-1106739011-r3" x="573.4" y="337.2" textLength="36.6" clip-path="url(#terminal-1106739011-line-13)">1.5</text><text class="terminal-1106739011-r1" x="610" y="337.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-13)">.</text><text class="terminal-1106739011-r3" x="622.2" y="337.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-13)">3</text><text class="terminal-1106739011-r1" x="634.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1106739011-line-13)">..</text><text class="terminal-1106739011-r3" x="658.8" y="337.2" textLength="36.6" clip-path="url(#terminal-1106739011-line-13)">1.7</text><text class="terminal-1106739011-r1" x="695.4" y="337.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-13)">.</text><text class="terminal-1106739011-r3" x="707.6" y="337.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-13)">9</text><text class="terminal-1106739011-r2" x="719.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-13)">)</text><text class="terminal-1106739011-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-13)">
-</text><text class="terminal-1106739011-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-14)">
-</text><text class="terminal-1106739011-r1" x="0" y="386" textLength="97.6" clip-path="url(#terminal-1106739011-line-15)">options:</text><text class="terminal-1106739011-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1106739011-line-15)">
-</text><text class="terminal-1106739011-r1" x="0" y="410.4" textLength="671" clip-path="url(#terminal-1106739011-line-16)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-1106739011-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-16)">
-</text><text class="terminal-1106739011-r1" x="0" y="434.8" textLength="585.6" clip-path="url(#terminal-1106739011-line-17)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;changelog&#160;to&#160;stdout</text><text class="terminal-1106739011-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-17)">
-</text><text class="terminal-1106739011-r1" x="0" y="459.2" textLength="280.6" clip-path="url(#terminal-1106739011-line-18)">&#160;&#160;--file-name&#160;FILE_NAME</text><text class="terminal-1106739011-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-18)">
-</text><text class="terminal-1106739011-r1" x="0" y="483.6" textLength="573.4" clip-path="url(#terminal-1106739011-line-19)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;file&#160;name&#160;of&#160;changelog&#160;</text><text class="terminal-1106739011-r2" x="573.4" y="483.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-19)">(</text><text class="terminal-1106739011-r1" x="585.6" y="483.6" textLength="109.8" clip-path="url(#terminal-1106739011-line-19)">default:&#160;</text><text class="terminal-1106739011-r4" x="695.4" y="483.6" textLength="170.8" clip-path="url(#terminal-1106739011-line-19)">&#x27;CHANGELOG.md&#x27;</text><text class="terminal-1106739011-r2" x="866.2" y="483.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-19)">)</text><text class="terminal-1106739011-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-19)">
-</text><text class="terminal-1106739011-r1" x="0" y="508" textLength="500.2" clip-path="url(#terminal-1106739011-line-20)">&#160;&#160;--unreleased-version&#160;UNRELEASED_VERSION</text><text class="terminal-1106739011-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1106739011-line-20)">
-</text><text class="terminal-1106739011-r1" x="0" y="532.4" textLength="707.6" clip-path="url(#terminal-1106739011-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;set&#160;the&#160;value&#160;for&#160;the&#160;new&#160;version&#160;</text><text class="terminal-1106739011-r2" x="707.6" y="532.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-21)">(</text><text class="terminal-1106739011-r1" x="719.8" y="532.4" textLength="207.4" clip-path="url(#terminal-1106739011-line-21)">use&#160;the&#160;tag&#160;value</text><text class="terminal-1106739011-r2" x="927.2" y="532.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-21)">)</text><text class="terminal-1106739011-r1" x="939.4" y="532.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-21)">,</text><text class="terminal-1106739011-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-21)">
-</text><text class="terminal-1106739011-r1" x="0" y="556.8" textLength="622.2" clip-path="url(#terminal-1106739011-line-22)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;instead&#160;of&#160;using&#160;unreleased</text><text class="terminal-1106739011-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-22)">
-</text><text class="terminal-1106739011-r1" x="0" y="581.2" textLength="939.4" clip-path="url(#terminal-1106739011-line-23)">&#160;&#160;--incremental&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;generates&#160;changelog&#160;from&#160;last&#160;created&#160;version,&#160;useful</text><text class="terminal-1106739011-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-23)">
-</text><text class="terminal-1106739011-r1" x="0" y="605.6" textLength="817.4" clip-path="url(#terminal-1106739011-line-24)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;if&#160;the&#160;changelog&#160;has&#160;been&#160;manually&#160;modified</text><text class="terminal-1106739011-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-24)">
-</text><text class="terminal-1106739011-r1" x="0" y="630" textLength="280.6" clip-path="url(#terminal-1106739011-line-25)">&#160;&#160;--start-rev&#160;START_REV</text><text class="terminal-1106739011-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-1106739011-line-25)">
-</text><text class="terminal-1106739011-r1" x="0" y="654.4" textLength="866.2" clip-path="url(#terminal-1106739011-line-26)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;start&#160;rev&#160;of&#160;the&#160;changelog.&#160;If&#160;not&#160;set,&#160;it&#160;will</text><text class="terminal-1106739011-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-26)">
-</text><text class="terminal-1106739011-r1" x="0" y="678.8" textLength="695.4" clip-path="url(#terminal-1106739011-line-27)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;generate&#160;changelog&#160;from&#160;the&#160;start</text><text class="terminal-1106739011-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-27)">
-</text><text class="terminal-1106739011-r1" x="0" y="703.2" textLength="915" clip-path="url(#terminal-1106739011-line-28)">&#160;&#160;--merge-prerelease&#160;&#160;&#160;&#160;collect&#160;all&#160;changes&#160;from&#160;prereleases&#160;into&#160;next&#160;non-</text><text class="terminal-1106739011-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-28)">
-</text><text class="terminal-1106739011-r1" x="0" y="727.6" textLength="951.6" clip-path="url(#terminal-1106739011-line-29)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;prerelease.&#160;If&#160;not&#160;set,&#160;it&#160;will&#160;include&#160;prereleases&#160;in</text><text class="terminal-1106739011-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-29)">
-</text><text class="terminal-1106739011-r1" x="0" y="752" textLength="451.4" clip-path="url(#terminal-1106739011-line-30)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;changelog</text><text class="terminal-1106739011-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-1106739011-line-30)">
-</text><text class="terminal-1106739011-r1" x="0" y="776.4" textLength="231.8" clip-path="url(#terminal-1106739011-line-31)">&#160;&#160;--version-scheme&#160;</text><text class="terminal-1106739011-r2" x="231.8" y="776.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-31)">{</text><text class="terminal-1106739011-r1" x="244" y="776.4" textLength="256.2" clip-path="url(#terminal-1106739011-line-31)">pep440,semver,semver2</text><text class="terminal-1106739011-r2" x="500.2" y="776.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-31)">}</text><text class="terminal-1106739011-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-31)">
-</text><text class="terminal-1106739011-r1" x="0" y="800.8" textLength="549" clip-path="url(#terminal-1106739011-line-32)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;choose&#160;version&#160;scheme</text><text class="terminal-1106739011-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-32)">
-</text><text class="terminal-1106739011-r1" x="0" y="825.2" textLength="427" clip-path="url(#terminal-1106739011-line-33)">&#160;&#160;--export-template&#160;EXPORT_TEMPLATE</text><text class="terminal-1106739011-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-33)">
-</text><text class="terminal-1106739011-r1" x="0" y="849.6" textLength="927.2" clip-path="url(#terminal-1106739011-line-34)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Export&#160;the&#160;changelog&#160;template&#160;into&#160;this&#160;file&#160;instead</text><text class="terminal-1106739011-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-34)">
-</text><text class="terminal-1106739011-r1" x="0" y="874" textLength="475.8" clip-path="url(#terminal-1106739011-line-35)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;of&#160;rendering&#160;it</text><text class="terminal-1106739011-r1" x="976" y="874" textLength="12.2" clip-path="url(#terminal-1106739011-line-35)">
-</text><text class="terminal-1106739011-r1" x="0" y="898.4" textLength="305" clip-path="url(#terminal-1106739011-line-36)">&#160;&#160;--template,&#160;-t&#160;TEMPLATE</text><text class="terminal-1106739011-r1" x="976" y="898.4" textLength="12.2" clip-path="url(#terminal-1106739011-line-36)">
-</text><text class="terminal-1106739011-r1" x="0" y="922.8" textLength="646.6" clip-path="url(#terminal-1106739011-line-37)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;changelog&#160;template&#160;file&#160;name&#160;</text><text class="terminal-1106739011-r2" x="646.6" y="922.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-37)">(</text><text class="terminal-1106739011-r1" x="658.8" y="922.8" textLength="280.6" clip-path="url(#terminal-1106739011-line-37)">relative&#160;to&#160;the&#160;current</text><text class="terminal-1106739011-r1" x="976" y="922.8" textLength="12.2" clip-path="url(#terminal-1106739011-line-37)">
-</text><text class="terminal-1106739011-r1" x="0" y="947.2" textLength="500.2" clip-path="url(#terminal-1106739011-line-38)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;working&#160;directory</text><text class="terminal-1106739011-r2" x="500.2" y="947.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-38)">)</text><text class="terminal-1106739011-r1" x="976" y="947.2" textLength="12.2" clip-path="url(#terminal-1106739011-line-38)">
-</text><text class="terminal-1106739011-r1" x="0" y="971.6" textLength="622.2" clip-path="url(#terminal-1106739011-line-39)">&#160;&#160;--extra,&#160;-e&#160;EXTRA&#160;&#160;&#160;&#160;&#160;a&#160;changelog&#160;extra&#160;variable&#160;</text><text class="terminal-1106739011-r2" x="622.2" y="971.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-39)">(</text><text class="terminal-1106739011-r1" x="634.4" y="971.6" textLength="146.4" clip-path="url(#terminal-1106739011-line-39)">in&#160;the&#160;form&#160;</text><text class="terminal-1106739011-r4" x="780.8" y="971.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-39)">&#x27;</text><text class="terminal-1106739011-r4" x="793" y="971.6" textLength="36.6" clip-path="url(#terminal-1106739011-line-39)">key</text><text class="terminal-1106739011-r4" x="829.6" y="971.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-39)">=</text><text class="terminal-1106739011-r4" x="841.8" y="971.6" textLength="61" clip-path="url(#terminal-1106739011-line-39)">value</text><text class="terminal-1106739011-r4" x="902.8" y="971.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-39)">&#x27;</text><text class="terminal-1106739011-r2" x="915" y="971.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-39)">)</text><text class="terminal-1106739011-r1" x="976" y="971.6" textLength="12.2" clip-path="url(#terminal-1106739011-line-39)">
-</text><text class="terminal-1106739011-r1" x="976" y="996" textLength="12.2" clip-path="url(#terminal-1106739011-line-40)">
+    <g class="terminal-2035912735-matrix">
+    <text class="terminal-2035912735-r1" x="0" y="20" textLength="256.2" clip-path="url(#terminal-2035912735-line-0)">$&#160;cz&#160;changelog&#160;--help</text><text class="terminal-2035912735-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2035912735-line-0)">
+</text><text class="terminal-2035912735-r1" x="0" y="44.4" textLength="244" clip-path="url(#terminal-2035912735-line-1)">usage:&#160;cz&#160;changelog&#160;</text><text class="terminal-2035912735-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-1)">[</text><text class="terminal-2035912735-r1" x="256.2" y="44.4" textLength="24.4" clip-path="url(#terminal-2035912735-line-1)">-h</text><text class="terminal-2035912735-r2" x="280.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-1)">]</text><text class="terminal-2035912735-r2" x="305" y="44.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-1)">[</text><text class="terminal-2035912735-r1" x="317.2" y="44.4" textLength="109.8" clip-path="url(#terminal-2035912735-line-1)">--dry-run</text><text class="terminal-2035912735-r2" x="427" y="44.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-1)">]</text><text class="terminal-2035912735-r2" x="451.4" y="44.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-1)">[</text><text class="terminal-2035912735-r1" x="463.6" y="44.4" textLength="256.2" clip-path="url(#terminal-2035912735-line-1)">--file-name&#160;FILE_NAME</text><text class="terminal-2035912735-r2" x="719.8" y="44.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-1)">]</text><text class="terminal-2035912735-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-1)">
+</text><text class="terminal-2035912735-r2" x="244" y="68.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-2)">[</text><text class="terminal-2035912735-r1" x="256.2" y="68.8" textLength="475.8" clip-path="url(#terminal-2035912735-line-2)">--unreleased-version&#160;UNRELEASED_VERSION</text><text class="terminal-2035912735-r2" x="732" y="68.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-2)">]</text><text class="terminal-2035912735-r2" x="756.4" y="68.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-2)">[</text><text class="terminal-2035912735-r1" x="768.6" y="68.8" textLength="158.6" clip-path="url(#terminal-2035912735-line-2)">--incremental</text><text class="terminal-2035912735-r2" x="927.2" y="68.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-2)">]</text><text class="terminal-2035912735-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-2)">
+</text><text class="terminal-2035912735-r2" x="244" y="93.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-3)">[</text><text class="terminal-2035912735-r1" x="256.2" y="93.2" textLength="256.2" clip-path="url(#terminal-2035912735-line-3)">--start-rev&#160;START_REV</text><text class="terminal-2035912735-r2" x="512.4" y="93.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-3)">]</text><text class="terminal-2035912735-r2" x="536.8" y="93.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-3)">[</text><text class="terminal-2035912735-r1" x="549" y="93.2" textLength="219.6" clip-path="url(#terminal-2035912735-line-3)">--merge-prerelease</text><text class="terminal-2035912735-r2" x="768.6" y="93.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-3)">]</text><text class="terminal-2035912735-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-3)">
+</text><text class="terminal-2035912735-r2" x="244" y="117.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-4)">[</text><text class="terminal-2035912735-r1" x="256.2" y="117.6" textLength="207.4" clip-path="url(#terminal-2035912735-line-4)">--version-scheme&#160;</text><text class="terminal-2035912735-r2" x="463.6" y="117.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-4)">{</text><text class="terminal-2035912735-r1" x="475.8" y="117.6" textLength="256.2" clip-path="url(#terminal-2035912735-line-4)">pep440,semver,semver2</text><text class="terminal-2035912735-r2" x="732" y="117.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-4)">}</text><text class="terminal-2035912735-r2" x="744.2" y="117.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-4)">]</text><text class="terminal-2035912735-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-4)">
+</text><text class="terminal-2035912735-r2" x="244" y="142" textLength="12.2" clip-path="url(#terminal-2035912735-line-5)">[</text><text class="terminal-2035912735-r1" x="256.2" y="142" textLength="402.6" clip-path="url(#terminal-2035912735-line-5)">--export-template&#160;EXPORT_TEMPLATE</text><text class="terminal-2035912735-r2" x="658.8" y="142" textLength="12.2" clip-path="url(#terminal-2035912735-line-5)">]</text><text class="terminal-2035912735-r2" x="683.2" y="142" textLength="12.2" clip-path="url(#terminal-2035912735-line-5)">[</text><text class="terminal-2035912735-r1" x="695.4" y="142" textLength="231.8" clip-path="url(#terminal-2035912735-line-5)">--template&#160;TEMPLATE</text><text class="terminal-2035912735-r2" x="927.2" y="142" textLength="12.2" clip-path="url(#terminal-2035912735-line-5)">]</text><text class="terminal-2035912735-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2035912735-line-5)">
+</text><text class="terminal-2035912735-r2" x="244" y="166.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-6)">[</text><text class="terminal-2035912735-r1" x="256.2" y="166.4" textLength="158.6" clip-path="url(#terminal-2035912735-line-6)">--extra&#160;EXTRA</text><text class="terminal-2035912735-r2" x="414.8" y="166.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-6)">]</text><text class="terminal-2035912735-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-6)">
+</text><text class="terminal-2035912735-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-7)">
+</text><text class="terminal-2035912735-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-8)">
+</text><text class="terminal-2035912735-r1" x="0" y="239.6" textLength="231.8" clip-path="url(#terminal-2035912735-line-9)">generate&#160;changelog&#160;</text><text class="terminal-2035912735-r2" x="231.8" y="239.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-9)">(</text><text class="terminal-2035912735-r1" x="244" y="239.6" textLength="500.2" clip-path="url(#terminal-2035912735-line-9)">note&#160;that&#160;it&#160;will&#160;overwrite&#160;existing&#160;file</text><text class="terminal-2035912735-r2" x="744.2" y="239.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-9)">)</text><text class="terminal-2035912735-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-9)">
+</text><text class="terminal-2035912735-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2035912735-line-10)">
+</text><text class="terminal-2035912735-r1" x="0" y="288.4" textLength="256.2" clip-path="url(#terminal-2035912735-line-11)">positional&#160;arguments:</text><text class="terminal-2035912735-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-11)">
+</text><text class="terminal-2035912735-r1" x="0" y="312.8" textLength="805.2" clip-path="url(#terminal-2035912735-line-12)">&#160;&#160;rev_range&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;generates&#160;changelog&#160;for&#160;the&#160;given&#160;version&#160;</text><text class="terminal-2035912735-r2" x="805.2" y="312.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-12)">(</text><text class="terminal-2035912735-r1" x="817.4" y="312.8" textLength="61" clip-path="url(#terminal-2035912735-line-12)">e.g:&#160;</text><text class="terminal-2035912735-r3" x="878.4" y="312.8" textLength="36.6" clip-path="url(#terminal-2035912735-line-12)">1.5</text><text class="terminal-2035912735-r1" x="915" y="312.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-12)">.</text><text class="terminal-2035912735-r3" x="927.2" y="312.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-12)">3</text><text class="terminal-2035912735-r2" x="939.4" y="312.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-12)">)</text><text class="terminal-2035912735-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-12)">
+</text><text class="terminal-2035912735-r1" x="0" y="337.2" textLength="500.2" clip-path="url(#terminal-2035912735-line-13)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;or&#160;version&#160;range&#160;</text><text class="terminal-2035912735-r2" x="500.2" y="337.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-13)">(</text><text class="terminal-2035912735-r1" x="512.4" y="337.2" textLength="61" clip-path="url(#terminal-2035912735-line-13)">e.g:&#160;</text><text class="terminal-2035912735-r3" x="573.4" y="337.2" textLength="36.6" clip-path="url(#terminal-2035912735-line-13)">1.5</text><text class="terminal-2035912735-r1" x="610" y="337.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-13)">.</text><text class="terminal-2035912735-r3" x="622.2" y="337.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-13)">3</text><text class="terminal-2035912735-r1" x="634.4" y="337.2" textLength="24.4" clip-path="url(#terminal-2035912735-line-13)">..</text><text class="terminal-2035912735-r3" x="658.8" y="337.2" textLength="36.6" clip-path="url(#terminal-2035912735-line-13)">1.7</text><text class="terminal-2035912735-r1" x="695.4" y="337.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-13)">.</text><text class="terminal-2035912735-r3" x="707.6" y="337.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-13)">9</text><text class="terminal-2035912735-r2" x="719.8" y="337.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-13)">)</text><text class="terminal-2035912735-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-13)">
+</text><text class="terminal-2035912735-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-14)">
+</text><text class="terminal-2035912735-r1" x="0" y="386" textLength="97.6" clip-path="url(#terminal-2035912735-line-15)">options:</text><text class="terminal-2035912735-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2035912735-line-15)">
+</text><text class="terminal-2035912735-r1" x="0" y="410.4" textLength="671" clip-path="url(#terminal-2035912735-line-16)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-2035912735-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-16)">
+</text><text class="terminal-2035912735-r1" x="0" y="434.8" textLength="585.6" clip-path="url(#terminal-2035912735-line-17)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;changelog&#160;to&#160;stdout</text><text class="terminal-2035912735-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-17)">
+</text><text class="terminal-2035912735-r1" x="0" y="459.2" textLength="280.6" clip-path="url(#terminal-2035912735-line-18)">&#160;&#160;--file-name&#160;FILE_NAME</text><text class="terminal-2035912735-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-18)">
+</text><text class="terminal-2035912735-r1" x="0" y="483.6" textLength="573.4" clip-path="url(#terminal-2035912735-line-19)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;file&#160;name&#160;of&#160;changelog&#160;</text><text class="terminal-2035912735-r2" x="573.4" y="483.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-19)">(</text><text class="terminal-2035912735-r1" x="585.6" y="483.6" textLength="109.8" clip-path="url(#terminal-2035912735-line-19)">default:&#160;</text><text class="terminal-2035912735-r4" x="695.4" y="483.6" textLength="170.8" clip-path="url(#terminal-2035912735-line-19)">&#x27;CHANGELOG.md&#x27;</text><text class="terminal-2035912735-r2" x="866.2" y="483.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-19)">)</text><text class="terminal-2035912735-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-19)">
+</text><text class="terminal-2035912735-r1" x="0" y="508" textLength="500.2" clip-path="url(#terminal-2035912735-line-20)">&#160;&#160;--unreleased-version&#160;UNRELEASED_VERSION</text><text class="terminal-2035912735-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2035912735-line-20)">
+</text><text class="terminal-2035912735-r1" x="0" y="532.4" textLength="707.6" clip-path="url(#terminal-2035912735-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;set&#160;the&#160;value&#160;for&#160;the&#160;new&#160;version&#160;</text><text class="terminal-2035912735-r2" x="707.6" y="532.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-21)">(</text><text class="terminal-2035912735-r1" x="719.8" y="532.4" textLength="207.4" clip-path="url(#terminal-2035912735-line-21)">use&#160;the&#160;tag&#160;value</text><text class="terminal-2035912735-r2" x="927.2" y="532.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-21)">)</text><text class="terminal-2035912735-r1" x="939.4" y="532.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-21)">,</text><text class="terminal-2035912735-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-21)">
+</text><text class="terminal-2035912735-r1" x="0" y="556.8" textLength="622.2" clip-path="url(#terminal-2035912735-line-22)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;instead&#160;of&#160;using&#160;unreleased</text><text class="terminal-2035912735-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-22)">
+</text><text class="terminal-2035912735-r1" x="0" y="581.2" textLength="939.4" clip-path="url(#terminal-2035912735-line-23)">&#160;&#160;--incremental&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;generates&#160;changelog&#160;from&#160;last&#160;created&#160;version,&#160;useful</text><text class="terminal-2035912735-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-23)">
+</text><text class="terminal-2035912735-r1" x="0" y="605.6" textLength="817.4" clip-path="url(#terminal-2035912735-line-24)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;if&#160;the&#160;changelog&#160;has&#160;been&#160;manually&#160;modified</text><text class="terminal-2035912735-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-24)">
+</text><text class="terminal-2035912735-r1" x="0" y="630" textLength="280.6" clip-path="url(#terminal-2035912735-line-25)">&#160;&#160;--start-rev&#160;START_REV</text><text class="terminal-2035912735-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-2035912735-line-25)">
+</text><text class="terminal-2035912735-r1" x="0" y="654.4" textLength="866.2" clip-path="url(#terminal-2035912735-line-26)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;start&#160;rev&#160;of&#160;the&#160;changelog.&#160;If&#160;not&#160;set,&#160;it&#160;will</text><text class="terminal-2035912735-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-26)">
+</text><text class="terminal-2035912735-r1" x="0" y="678.8" textLength="695.4" clip-path="url(#terminal-2035912735-line-27)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;generate&#160;changelog&#160;from&#160;the&#160;start</text><text class="terminal-2035912735-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-27)">
+</text><text class="terminal-2035912735-r1" x="0" y="703.2" textLength="915" clip-path="url(#terminal-2035912735-line-28)">&#160;&#160;--merge-prerelease&#160;&#160;&#160;&#160;collect&#160;all&#160;changes&#160;from&#160;prereleases&#160;into&#160;next&#160;non-</text><text class="terminal-2035912735-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-28)">
+</text><text class="terminal-2035912735-r1" x="0" y="727.6" textLength="951.6" clip-path="url(#terminal-2035912735-line-29)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;prerelease.&#160;If&#160;not&#160;set,&#160;it&#160;will&#160;include&#160;prereleases&#160;in</text><text class="terminal-2035912735-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-29)">
+</text><text class="terminal-2035912735-r1" x="0" y="752" textLength="451.4" clip-path="url(#terminal-2035912735-line-30)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;changelog</text><text class="terminal-2035912735-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-2035912735-line-30)">
+</text><text class="terminal-2035912735-r1" x="0" y="776.4" textLength="231.8" clip-path="url(#terminal-2035912735-line-31)">&#160;&#160;--version-scheme&#160;</text><text class="terminal-2035912735-r2" x="231.8" y="776.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-31)">{</text><text class="terminal-2035912735-r1" x="244" y="776.4" textLength="256.2" clip-path="url(#terminal-2035912735-line-31)">pep440,semver,semver2</text><text class="terminal-2035912735-r2" x="500.2" y="776.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-31)">}</text><text class="terminal-2035912735-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-31)">
+</text><text class="terminal-2035912735-r1" x="0" y="800.8" textLength="549" clip-path="url(#terminal-2035912735-line-32)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;choose&#160;version&#160;scheme</text><text class="terminal-2035912735-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-32)">
+</text><text class="terminal-2035912735-r1" x="0" y="825.2" textLength="427" clip-path="url(#terminal-2035912735-line-33)">&#160;&#160;--export-template&#160;EXPORT_TEMPLATE</text><text class="terminal-2035912735-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-33)">
+</text><text class="terminal-2035912735-r1" x="0" y="849.6" textLength="927.2" clip-path="url(#terminal-2035912735-line-34)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Export&#160;the&#160;changelog&#160;template&#160;into&#160;this&#160;file&#160;instead</text><text class="terminal-2035912735-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-34)">
+</text><text class="terminal-2035912735-r1" x="0" y="874" textLength="475.8" clip-path="url(#terminal-2035912735-line-35)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;of&#160;rendering&#160;it</text><text class="terminal-2035912735-r1" x="976" y="874" textLength="12.2" clip-path="url(#terminal-2035912735-line-35)">
+</text><text class="terminal-2035912735-r1" x="0" y="898.4" textLength="414.8" clip-path="url(#terminal-2035912735-line-36)">&#160;&#160;--template&#160;TEMPLATE,&#160;-t&#160;TEMPLATE</text><text class="terminal-2035912735-r1" x="976" y="898.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-36)">
+</text><text class="terminal-2035912735-r1" x="0" y="922.8" textLength="646.6" clip-path="url(#terminal-2035912735-line-37)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;changelog&#160;template&#160;file&#160;name&#160;</text><text class="terminal-2035912735-r2" x="646.6" y="922.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-37)">(</text><text class="terminal-2035912735-r1" x="658.8" y="922.8" textLength="280.6" clip-path="url(#terminal-2035912735-line-37)">relative&#160;to&#160;the&#160;current</text><text class="terminal-2035912735-r1" x="976" y="922.8" textLength="12.2" clip-path="url(#terminal-2035912735-line-37)">
+</text><text class="terminal-2035912735-r1" x="0" y="947.2" textLength="500.2" clip-path="url(#terminal-2035912735-line-38)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;working&#160;directory</text><text class="terminal-2035912735-r2" x="500.2" y="947.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-38)">)</text><text class="terminal-2035912735-r1" x="976" y="947.2" textLength="12.2" clip-path="url(#terminal-2035912735-line-38)">
+</text><text class="terminal-2035912735-r1" x="0" y="971.6" textLength="305" clip-path="url(#terminal-2035912735-line-39)">&#160;&#160;--extra&#160;EXTRA,&#160;-e&#160;EXTRA</text><text class="terminal-2035912735-r1" x="976" y="971.6" textLength="12.2" clip-path="url(#terminal-2035912735-line-39)">
+</text><text class="terminal-2035912735-r1" x="0" y="996" textLength="622.2" clip-path="url(#terminal-2035912735-line-40)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;a&#160;changelog&#160;extra&#160;variable&#160;</text><text class="terminal-2035912735-r2" x="622.2" y="996" textLength="12.2" clip-path="url(#terminal-2035912735-line-40)">(</text><text class="terminal-2035912735-r1" x="634.4" y="996" textLength="146.4" clip-path="url(#terminal-2035912735-line-40)">in&#160;the&#160;form&#160;</text><text class="terminal-2035912735-r4" x="780.8" y="996" textLength="12.2" clip-path="url(#terminal-2035912735-line-40)">&#x27;</text><text class="terminal-2035912735-r4" x="793" y="996" textLength="36.6" clip-path="url(#terminal-2035912735-line-40)">key</text><text class="terminal-2035912735-r4" x="829.6" y="996" textLength="12.2" clip-path="url(#terminal-2035912735-line-40)">=</text><text class="terminal-2035912735-r4" x="841.8" y="996" textLength="61" clip-path="url(#terminal-2035912735-line-40)">value</text><text class="terminal-2035912735-r4" x="902.8" y="996" textLength="12.2" clip-path="url(#terminal-2035912735-line-40)">&#x27;</text><text class="terminal-2035912735-r2" x="915" y="996" textLength="12.2" clip-path="url(#terminal-2035912735-line-40)">)</text><text class="terminal-2035912735-r1" x="976" y="996" textLength="12.2" clip-path="url(#terminal-2035912735-line-40)">
+</text><text class="terminal-2035912735-r1" x="976" y="1020.4" textLength="12.2" clip-path="url(#terminal-2035912735-line-41)">
 </text>
     </g>
     </g>

--- a/docs/images/cli_help/cz_check___help.svg
+++ b/docs/images/cli_help/cz_check___help.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 994 708.8" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 733.1999999999999" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,146 +19,150 @@
         font-weight: 700;
     }
 
-    .terminal-1360575461-matrix {
+    .terminal-1820510314-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-1360575461-title {
+    .terminal-1820510314-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-1360575461-r1 { fill: #c5c8c6 }
-.terminal-1360575461-r2 { fill: #c5c8c6;font-weight: bold }
-.terminal-1360575461-r3 { fill: #d0b344 }
-.terminal-1360575461-r4 { fill: #68a0b3;font-weight: bold }
+    .terminal-1820510314-r1 { fill: #c5c8c6 }
+.terminal-1820510314-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-1820510314-r3 { fill: #d0b344 }
+.terminal-1820510314-r4 { fill: #68a0b3;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-1360575461-clip-terminal">
-      <rect x="0" y="0" width="975.0" height="657.8" />
+    <clipPath id="terminal-1820510314-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="682.1999999999999" />
     </clipPath>
-    <clipPath id="terminal-1360575461-line-0">
+    <clipPath id="terminal-1820510314-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-1">
+<clipPath id="terminal-1820510314-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-2">
+<clipPath id="terminal-1820510314-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-3">
+<clipPath id="terminal-1820510314-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-4">
+<clipPath id="terminal-1820510314-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-5">
+<clipPath id="terminal-1820510314-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-6">
+<clipPath id="terminal-1820510314-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-7">
+<clipPath id="terminal-1820510314-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-8">
+<clipPath id="terminal-1820510314-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-9">
+<clipPath id="terminal-1820510314-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-10">
+<clipPath id="terminal-1820510314-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-11">
+<clipPath id="terminal-1820510314-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-12">
+<clipPath id="terminal-1820510314-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-13">
+<clipPath id="terminal-1820510314-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-14">
+<clipPath id="terminal-1820510314-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-15">
+<clipPath id="terminal-1820510314-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-16">
+<clipPath id="terminal-1820510314-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-17">
+<clipPath id="terminal-1820510314-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-18">
+<clipPath id="terminal-1820510314-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-19">
+<clipPath id="terminal-1820510314-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-20">
+<clipPath id="terminal-1820510314-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-21">
+<clipPath id="terminal-1820510314-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-22">
+<clipPath id="terminal-1820510314-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-23">
+<clipPath id="terminal-1820510314-line-23">
     <rect x="0" y="562.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-24">
+<clipPath id="terminal-1820510314-line-24">
     <rect x="0" y="587.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-1360575461-line-25">
+<clipPath id="terminal-1820510314-line-25">
     <rect x="0" y="611.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1820510314-line-26">
+    <rect x="0" y="635.9" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="706.8" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="731.2" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-1360575461-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1820510314-clip-terminal)">
     
-    <g class="terminal-1360575461-matrix">
-    <text class="terminal-1360575461-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-1360575461-line-0)">$&#160;cz&#160;check&#160;--help</text><text class="terminal-1360575461-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1360575461-line-0)">
-</text><text class="terminal-1360575461-r1" x="0" y="44.4" textLength="195.2" clip-path="url(#terminal-1360575461-line-1)">usage:&#160;cz&#160;check&#160;</text><text class="terminal-1360575461-r2" x="195.2" y="44.4" textLength="12.2" clip-path="url(#terminal-1360575461-line-1)">[</text><text class="terminal-1360575461-r1" x="207.4" y="44.4" textLength="24.4" clip-path="url(#terminal-1360575461-line-1)">-h</text><text class="terminal-1360575461-r2" x="231.8" y="44.4" textLength="12.2" clip-path="url(#terminal-1360575461-line-1)">]</text><text class="terminal-1360575461-r2" x="256.2" y="44.4" textLength="12.2" clip-path="url(#terminal-1360575461-line-1)">[</text><text class="terminal-1360575461-r1" x="268.4" y="44.4" textLength="427" clip-path="url(#terminal-1360575461-line-1)">--commit-msg-file&#160;COMMIT_MSG_FILE&#160;|</text><text class="terminal-1360575461-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1360575461-line-1)">
-</text><text class="terminal-1360575461-r1" x="0" y="68.8" textLength="610" clip-path="url(#terminal-1360575461-line-2)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;--rev-range&#160;REV_RANGE&#160;|&#160;-m&#160;MESSAGE</text><text class="terminal-1360575461-r2" x="610" y="68.8" textLength="12.2" clip-path="url(#terminal-1360575461-line-2)">]</text><text class="terminal-1360575461-r2" x="634.4" y="68.8" textLength="12.2" clip-path="url(#terminal-1360575461-line-2)">[</text><text class="terminal-1360575461-r1" x="646.6" y="68.8" textLength="158.6" clip-path="url(#terminal-1360575461-line-2)">--allow-abort</text><text class="terminal-1360575461-r2" x="805.2" y="68.8" textLength="12.2" clip-path="url(#terminal-1360575461-line-2)">]</text><text class="terminal-1360575461-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1360575461-line-2)">
-</text><text class="terminal-1360575461-r2" x="195.2" y="93.2" textLength="12.2" clip-path="url(#terminal-1360575461-line-3)">[</text><text class="terminal-1360575461-r1" x="207.4" y="93.2" textLength="231.8" clip-path="url(#terminal-1360575461-line-3)">--allowed-prefixes&#160;</text><text class="terminal-1360575461-r2" x="439.2" y="93.2" textLength="12.2" clip-path="url(#terminal-1360575461-line-3)">[</text><text class="terminal-1360575461-r1" x="451.4" y="93.2" textLength="207.4" clip-path="url(#terminal-1360575461-line-3)">ALLOWED_PREFIXES&#160;</text><text class="terminal-1360575461-r3" x="658.8" y="93.2" textLength="36.6" clip-path="url(#terminal-1360575461-line-3)">...</text><text class="terminal-1360575461-r2" x="695.4" y="93.2" textLength="12.2" clip-path="url(#terminal-1360575461-line-3)">]</text><text class="terminal-1360575461-r2" x="707.6" y="93.2" textLength="12.2" clip-path="url(#terminal-1360575461-line-3)">]</text><text class="terminal-1360575461-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1360575461-line-3)">
-</text><text class="terminal-1360575461-r2" x="195.2" y="117.6" textLength="12.2" clip-path="url(#terminal-1360575461-line-4)">[</text><text class="terminal-1360575461-r1" x="207.4" y="117.6" textLength="280.6" clip-path="url(#terminal-1360575461-line-4)">-l&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-1360575461-r2" x="488" y="117.6" textLength="12.2" clip-path="url(#terminal-1360575461-line-4)">]</text><text class="terminal-1360575461-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1360575461-line-4)">
-</text><text class="terminal-1360575461-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1360575461-line-5)">
-</text><text class="terminal-1360575461-r1" x="0" y="166.4" textLength="744.2" clip-path="url(#terminal-1360575461-line-6)">validates&#160;that&#160;a&#160;commit&#160;message&#160;matches&#160;the&#160;commitizen&#160;schema</text><text class="terminal-1360575461-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1360575461-line-6)">
-</text><text class="terminal-1360575461-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1360575461-line-7)">
-</text><text class="terminal-1360575461-r1" x="0" y="215.2" textLength="97.6" clip-path="url(#terminal-1360575461-line-8)">options:</text><text class="terminal-1360575461-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1360575461-line-8)">
-</text><text class="terminal-1360575461-r1" x="0" y="239.6" textLength="671" clip-path="url(#terminal-1360575461-line-9)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-1360575461-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1360575461-line-9)">
-</text><text class="terminal-1360575461-r1" x="0" y="264" textLength="427" clip-path="url(#terminal-1360575461-line-10)">&#160;&#160;--commit-msg-file&#160;COMMIT_MSG_FILE</text><text class="terminal-1360575461-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1360575461-line-10)">
-</text><text class="terminal-1360575461-r1" x="0" y="288.4" textLength="915" clip-path="url(#terminal-1360575461-line-11)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;ask&#160;for&#160;the&#160;name&#160;of&#160;the&#160;temporal&#160;file&#160;that&#160;contains</text><text class="terminal-1360575461-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1360575461-line-11)">
-</text><text class="terminal-1360575461-r1" x="0" y="312.8" textLength="902.8" clip-path="url(#terminal-1360575461-line-12)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;commit&#160;message.&#160;Using&#160;it&#160;in&#160;a&#160;git&#160;hook&#160;script:</text><text class="terminal-1360575461-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1360575461-line-12)">
-</text><text class="terminal-1360575461-r3" x="292.8" y="337.2" textLength="97.6" clip-path="url(#terminal-1360575461-line-13)">MSG_FILE</text><text class="terminal-1360575461-r1" x="390.4" y="337.2" textLength="24.4" clip-path="url(#terminal-1360575461-line-13)">=$</text><text class="terminal-1360575461-r4" x="414.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1360575461-line-13)">1</text><text class="terminal-1360575461-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1360575461-line-13)">
-</text><text class="terminal-1360575461-r1" x="0" y="361.6" textLength="280.6" clip-path="url(#terminal-1360575461-line-14)">&#160;&#160;--rev-range&#160;REV_RANGE</text><text class="terminal-1360575461-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1360575461-line-14)">
-</text><text class="terminal-1360575461-r1" x="0" y="386" textLength="854" clip-path="url(#terminal-1360575461-line-15)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;a&#160;range&#160;of&#160;git&#160;rev&#160;to&#160;check.&#160;e.g,&#160;master..HEAD</text><text class="terminal-1360575461-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1360575461-line-15)">
-</text><text class="terminal-1360575461-r1" x="0" y="410.4" textLength="280.6" clip-path="url(#terminal-1360575461-line-16)">&#160;&#160;-m,&#160;--message&#160;MESSAGE</text><text class="terminal-1360575461-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1360575461-line-16)">
-</text><text class="terminal-1360575461-r1" x="0" y="434.8" textLength="768.6" clip-path="url(#terminal-1360575461-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;commit&#160;message&#160;that&#160;needs&#160;to&#160;be&#160;checked</text><text class="terminal-1360575461-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1360575461-line-17)">
-</text><text class="terminal-1360575461-r1" x="0" y="459.2" textLength="927.2" clip-path="url(#terminal-1360575461-line-18)">&#160;&#160;--allow-abort&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;allow&#160;empty&#160;commit&#160;messages,&#160;which&#160;typically&#160;abort&#160;a</text><text class="terminal-1360575461-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1360575461-line-18)">
-</text><text class="terminal-1360575461-r1" x="0" y="483.6" textLength="366" clip-path="url(#terminal-1360575461-line-19)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;commit</text><text class="terminal-1360575461-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1360575461-line-19)">
-</text><text class="terminal-1360575461-r1" x="0" y="508" textLength="256.2" clip-path="url(#terminal-1360575461-line-20)">&#160;&#160;--allowed-prefixes&#160;</text><text class="terminal-1360575461-r2" x="256.2" y="508" textLength="12.2" clip-path="url(#terminal-1360575461-line-20)">[</text><text class="terminal-1360575461-r1" x="268.4" y="508" textLength="207.4" clip-path="url(#terminal-1360575461-line-20)">ALLOWED_PREFIXES&#160;</text><text class="terminal-1360575461-r3" x="475.8" y="508" textLength="36.6" clip-path="url(#terminal-1360575461-line-20)">...</text><text class="terminal-1360575461-r2" x="512.4" y="508" textLength="12.2" clip-path="url(#terminal-1360575461-line-20)">]</text><text class="terminal-1360575461-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1360575461-line-20)">
-</text><text class="terminal-1360575461-r1" x="0" y="532.4" textLength="951.6" clip-path="url(#terminal-1360575461-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;allowed&#160;commit&#160;message&#160;prefixes.&#160;If&#160;the&#160;message&#160;starts</text><text class="terminal-1360575461-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1360575461-line-21)">
-</text><text class="terminal-1360575461-r1" x="0" y="556.8" textLength="951.6" clip-path="url(#terminal-1360575461-line-22)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;by&#160;one&#160;of&#160;these&#160;prefixes,&#160;the&#160;message&#160;won&#x27;t&#160;be&#160;checked</text><text class="terminal-1360575461-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1360575461-line-22)">
-</text><text class="terminal-1360575461-r1" x="0" y="581.2" textLength="500.2" clip-path="url(#terminal-1360575461-line-23)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;against&#160;the&#160;regex</text><text class="terminal-1360575461-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-1360575461-line-23)">
-</text><text class="terminal-1360575461-r1" x="0" y="605.6" textLength="597.8" clip-path="url(#terminal-1360575461-line-24)">&#160;&#160;-l,&#160;--message-length-limit&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-1360575461-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-1360575461-line-24)">
-</text><text class="terminal-1360575461-r1" x="0" y="630" textLength="732" clip-path="url(#terminal-1360575461-line-25)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;length&#160;limit&#160;of&#160;the&#160;commit&#160;message;&#160;</text><text class="terminal-1360575461-r4" x="732" y="630" textLength="12.2" clip-path="url(#terminal-1360575461-line-25)">0</text><text class="terminal-1360575461-r1" x="744.2" y="630" textLength="158.6" clip-path="url(#terminal-1360575461-line-25)">&#160;for&#160;no&#160;limit</text><text class="terminal-1360575461-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-1360575461-line-25)">
-</text><text class="terminal-1360575461-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-1360575461-line-26)">
+    <g class="terminal-1820510314-matrix">
+    <text class="terminal-1820510314-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-1820510314-line-0)">$&#160;cz&#160;check&#160;--help</text><text class="terminal-1820510314-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1820510314-line-0)">
+</text><text class="terminal-1820510314-r1" x="0" y="44.4" textLength="195.2" clip-path="url(#terminal-1820510314-line-1)">usage:&#160;cz&#160;check&#160;</text><text class="terminal-1820510314-r2" x="195.2" y="44.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-1)">[</text><text class="terminal-1820510314-r1" x="207.4" y="44.4" textLength="24.4" clip-path="url(#terminal-1820510314-line-1)">-h</text><text class="terminal-1820510314-r2" x="231.8" y="44.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-1)">]</text><text class="terminal-1820510314-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-1)">
+</text><text class="terminal-1820510314-r2" x="195.2" y="68.8" textLength="12.2" clip-path="url(#terminal-1820510314-line-2)">[</text><text class="terminal-1820510314-r1" x="207.4" y="68.8" textLength="768.6" clip-path="url(#terminal-1820510314-line-2)">--commit-msg-file&#160;COMMIT_MSG_FILE&#160;|&#160;--rev-range&#160;REV_RANGE&#160;|&#160;-m&#160;</text><text class="terminal-1820510314-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1820510314-line-2)">
+</text><text class="terminal-1820510314-r1" x="0" y="93.2" textLength="85.4" clip-path="url(#terminal-1820510314-line-3)">MESSAGE</text><text class="terminal-1820510314-r2" x="85.4" y="93.2" textLength="12.2" clip-path="url(#terminal-1820510314-line-3)">]</text><text class="terminal-1820510314-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1820510314-line-3)">
+</text><text class="terminal-1820510314-r2" x="195.2" y="117.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-4)">[</text><text class="terminal-1820510314-r1" x="207.4" y="117.6" textLength="158.6" clip-path="url(#terminal-1820510314-line-4)">--allow-abort</text><text class="terminal-1820510314-r2" x="366" y="117.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-4)">]</text><text class="terminal-1820510314-r2" x="390.4" y="117.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-4)">[</text><text class="terminal-1820510314-r1" x="402.6" y="117.6" textLength="231.8" clip-path="url(#terminal-1820510314-line-4)">--allowed-prefixes&#160;</text><text class="terminal-1820510314-r2" x="634.4" y="117.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-4)">[</text><text class="terminal-1820510314-r1" x="646.6" y="117.6" textLength="207.4" clip-path="url(#terminal-1820510314-line-4)">ALLOWED_PREFIXES&#160;</text><text class="terminal-1820510314-r3" x="854" y="117.6" textLength="36.6" clip-path="url(#terminal-1820510314-line-4)">...</text><text class="terminal-1820510314-r2" x="890.6" y="117.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-4)">]</text><text class="terminal-1820510314-r2" x="902.8" y="117.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-4)">]</text><text class="terminal-1820510314-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-4)">
+</text><text class="terminal-1820510314-r2" x="195.2" y="142" textLength="12.2" clip-path="url(#terminal-1820510314-line-5)">[</text><text class="terminal-1820510314-r1" x="207.4" y="142" textLength="280.6" clip-path="url(#terminal-1820510314-line-5)">-l&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-1820510314-r2" x="488" y="142" textLength="12.2" clip-path="url(#terminal-1820510314-line-5)">]</text><text class="terminal-1820510314-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1820510314-line-5)">
+</text><text class="terminal-1820510314-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-6)">
+</text><text class="terminal-1820510314-r1" x="0" y="190.8" textLength="744.2" clip-path="url(#terminal-1820510314-line-7)">validates&#160;that&#160;a&#160;commit&#160;message&#160;matches&#160;the&#160;commitizen&#160;schema</text><text class="terminal-1820510314-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1820510314-line-7)">
+</text><text class="terminal-1820510314-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1820510314-line-8)">
+</text><text class="terminal-1820510314-r1" x="0" y="239.6" textLength="97.6" clip-path="url(#terminal-1820510314-line-9)">options:</text><text class="terminal-1820510314-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-9)">
+</text><text class="terminal-1820510314-r1" x="0" y="264" textLength="671" clip-path="url(#terminal-1820510314-line-10)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-1820510314-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1820510314-line-10)">
+</text><text class="terminal-1820510314-r1" x="0" y="288.4" textLength="427" clip-path="url(#terminal-1820510314-line-11)">&#160;&#160;--commit-msg-file&#160;COMMIT_MSG_FILE</text><text class="terminal-1820510314-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-11)">
+</text><text class="terminal-1820510314-r1" x="0" y="312.8" textLength="915" clip-path="url(#terminal-1820510314-line-12)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;ask&#160;for&#160;the&#160;name&#160;of&#160;the&#160;temporal&#160;file&#160;that&#160;contains</text><text class="terminal-1820510314-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1820510314-line-12)">
+</text><text class="terminal-1820510314-r1" x="0" y="337.2" textLength="902.8" clip-path="url(#terminal-1820510314-line-13)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;commit&#160;message.&#160;Using&#160;it&#160;in&#160;a&#160;git&#160;hook&#160;script:</text><text class="terminal-1820510314-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1820510314-line-13)">
+</text><text class="terminal-1820510314-r3" x="292.8" y="361.6" textLength="97.6" clip-path="url(#terminal-1820510314-line-14)">MSG_FILE</text><text class="terminal-1820510314-r1" x="390.4" y="361.6" textLength="24.4" clip-path="url(#terminal-1820510314-line-14)">=$</text><text class="terminal-1820510314-r4" x="414.8" y="361.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-14)">1</text><text class="terminal-1820510314-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-14)">
+</text><text class="terminal-1820510314-r1" x="0" y="386" textLength="280.6" clip-path="url(#terminal-1820510314-line-15)">&#160;&#160;--rev-range&#160;REV_RANGE</text><text class="terminal-1820510314-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1820510314-line-15)">
+</text><text class="terminal-1820510314-r1" x="0" y="410.4" textLength="854" clip-path="url(#terminal-1820510314-line-16)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;a&#160;range&#160;of&#160;git&#160;rev&#160;to&#160;check.&#160;e.g,&#160;master..HEAD</text><text class="terminal-1820510314-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-16)">
+</text><text class="terminal-1820510314-r1" x="0" y="434.8" textLength="378.2" clip-path="url(#terminal-1820510314-line-17)">&#160;&#160;-m&#160;MESSAGE,&#160;--message&#160;MESSAGE</text><text class="terminal-1820510314-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1820510314-line-17)">
+</text><text class="terminal-1820510314-r1" x="0" y="459.2" textLength="768.6" clip-path="url(#terminal-1820510314-line-18)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;commit&#160;message&#160;that&#160;needs&#160;to&#160;be&#160;checked</text><text class="terminal-1820510314-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1820510314-line-18)">
+</text><text class="terminal-1820510314-r1" x="0" y="483.6" textLength="927.2" clip-path="url(#terminal-1820510314-line-19)">&#160;&#160;--allow-abort&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;allow&#160;empty&#160;commit&#160;messages,&#160;which&#160;typically&#160;abort&#160;a</text><text class="terminal-1820510314-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-19)">
+</text><text class="terminal-1820510314-r1" x="0" y="508" textLength="366" clip-path="url(#terminal-1820510314-line-20)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;commit</text><text class="terminal-1820510314-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1820510314-line-20)">
+</text><text class="terminal-1820510314-r1" x="0" y="532.4" textLength="256.2" clip-path="url(#terminal-1820510314-line-21)">&#160;&#160;--allowed-prefixes&#160;</text><text class="terminal-1820510314-r2" x="256.2" y="532.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-21)">[</text><text class="terminal-1820510314-r1" x="268.4" y="532.4" textLength="207.4" clip-path="url(#terminal-1820510314-line-21)">ALLOWED_PREFIXES&#160;</text><text class="terminal-1820510314-r3" x="475.8" y="532.4" textLength="36.6" clip-path="url(#terminal-1820510314-line-21)">...</text><text class="terminal-1820510314-r2" x="512.4" y="532.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-21)">]</text><text class="terminal-1820510314-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-21)">
+</text><text class="terminal-1820510314-r1" x="0" y="556.8" textLength="951.6" clip-path="url(#terminal-1820510314-line-22)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;allowed&#160;commit&#160;message&#160;prefixes.&#160;If&#160;the&#160;message&#160;starts</text><text class="terminal-1820510314-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1820510314-line-22)">
+</text><text class="terminal-1820510314-r1" x="0" y="581.2" textLength="951.6" clip-path="url(#terminal-1820510314-line-23)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;by&#160;one&#160;of&#160;these&#160;prefixes,&#160;the&#160;message&#160;won&#x27;t&#160;be&#160;checked</text><text class="terminal-1820510314-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-1820510314-line-23)">
+</text><text class="terminal-1820510314-r1" x="0" y="605.6" textLength="500.2" clip-path="url(#terminal-1820510314-line-24)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;against&#160;the&#160;regex</text><text class="terminal-1820510314-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-1820510314-line-24)">
+</text><text class="terminal-1820510314-r1" x="0" y="630" textLength="854" clip-path="url(#terminal-1820510314-line-25)">&#160;&#160;-l&#160;MESSAGE_LENGTH_LIMIT,&#160;--message-length-limit&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-1820510314-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-1820510314-line-25)">
+</text><text class="terminal-1820510314-r1" x="0" y="654.4" textLength="732" clip-path="url(#terminal-1820510314-line-26)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;length&#160;limit&#160;of&#160;the&#160;commit&#160;message;&#160;</text><text class="terminal-1820510314-r4" x="732" y="654.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-26)">0</text><text class="terminal-1820510314-r1" x="744.2" y="654.4" textLength="158.6" clip-path="url(#terminal-1820510314-line-26)">&#160;for&#160;no&#160;limit</text><text class="terminal-1820510314-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-1820510314-line-26)">
+</text><text class="terminal-1820510314-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-1820510314-line-27)">
 </text>
     </g>
     </g>

--- a/docs/images/cli_help/cz_commit___help.svg
+++ b/docs/images/cli_help/cz_commit___help.svg
@@ -19,95 +19,95 @@
         font-weight: 700;
     }
 
-    .terminal-463778956-matrix {
+    .terminal-1670560432-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-463778956-title {
+    .terminal-1670560432-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-463778956-r1 { fill: #c5c8c6 }
-.terminal-463778956-r2 { fill: #c5c8c6;font-weight: bold }
-.terminal-463778956-r3 { fill: #68a0b3;font-weight: bold }
+    .terminal-1670560432-r1 { fill: #c5c8c6 }
+.terminal-1670560432-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-1670560432-r3 { fill: #68a0b3;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-463778956-clip-terminal">
+    <clipPath id="terminal-1670560432-clip-terminal">
       <rect x="0" y="0" width="975.0" height="584.5999999999999" />
     </clipPath>
-    <clipPath id="terminal-463778956-line-0">
+    <clipPath id="terminal-1670560432-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-1">
+<clipPath id="terminal-1670560432-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-2">
+<clipPath id="terminal-1670560432-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-3">
+<clipPath id="terminal-1670560432-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-4">
+<clipPath id="terminal-1670560432-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-5">
+<clipPath id="terminal-1670560432-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-6">
+<clipPath id="terminal-1670560432-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-7">
+<clipPath id="terminal-1670560432-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-8">
+<clipPath id="terminal-1670560432-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-9">
+<clipPath id="terminal-1670560432-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-10">
+<clipPath id="terminal-1670560432-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-11">
+<clipPath id="terminal-1670560432-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-12">
+<clipPath id="terminal-1670560432-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-13">
+<clipPath id="terminal-1670560432-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-14">
+<clipPath id="terminal-1670560432-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-15">
+<clipPath id="terminal-1670560432-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-16">
+<clipPath id="terminal-1670560432-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-17">
+<clipPath id="terminal-1670560432-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-18">
+<clipPath id="terminal-1670560432-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-19">
+<clipPath id="terminal-1670560432-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-20">
+<clipPath id="terminal-1670560432-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-21">
+<clipPath id="terminal-1670560432-line-21">
     <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-463778956-line-22">
+<clipPath id="terminal-1670560432-line-22">
     <rect x="0" y="538.3" width="976" height="24.65"/>
             </clipPath>
     </defs>
@@ -119,33 +119,33 @@
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-463778956-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1670560432-clip-terminal)">
     
-    <g class="terminal-463778956-matrix">
-    <text class="terminal-463778956-r1" x="0" y="20" textLength="219.6" clip-path="url(#terminal-463778956-line-0)">$&#160;cz&#160;commit&#160;--help</text><text class="terminal-463778956-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-463778956-line-0)">
-</text><text class="terminal-463778956-r1" x="0" y="44.4" textLength="207.4" clip-path="url(#terminal-463778956-line-1)">usage:&#160;cz&#160;commit&#160;</text><text class="terminal-463778956-r2" x="207.4" y="44.4" textLength="12.2" clip-path="url(#terminal-463778956-line-1)">[</text><text class="terminal-463778956-r1" x="219.6" y="44.4" textLength="24.4" clip-path="url(#terminal-463778956-line-1)">-h</text><text class="terminal-463778956-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-463778956-line-1)">]</text><text class="terminal-463778956-r2" x="268.4" y="44.4" textLength="12.2" clip-path="url(#terminal-463778956-line-1)">[</text><text class="terminal-463778956-r1" x="280.6" y="44.4" textLength="85.4" clip-path="url(#terminal-463778956-line-1)">--retry</text><text class="terminal-463778956-r2" x="366" y="44.4" textLength="12.2" clip-path="url(#terminal-463778956-line-1)">]</text><text class="terminal-463778956-r2" x="390.4" y="44.4" textLength="12.2" clip-path="url(#terminal-463778956-line-1)">[</text><text class="terminal-463778956-r1" x="402.6" y="44.4" textLength="122" clip-path="url(#terminal-463778956-line-1)">--no-retry</text><text class="terminal-463778956-r2" x="524.6" y="44.4" textLength="12.2" clip-path="url(#terminal-463778956-line-1)">]</text><text class="terminal-463778956-r2" x="549" y="44.4" textLength="12.2" clip-path="url(#terminal-463778956-line-1)">[</text><text class="terminal-463778956-r1" x="561.2" y="44.4" textLength="109.8" clip-path="url(#terminal-463778956-line-1)">--dry-run</text><text class="terminal-463778956-r2" x="671" y="44.4" textLength="12.2" clip-path="url(#terminal-463778956-line-1)">]</text><text class="terminal-463778956-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-463778956-line-1)">
-</text><text class="terminal-463778956-r2" x="207.4" y="68.8" textLength="12.2" clip-path="url(#terminal-463778956-line-2)">[</text><text class="terminal-463778956-r1" x="219.6" y="68.8" textLength="402.6" clip-path="url(#terminal-463778956-line-2)">--write-message-to-file&#160;FILE_PATH</text><text class="terminal-463778956-r2" x="622.2" y="68.8" textLength="12.2" clip-path="url(#terminal-463778956-line-2)">]</text><text class="terminal-463778956-r2" x="646.6" y="68.8" textLength="12.2" clip-path="url(#terminal-463778956-line-2)">[</text><text class="terminal-463778956-r1" x="658.8" y="68.8" textLength="24.4" clip-path="url(#terminal-463778956-line-2)">-s</text><text class="terminal-463778956-r2" x="683.2" y="68.8" textLength="12.2" clip-path="url(#terminal-463778956-line-2)">]</text><text class="terminal-463778956-r2" x="707.6" y="68.8" textLength="12.2" clip-path="url(#terminal-463778956-line-2)">[</text><text class="terminal-463778956-r1" x="719.8" y="68.8" textLength="24.4" clip-path="url(#terminal-463778956-line-2)">-a</text><text class="terminal-463778956-r2" x="744.2" y="68.8" textLength="12.2" clip-path="url(#terminal-463778956-line-2)">]</text><text class="terminal-463778956-r2" x="768.6" y="68.8" textLength="12.2" clip-path="url(#terminal-463778956-line-2)">[</text><text class="terminal-463778956-r1" x="780.8" y="68.8" textLength="24.4" clip-path="url(#terminal-463778956-line-2)">-e</text><text class="terminal-463778956-r2" x="805.2" y="68.8" textLength="12.2" clip-path="url(#terminal-463778956-line-2)">]</text><text class="terminal-463778956-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-463778956-line-2)">
-</text><text class="terminal-463778956-r2" x="207.4" y="93.2" textLength="12.2" clip-path="url(#terminal-463778956-line-3)">[</text><text class="terminal-463778956-r1" x="219.6" y="93.2" textLength="280.6" clip-path="url(#terminal-463778956-line-3)">-l&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-463778956-r2" x="500.2" y="93.2" textLength="12.2" clip-path="url(#terminal-463778956-line-3)">]</text><text class="terminal-463778956-r2" x="524.6" y="93.2" textLength="12.2" clip-path="url(#terminal-463778956-line-3)">[</text><text class="terminal-463778956-r1" x="536.8" y="93.2" textLength="24.4" clip-path="url(#terminal-463778956-line-3)">--</text><text class="terminal-463778956-r2" x="561.2" y="93.2" textLength="12.2" clip-path="url(#terminal-463778956-line-3)">]</text><text class="terminal-463778956-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-463778956-line-3)">
-</text><text class="terminal-463778956-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-463778956-line-4)">
-</text><text class="terminal-463778956-r1" x="0" y="142" textLength="207.4" clip-path="url(#terminal-463778956-line-5)">create&#160;new&#160;commit</text><text class="terminal-463778956-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-463778956-line-5)">
-</text><text class="terminal-463778956-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-463778956-line-6)">
-</text><text class="terminal-463778956-r1" x="0" y="190.8" textLength="97.6" clip-path="url(#terminal-463778956-line-7)">options:</text><text class="terminal-463778956-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-463778956-line-7)">
-</text><text class="terminal-463778956-r1" x="0" y="215.2" textLength="671" clip-path="url(#terminal-463778956-line-8)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-463778956-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-463778956-line-8)">
-</text><text class="terminal-463778956-r1" x="0" y="239.6" textLength="500.2" clip-path="url(#terminal-463778956-line-9)">&#160;&#160;--retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;retry&#160;last&#160;commit</text><text class="terminal-463778956-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-463778956-line-9)">
-</text><text class="terminal-463778956-r1" x="0" y="264" textLength="878.4" clip-path="url(#terminal-463778956-line-10)">&#160;&#160;--no-retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;skip&#160;retry&#160;if&#160;retry_after_failure&#160;is&#160;set&#160;to&#160;true</text><text class="terminal-463778956-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-463778956-line-10)">
-</text><text class="terminal-463778956-r1" x="0" y="288.4" textLength="915" clip-path="url(#terminal-463778956-line-11)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;output&#160;to&#160;stdout,&#160;no&#160;commit,&#160;no&#160;modified&#160;files</text><text class="terminal-463778956-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-463778956-line-11)">
-</text><text class="terminal-463778956-r1" x="0" y="312.8" textLength="427" clip-path="url(#terminal-463778956-line-12)">&#160;&#160;--write-message-to-file&#160;FILE_PATH</text><text class="terminal-463778956-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-463778956-line-12)">
-</text><text class="terminal-463778956-r1" x="0" y="337.2" textLength="780.8" clip-path="url(#terminal-463778956-line-13)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;write&#160;message&#160;to&#160;file&#160;before&#160;committing&#160;</text><text class="terminal-463778956-r2" x="780.8" y="337.2" textLength="12.2" clip-path="url(#terminal-463778956-line-13)">(</text><text class="terminal-463778956-r1" x="793" y="337.2" textLength="73.2" clip-path="url(#terminal-463778956-line-13)">can&#160;be</text><text class="terminal-463778956-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-463778956-line-13)">
-</text><text class="terminal-463778956-r1" x="0" y="361.6" textLength="573.4" clip-path="url(#terminal-463778956-line-14)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;combined&#160;with&#160;--dry-run</text><text class="terminal-463778956-r2" x="573.4" y="361.6" textLength="12.2" clip-path="url(#terminal-463778956-line-14)">)</text><text class="terminal-463778956-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-463778956-line-14)">
-</text><text class="terminal-463778956-r1" x="0" y="386" textLength="524.6" clip-path="url(#terminal-463778956-line-15)">&#160;&#160;-s,&#160;--signoff&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sign&#160;off&#160;the&#160;commit</text><text class="terminal-463778956-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-463778956-line-15)">
-</text><text class="terminal-463778956-r1" x="0" y="410.4" textLength="902.8" clip-path="url(#terminal-463778956-line-16)">&#160;&#160;-a,&#160;--all&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Tell&#160;the&#160;command&#160;to&#160;automatically&#160;stage&#160;files&#160;that</text><text class="terminal-463778956-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-463778956-line-16)">
-</text><text class="terminal-463778956-r1" x="0" y="434.8" textLength="951.6" clip-path="url(#terminal-463778956-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;have&#160;been&#160;modified&#160;and&#160;deleted,&#160;but&#160;new&#160;files&#160;you&#160;have</text><text class="terminal-463778956-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-463778956-line-17)">
-</text><text class="terminal-463778956-r1" x="0" y="459.2" textLength="732" clip-path="url(#terminal-463778956-line-18)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;not&#160;told&#160;Git&#160;about&#160;are&#160;not&#160;affected.</text><text class="terminal-463778956-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-463778956-line-18)">
-</text><text class="terminal-463778956-r1" x="0" y="483.6" textLength="793" clip-path="url(#terminal-463778956-line-19)">&#160;&#160;-e,&#160;--edit&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;edit&#160;the&#160;commit&#160;message&#160;before&#160;committing</text><text class="terminal-463778956-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-463778956-line-19)">
-</text><text class="terminal-463778956-r1" x="0" y="508" textLength="597.8" clip-path="url(#terminal-463778956-line-20)">&#160;&#160;-l,&#160;--message-length-limit&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-463778956-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-463778956-line-20)">
-</text><text class="terminal-463778956-r1" x="0" y="532.4" textLength="732" clip-path="url(#terminal-463778956-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;length&#160;limit&#160;of&#160;the&#160;commit&#160;message;&#160;</text><text class="terminal-463778956-r3" x="732" y="532.4" textLength="12.2" clip-path="url(#terminal-463778956-line-21)">0</text><text class="terminal-463778956-r1" x="744.2" y="532.4" textLength="158.6" clip-path="url(#terminal-463778956-line-21)">&#160;for&#160;no&#160;limit</text><text class="terminal-463778956-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-463778956-line-21)">
-</text><text class="terminal-463778956-r1" x="0" y="556.8" textLength="671" clip-path="url(#terminal-463778956-line-22)">&#160;&#160;--&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Positional&#160;arguments&#160;separator&#160;</text><text class="terminal-463778956-r2" x="671" y="556.8" textLength="12.2" clip-path="url(#terminal-463778956-line-22)">(</text><text class="terminal-463778956-r1" x="683.2" y="556.8" textLength="134.2" clip-path="url(#terminal-463778956-line-22)">recommended</text><text class="terminal-463778956-r2" x="817.4" y="556.8" textLength="12.2" clip-path="url(#terminal-463778956-line-22)">)</text><text class="terminal-463778956-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-463778956-line-22)">
-</text><text class="terminal-463778956-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-463778956-line-23)">
+    <g class="terminal-1670560432-matrix">
+    <text class="terminal-1670560432-r1" x="0" y="20" textLength="219.6" clip-path="url(#terminal-1670560432-line-0)">$&#160;cz&#160;commit&#160;--help</text><text class="terminal-1670560432-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1670560432-line-0)">
+</text><text class="terminal-1670560432-r1" x="0" y="44.4" textLength="207.4" clip-path="url(#terminal-1670560432-line-1)">usage:&#160;cz&#160;commit&#160;</text><text class="terminal-1670560432-r2" x="207.4" y="44.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-1)">[</text><text class="terminal-1670560432-r1" x="219.6" y="44.4" textLength="24.4" clip-path="url(#terminal-1670560432-line-1)">-h</text><text class="terminal-1670560432-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-1)">]</text><text class="terminal-1670560432-r2" x="268.4" y="44.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-1)">[</text><text class="terminal-1670560432-r1" x="280.6" y="44.4" textLength="85.4" clip-path="url(#terminal-1670560432-line-1)">--retry</text><text class="terminal-1670560432-r2" x="366" y="44.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-1)">]</text><text class="terminal-1670560432-r2" x="390.4" y="44.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-1)">[</text><text class="terminal-1670560432-r1" x="402.6" y="44.4" textLength="122" clip-path="url(#terminal-1670560432-line-1)">--no-retry</text><text class="terminal-1670560432-r2" x="524.6" y="44.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-1)">]</text><text class="terminal-1670560432-r2" x="549" y="44.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-1)">[</text><text class="terminal-1670560432-r1" x="561.2" y="44.4" textLength="109.8" clip-path="url(#terminal-1670560432-line-1)">--dry-run</text><text class="terminal-1670560432-r2" x="671" y="44.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-1)">]</text><text class="terminal-1670560432-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-1)">
+</text><text class="terminal-1670560432-r2" x="207.4" y="68.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-2)">[</text><text class="terminal-1670560432-r1" x="219.6" y="68.8" textLength="402.6" clip-path="url(#terminal-1670560432-line-2)">--write-message-to-file&#160;FILE_PATH</text><text class="terminal-1670560432-r2" x="622.2" y="68.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-2)">]</text><text class="terminal-1670560432-r2" x="646.6" y="68.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-2)">[</text><text class="terminal-1670560432-r1" x="658.8" y="68.8" textLength="24.4" clip-path="url(#terminal-1670560432-line-2)">-s</text><text class="terminal-1670560432-r2" x="683.2" y="68.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-2)">]</text><text class="terminal-1670560432-r2" x="707.6" y="68.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-2)">[</text><text class="terminal-1670560432-r1" x="719.8" y="68.8" textLength="24.4" clip-path="url(#terminal-1670560432-line-2)">-a</text><text class="terminal-1670560432-r2" x="744.2" y="68.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-2)">]</text><text class="terminal-1670560432-r2" x="768.6" y="68.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-2)">[</text><text class="terminal-1670560432-r1" x="780.8" y="68.8" textLength="24.4" clip-path="url(#terminal-1670560432-line-2)">-e</text><text class="terminal-1670560432-r2" x="805.2" y="68.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-2)">]</text><text class="terminal-1670560432-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-2)">
+</text><text class="terminal-1670560432-r2" x="207.4" y="93.2" textLength="12.2" clip-path="url(#terminal-1670560432-line-3)">[</text><text class="terminal-1670560432-r1" x="219.6" y="93.2" textLength="280.6" clip-path="url(#terminal-1670560432-line-3)">-l&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-1670560432-r2" x="500.2" y="93.2" textLength="12.2" clip-path="url(#terminal-1670560432-line-3)">]</text><text class="terminal-1670560432-r2" x="524.6" y="93.2" textLength="12.2" clip-path="url(#terminal-1670560432-line-3)">[</text><text class="terminal-1670560432-r1" x="536.8" y="93.2" textLength="24.4" clip-path="url(#terminal-1670560432-line-3)">--</text><text class="terminal-1670560432-r2" x="561.2" y="93.2" textLength="12.2" clip-path="url(#terminal-1670560432-line-3)">]</text><text class="terminal-1670560432-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1670560432-line-3)">
+</text><text class="terminal-1670560432-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1670560432-line-4)">
+</text><text class="terminal-1670560432-r1" x="0" y="142" textLength="207.4" clip-path="url(#terminal-1670560432-line-5)">create&#160;new&#160;commit</text><text class="terminal-1670560432-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1670560432-line-5)">
+</text><text class="terminal-1670560432-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-6)">
+</text><text class="terminal-1670560432-r1" x="0" y="190.8" textLength="97.6" clip-path="url(#terminal-1670560432-line-7)">options:</text><text class="terminal-1670560432-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-7)">
+</text><text class="terminal-1670560432-r1" x="0" y="215.2" textLength="671" clip-path="url(#terminal-1670560432-line-8)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-1670560432-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1670560432-line-8)">
+</text><text class="terminal-1670560432-r1" x="0" y="239.6" textLength="500.2" clip-path="url(#terminal-1670560432-line-9)">&#160;&#160;--retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;retry&#160;last&#160;commit</text><text class="terminal-1670560432-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1670560432-line-9)">
+</text><text class="terminal-1670560432-r1" x="0" y="264" textLength="878.4" clip-path="url(#terminal-1670560432-line-10)">&#160;&#160;--no-retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;skip&#160;retry&#160;if&#160;retry_after_failure&#160;is&#160;set&#160;to&#160;true</text><text class="terminal-1670560432-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1670560432-line-10)">
+</text><text class="terminal-1670560432-r1" x="0" y="288.4" textLength="915" clip-path="url(#terminal-1670560432-line-11)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;output&#160;to&#160;stdout,&#160;no&#160;commit,&#160;no&#160;modified&#160;files</text><text class="terminal-1670560432-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-11)">
+</text><text class="terminal-1670560432-r1" x="0" y="312.8" textLength="427" clip-path="url(#terminal-1670560432-line-12)">&#160;&#160;--write-message-to-file&#160;FILE_PATH</text><text class="terminal-1670560432-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-12)">
+</text><text class="terminal-1670560432-r1" x="0" y="337.2" textLength="780.8" clip-path="url(#terminal-1670560432-line-13)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;write&#160;message&#160;to&#160;file&#160;before&#160;committing&#160;</text><text class="terminal-1670560432-r2" x="780.8" y="337.2" textLength="12.2" clip-path="url(#terminal-1670560432-line-13)">(</text><text class="terminal-1670560432-r1" x="793" y="337.2" textLength="73.2" clip-path="url(#terminal-1670560432-line-13)">can&#160;be</text><text class="terminal-1670560432-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-1670560432-line-13)">
+</text><text class="terminal-1670560432-r1" x="0" y="361.6" textLength="573.4" clip-path="url(#terminal-1670560432-line-14)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;combined&#160;with&#160;--dry-run</text><text class="terminal-1670560432-r2" x="573.4" y="361.6" textLength="12.2" clip-path="url(#terminal-1670560432-line-14)">)</text><text class="terminal-1670560432-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-1670560432-line-14)">
+</text><text class="terminal-1670560432-r1" x="0" y="386" textLength="524.6" clip-path="url(#terminal-1670560432-line-15)">&#160;&#160;-s,&#160;--signoff&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sign&#160;off&#160;the&#160;commit</text><text class="terminal-1670560432-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-1670560432-line-15)">
+</text><text class="terminal-1670560432-r1" x="0" y="410.4" textLength="902.8" clip-path="url(#terminal-1670560432-line-16)">&#160;&#160;-a,&#160;--all&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Tell&#160;the&#160;command&#160;to&#160;automatically&#160;stage&#160;files&#160;that</text><text class="terminal-1670560432-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-16)">
+</text><text class="terminal-1670560432-r1" x="0" y="434.8" textLength="951.6" clip-path="url(#terminal-1670560432-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;have&#160;been&#160;modified&#160;and&#160;deleted,&#160;but&#160;new&#160;files&#160;you&#160;have</text><text class="terminal-1670560432-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-17)">
+</text><text class="terminal-1670560432-r1" x="0" y="459.2" textLength="732" clip-path="url(#terminal-1670560432-line-18)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;not&#160;told&#160;Git&#160;about&#160;are&#160;not&#160;affected.</text><text class="terminal-1670560432-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-1670560432-line-18)">
+</text><text class="terminal-1670560432-r1" x="0" y="483.6" textLength="793" clip-path="url(#terminal-1670560432-line-19)">&#160;&#160;-e,&#160;--edit&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;edit&#160;the&#160;commit&#160;message&#160;before&#160;committing</text><text class="terminal-1670560432-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-1670560432-line-19)">
+</text><text class="terminal-1670560432-r1" x="0" y="508" textLength="854" clip-path="url(#terminal-1670560432-line-20)">&#160;&#160;-l&#160;MESSAGE_LENGTH_LIMIT,&#160;--message-length-limit&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-1670560432-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-1670560432-line-20)">
+</text><text class="terminal-1670560432-r1" x="0" y="532.4" textLength="732" clip-path="url(#terminal-1670560432-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;length&#160;limit&#160;of&#160;the&#160;commit&#160;message;&#160;</text><text class="terminal-1670560432-r3" x="732" y="532.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-21)">0</text><text class="terminal-1670560432-r1" x="744.2" y="532.4" textLength="158.6" clip-path="url(#terminal-1670560432-line-21)">&#160;for&#160;no&#160;limit</text><text class="terminal-1670560432-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-1670560432-line-21)">
+</text><text class="terminal-1670560432-r1" x="0" y="556.8" textLength="671" clip-path="url(#terminal-1670560432-line-22)">&#160;&#160;--&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Positional&#160;arguments&#160;separator&#160;</text><text class="terminal-1670560432-r2" x="671" y="556.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-22)">(</text><text class="terminal-1670560432-r1" x="683.2" y="556.8" textLength="134.2" clip-path="url(#terminal-1670560432-line-22)">recommended</text><text class="terminal-1670560432-r2" x="817.4" y="556.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-22)">)</text><text class="terminal-1670560432-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-1670560432-line-22)">
+</text><text class="terminal-1670560432-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-1670560432-line-23)">
 </text>
     </g>
     </g>

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1543,3 +1543,104 @@ def test_bump_get_next__no_eligible_commits_raises(mocker: MockFixture):
 
     with pytest.raises(NoneIncrementExit):
         cli.main()
+
+
+def test_bump_allow_no_commit_with_no_commit(mocker, tmp_commitizen_project, capsys):
+    with tmp_commitizen_project.as_cwd():
+        # Create the first commit and bump to 1.0.0
+        create_file_and_commit("feat(user)!: new file")
+        testargs = ["cz", "bump", "--yes"]
+        mocker.patch.object(sys, "argv", testargs)
+        cli.main()
+
+        # Verify NoCommitsFoundError should be raised
+        # when there's no new commit and "--allow-no-commit" is not set
+        with pytest.raises(NoCommitsFoundError):
+            testargs = ["cz", "bump"]
+            mocker.patch.object(sys, "argv", testargs)
+            cli.main()
+
+        # bump to 1.0.1 with new commit when "--allow-no-commit" is set
+        testargs = ["cz", "bump", "--allow-no-commit"]
+        mocker.patch.object(sys, "argv", testargs)
+        cli.main()
+        out, _ = capsys.readouterr()
+        assert "bump: version 1.0.0 → 1.0.1" in out
+
+
+def test_bump_allow_no_commit_with_no_eligible_commit(
+    mocker, tmp_commitizen_project, capsys
+):
+    with tmp_commitizen_project.as_cwd():
+        # Create the first commit and bump to 1.0.0
+        create_file_and_commit("feat(user)!: new file")
+        testargs = ["cz", "bump", "--yes"]
+        mocker.patch.object(sys, "argv", testargs)
+        cli.main()
+
+        # Create a commit that is ineligible to bump
+        create_file_and_commit("docs(bump): add description for allow no commit")
+
+        # Verify NoneIncrementExit should be raised
+        # when there's no eligible bumping commit and "--allow-no-commit" is not set
+        with pytest.raises(NoneIncrementExit):
+            testargs = ["cz", "bump", "--yes"]
+            mocker.patch.object(sys, "argv", testargs)
+            cli.main()
+
+        # bump to 1.0.1 with ineligible commit when "--allow-no-commit" is set
+        testargs = ["cz", "bump", "--allow-no-commit"]
+        mocker.patch.object(sys, "argv", testargs)
+        cli.main()
+        out, _ = capsys.readouterr()
+        assert "bump: version 1.0.0 → 1.0.1" in out
+
+
+def test_bump_allow_no_commit_with_increment(mocker, tmp_commitizen_project, capsys):
+    with tmp_commitizen_project.as_cwd():
+        # # Create the first commit and bump to 1.0.0
+        create_file_and_commit("feat(user)!: new file")
+        testargs = ["cz", "bump", "--yes"]
+        mocker.patch.object(sys, "argv", testargs)
+        cli.main()
+
+        # Verify NoCommitsFoundError should be raised
+        # when there's no new commit and "--allow-no-commit" is not set
+        with pytest.raises(NoCommitsFoundError):
+            testargs = ["cz", "bump", "--yes"]
+            mocker.patch.object(sys, "argv", testargs)
+            cli.main()
+
+        # bump to 1.1.0 with no new commit when "--allow-no-commit" is set
+        # and increment is specified
+        testargs = ["cz", "bump", "--yes", "--allow-no-commit", "--increment", "MINOR"]
+        mocker.patch.object(sys, "argv", testargs)
+        cli.main()
+        out, _ = capsys.readouterr()
+        assert "bump: version 1.0.0 → 1.1.0" in out
+
+
+def test_bump_allow_no_commit_with_manual_version(
+    mocker, tmp_commitizen_project, capsys
+):
+    with tmp_commitizen_project.as_cwd():
+        # # Create the first commit and bump to 1.0.0
+        create_file_and_commit("feat(user)!: new file")
+        testargs = ["cz", "bump", "--yes"]
+        mocker.patch.object(sys, "argv", testargs)
+        cli.main()
+
+        # Verify NoCommitsFoundError should be raised
+        # when there's no new commit and "--allow-no-commit" is not set
+        with pytest.raises(NoCommitsFoundError):
+            testargs = ["cz", "bump", "--yes"]
+            mocker.patch.object(sys, "argv", testargs)
+            cli.main()
+
+        # bump to 1.1.0 with no new commit when "--allow-no-commit" is set
+        # and increment is specified
+        testargs = ["cz", "bump", "--yes", "--allow-no-commit", "2.0.0"]
+        mocker.patch.object(sys, "argv", testargs)
+        cli.main()
+        out, _ = capsys.readouterr()
+        assert "bump: version 1.0.0 → 2.0.0" in out

--- a/tests/commands/test_bump_command/test_bump_command_shows_description_when_use_help_option.txt
+++ b/tests/commands/test_bump_command/test_bump_command_shows_description_when_use_help_option.txt
@@ -11,6 +11,7 @@ usage: cz bump [-h] [--dry-run] [--files-only] [--local-version] [--changelog]
                [--version-scheme {pep440,semver,semver2}]
                [--version-type {pep440,semver,semver2}]
                [--build-metadata BUILD_METADATA] [--get-next]
+               [--allow-no-commit]
                [MANUAL_VERSION]
 
 bump semantic version based on the git log
@@ -77,3 +78,4 @@ options:
   --build-metadata BUILD_METADATA
                         Add additional build-metadata to the version-number
   --get-next            Determine the next version and write to stdout
+  --allow-no-commit     bump version without eligible commits


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

superceed #696 

## Description

First draft of a new feature. The idea is to grant the user the capability to run `cz bump` without prior commits. The reasons are described in the associated issue. 

here we add an `--empty` parameter to the bump method
when this parameter is set and if no increment is find, a automatic "PATCH" is released. 

I'll wait for your feedback before working on tests and documentation.

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes


## Additional context
Fix #662 
