### PR TITLE
refactor: move ruff and black from the format file to the pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,18 @@ repos:
           - post-commit
           - push
 
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.262"
+    hooks:
+      - id: ruff
+        stages: [commit]
+
+  - repo: "https://github.com/psf/black"
+    rev: "23.3.0"
+    hooks:
+      - id: black
+        stages: [commit]
+
   - repo: local
     hooks:
       - id: format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,12 +42,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: format
-        name: format
-        language: system
-        pass_filenames: false
-        entry: ./scripts/format
-        types: [python]
 
       - id: linter and test
         name: linter and test

--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -23,7 +23,6 @@ else:
 def find_increment(
     commits: List[GitCommit], regex: str, increments_map: Union[dict, OrderedDict]
 ) -> Optional[str]:
-
     if isinstance(increments_map, dict):
         increments_map = OrderedDict(increments_map)
 
@@ -103,7 +102,6 @@ def semver_generator(current_version: str, increment: str = None) -> str:
     # so it doesn't matter the increment.
     # Example: 1.0.0a0 with PATCH/MINOR -> 1.0.0
     if not version.is_prerelease:
-
         if increment == MAJOR:
             increments_version[MAJOR] += 1
             increments_version[MINOR] = 0

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -74,7 +74,6 @@ class GitTag(GitObject):
 
     @classmethod
     def from_line(cls, line: str, inner_delimiter: str) -> "GitTag":
-
         name, objectname, date, obj = line.split(inner_delimiter)
         if not obj:
             obj = objectname

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,7 @@ pytest-mock = "^3.10"
 pytest-regressions = "^2.4.0"
 pytest-freezer = "^0.4.6"
 pytest-xdist = "^3.1.0"
-# code formatter
-black = "^22.10"
 # linter
-ruff = "^0.0.262"
 pre-commit = "^2.18.0"
 mypy = "^0.931"
 types-PyYAML = "^5.4.3"

--- a/scripts/format
+++ b/scripts/format
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-set -e
-
-export PREFIX="poetry run python -m "
-
-set -x
-
-${PREFIX}ruff commitizen tests --fix
-${PREFIX}black commitizen tests

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -115,7 +115,6 @@ def test_changelog_replacing_unreleased_using_incremental(
 def test_changelog_is_persisted_using_incremental(
     mocker: MockFixture, capsys, changelog_path, file_regression
 ):
-
     create_file_and_commit("feat: add new output")
     create_file_and_commit("fix: output glitch")
     create_file_and_commit("Merge into master")
@@ -519,7 +518,6 @@ def test_breaking_change_content_v1_multiline(
 def test_changelog_config_flag_increment(
     mocker: MockFixture, changelog_path, config_path, file_regression
 ):
-
     with open(config_path, "a") as f:
         f.write("changelog_incremental = true\n")
     with open(changelog_path, "a") as f:
@@ -576,7 +574,6 @@ def test_changelog_config_flag_merge_prerelease(
 def test_changelog_config_start_rev_option(
     mocker: MockFixture, capsys, config_path, file_regression
 ):
-
     # create commit and tag
     create_file_and_commit("feat: new file")
     testargs = ["cz", "bump", "--yes"]
@@ -738,7 +735,6 @@ def test_changelog_incremental_with_merge_prerelease(
 def test_changelog_with_filename_as_empty_string(
     mocker: MockFixture, changelog_path, config_path
 ):
-
     with open(config_path, "a") as f:
         f.write("changelog_file = true\n")
 

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -223,7 +223,6 @@ def test_check_command_with_invalid_argument(config):
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
 def test_check_command_with_empty_range(config, mocker: MockFixture):
-
     # must initialize git with a commit
     create_file_and_commit("feat: initial")
 


### PR DESCRIPTION
## Description
I ask myself, why using a format script to lint the lib instead of a pre-commit hook ? Looking at the format file, it's only using ruff and black so as they have very nicely design hooks I used them instead.


## Checklist

- [x] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes


If you agree with this modification, I'll update the PR/documentation instructions

related to #698 
