### PR TITLE
Fix/major version zero bump map

### DIFF
--- a/commitizen/cz/base.py
+++ b/commitizen/cz/base.py
@@ -11,6 +11,7 @@ from commitizen.defaults import Questions
 class BaseCommitizen(metaclass=ABCMeta):
     bump_pattern: Optional[str] = None
     bump_map: Optional[Dict[str, str]] = None
+    bump_map_major_version_zero: Optional[Dict[str, str]] = None
     default_style_config: List[Tuple[str, str]] = [
         ("qmark", "fg:#ff9d00 bold"),
         ("question", "bold"),

--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -30,6 +30,7 @@ def parse_subject(text):
 class ConventionalCommitsCz(BaseCommitizen):
     bump_pattern = defaults.bump_pattern
     bump_map = defaults.bump_map
+    bump_map_major_version_zero = defaults.bump_map_major_version_zero
     commit_parser = defaults.commit_parser
     version_parser = defaults.version_parser
     change_type_map = {

--- a/commitizen/cz/customize/customize.py
+++ b/commitizen/cz/customize/customize.py
@@ -17,6 +17,7 @@ __all__ = ["CustomizeCommitsCz"]
 class CustomizeCommitsCz(BaseCommitizen):
     bump_pattern = defaults.bump_pattern
     bump_map = defaults.bump_map
+    bump_map_major_version_zero = defaults.bump_map_major_version_zero
     change_type_order = defaults.change_type_order
 
     def __init__(self, config: BaseConfig):
@@ -33,6 +34,12 @@ class CustomizeCommitsCz(BaseCommitizen):
         custom_bump_map = self.custom_settings.get("bump_map")
         if custom_bump_map:
             self.bump_map = custom_bump_map
+
+        custom_bump_map_major_version_zero = self.custom_settings.get(
+            "bump_map_major_version_zero"
+        )
+        if custom_bump_map_major_version_zero:
+            self.bump_map_major_version_zero = custom_bump_map_major_version_zero
 
         custom_change_type_order = self.custom_settings.get("change_type_order")
         if custom_change_type_order:

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -15,6 +15,7 @@ Questions = Iterable[MutableMapping[str, Any]]
 class CzSettings(TypedDict, total=False):
     bump_pattern: str
     bump_map: "OrderedDict[str, str]"
+    bump_map_major_version_zero: "OrderedDict[str, str]"
     change_type_order: List[str]
 
     questions: Questions

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -980,3 +980,47 @@ def test_bump_command_prelease_version_type_check_old_tags(
     for version_file in [tmp_version_file, tmp_commitizen_cfg_file]:
         with open(version_file, "r") as f:
             assert "0.2.0" in f.read()
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+@pytest.mark.usefixtures("use_cz_semver")
+@pytest.mark.parametrize(
+    "message, expected_tag",
+    [
+        ("minor: add users", "0.2.0"),
+        ("patch: bug affecting users", "0.1.1"),
+        ("major: bug affecting users", "1.0.0"),
+    ],
+)
+def test_bump_with_plugin(mocker: MockFixture, message: str, expected_tag: str):
+    create_file_and_commit(message)
+
+    testargs = ["cz", "--name", "cz_semver", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    tag_exists = git.tag_exist(expected_tag)
+    assert tag_exists is True
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+@pytest.mark.usefixtures("use_cz_semver")
+@pytest.mark.parametrize(
+    "message, expected_tag",
+    [
+        ("minor: add users", "0.2.0"),
+        ("patch: bug affecting users", "0.1.1"),
+        ("major: bug affecting users", "0.2.0"),
+    ],
+)
+def test_bump_with_major_version_zero_with_plugin(
+    mocker: MockFixture, message: str, expected_tag: str
+):
+    create_file_and_commit(message)
+
+    testargs = ["cz", "--name", "cz_semver", "bump", "--yes", "--major-version-zero"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    tag_exists = git.tag_exist(expected_tag)
+    assert tag_exists is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,11 +143,11 @@ class SemverCommitizen(BaseCommitizen):
         "minor": "MINOR",
         "patch": "PATCH",
     }
-    # bump_map_major_version_zero = {
-    #     "major": "MINOR",
-    #     "minor": "MINOR",
-    #     "patch": "PATCH",
-    # }
+    bump_map_major_version_zero = {
+        "major": "MINOR",
+        "minor": "MINOR",
+        "patch": "PATCH",
+    }
     changelog_pattern = r"^(patch|minor|major)"
     commit_parser = r"^(?P<change_type>patch|minor|major)(?:\((?P<scope>[^()\r\n]*)\)|\()?:?\s(?P<message>.+)"  # noqa
     change_type_map = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
It's currently not possible to modify major version zero, meaning that it only works with conventional commits.

If you have a custom rule, and you set `major_version_zero` to true, it won't find any commits, because it will be actually using the one in `defaults.bump_major_version_zero` which matches with conventional commit conventions

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
Users should be able to express the behavior when major_version_zero is true, and they have a different set of rules.

