### PR TITLE
feat(commit): add --write-message-to-file option

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -63,9 +63,14 @@ data = {
                         "help": "show output to stdout, no commit, no modified files",
                     },
                     {
+                        "name": "--write-message-to-file",
+                        "metavar": "FILE_PATH",
+                        "help": "write message to file before commiting (can be combined with --dry-run)",
+                    },
+                    {
                         "name": ["-s", "--signoff"],
                         "action": "store_true",
-                        "help": "Sign off the commit",
+                        "help": "sign off the commit",
                     },
                 ],
             },

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import sys
+from pathlib import Path
 from functools import partial
 from types import TracebackType
 from typing import List
@@ -64,6 +65,7 @@ data = {
                     },
                     {
                         "name": "--write-message-to-file",
+                        "type": Path,
                         "metavar": "FILE_PATH",
                         "help": "write message to file before commiting (can be combined with --dry-run)",
                     },

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -69,12 +69,8 @@ class Commit:
         if git.is_staging_clean() and not dry_run:
             raise NothingToCommitError("No files added to staging!")
 
-        if write_message_to_file is not None:
-            if not isinstance(write_message_to_file, str):
-                raise NotAllowed(
-                    "Commit message file name is broken.\n"
-                    "Check the flag `--write-message-to-file` in the terminal"
-                )
+        if write_message_to_file is not None and write_message_to_file.is_dir():
+            raise NotAllowed(f"{write_message_to_file} is a directory")
 
         retry: bool = self.arguments.get("retry")
 

--- a/docs/commit.md
+++ b/docs/commit.md
@@ -8,7 +8,8 @@ A commit can be signed off using `cz commit --signoff` or the shortcut `cz commi
 
 You can run `cz commit --write-message-to-file COMMIT_MSG_FILE` to additionally save the
 generated message to a file. This can be combined with the `--dry-run` flag to only
-write the message to a file and not modify files and create a commit.
+write the message to a file and not modify files and create a commit. A possible use
+case for this is to [automatically prepare a commit message](./tutorials/auto_prepare_commit_message.md).
 
 !!! note
     To maintain platform compatibility, the `commit` command disable ANSI escaping in its output.

--- a/docs/commit.md
+++ b/docs/commit.md
@@ -6,6 +6,10 @@ In your terminal run `cz commit` or the shortcut `cz c` to generate a guided git
 
 A commit can be signed off using `cz commit --signoff` or the shortcut `cz commit -s`.
 
+You can run `cz commit --write-message-to-file COMMIT_MSG_FILE` to additionally save the
+generated message to a file. This can be combined with the `--dry-run` flag to only
+write the message to a file and not modify files and create a commit.
+
 !!! note
     To maintain platform compatibility, the `commit` command disable ANSI escaping in its output.
     In particular pre-commit hooks coloring will be deactivated as discussed in [commitizen-tools/commitizen#417](https://github.com/commitizen-tools/commitizen/issues/417).

--- a/docs/tutorials/auto_prepare_commit_message.md
+++ b/docs/tutorials/auto_prepare_commit_message.md
@@ -2,7 +2,20 @@
 
 ## About
 
-To automatically prepare a commit message prior to committing, you can use a [Git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).
+It can be desirable to use commitizen for all types of commits (i.e. regular, merge,
+squash) so that the complete git history adheres to the commit message convention
+without ever having to call `cz commit` manually.
+
+To automatically prepare a commit message prior to committing, you can
+use a [Git hook](prepare-commit-msg-docs):
+
+> The [prepare-commit-msg] hook is invoked by git-commit right after preparing the
+> default log message, and before the editor is started.
+
+This allows for enforcing the usage of commitizen so that whenever a commit is about to
+be created, commitizen is used for creating the commit message. Running `git commit` or
+`git commit -m "..."` for example, would trigger commitizen and use the generated commit
+message for the commit.
 
 ## How to
 
@@ -25,3 +38,8 @@ exec < /dev/tty && cz commit --dry-run --write-message-to-file $COMMIT_MSG_FILE 
 See the Git hooks documentation on [`prepare-commit-msg` hooks][prepare-commit-msg-docs] for details on how this works.
 
 [prepare-commit-msg-docs]: https://git-scm.com/docs/githooks#_prepare_commit_msg
+
+## Drawbacks
+
+If additional hooks are used (e.g. pre-commit) that prevent a commit from being created,
+the message has to be created from scratch when commiting again.

--- a/docs/tutorials/auto_prepare_commit_message.md
+++ b/docs/tutorials/auto_prepare_commit_message.md
@@ -4,42 +4,43 @@
 
 It can be desirable to use commitizen for all types of commits (i.e. regular, merge,
 squash) so that the complete git history adheres to the commit message convention
-without ever having to call `cz commit` manually.
+without ever having to call `cz commit`.
 
 To automatically prepare a commit message prior to committing, you can
-use a [Git hook](prepare-commit-msg-docs):
+use a [prepare-commit-msg Git hook](prepare-commit-msg-docs):
 
-> The [prepare-commit-msg] hook is invoked by git-commit right after preparing the
+> This hook is invoked by git-commit right after preparing the
 > default log message, and before the editor is started.
 
-This allows for enforcing the usage of commitizen so that whenever a commit is about to
-be created, commitizen is used for creating the commit message. Running `git commit` or
-`git commit -m "..."` for example, would trigger commitizen and use the generated commit
-message for the commit.
+To automatically perform arbitrary cleanup steps after a succesful commit you can use a
+[post-commit Git hook][post-commit-docs]:
 
-## How to
+> This hook is invoked by git-commit. It takes no parameters, and is invoked after a
+> commit is made.
 
-- Step 1: Create a new [`prepare-commit-msg`][prepare-commit-msg-docs] Git hook by running the following commands from the root of the Git repository:
+A combination of these two hooks allows for enforcing the usage of commitizen so that
+whenever a commit is about to be created, commitizen is used for creating the commit
+message. Running `git commit` or `git commit -m "..."` for example, would trigger
+commitizen and use the generated commit message for the commit.
 
-```sh
-cd .git/hooks
-touch prepare-commit-msg
-chmod +x prepare-commit-msg
+## Installation
+
+Copy the hooks from [here](https://github.com/commitizen-tools/hooks) into the `.git/hooks` folder and make them
+  executable by running the following commands from the root of your Git repository:
+
+```bash
+wget -o .git/hooks/prepare-commit-msg https://github.com/commitizen-tools/hooks/prepare-commit-msg.py
+chmod +x .git/hooks/prepare-commit-msg
+wget -o .git/hooks/post-commit https://github.com/commitizen-tools/hooks/post-commit.py
+chmod +x .git/hooks/post-commit
 ```
 
-- Step 2: Edit the newly created file and add the following content:
+## Features
 
-```sh
-#!/bin/sh
-COMMIT_MSG_FILE=$1
-exec < /dev/tty && cz commit --dry-run --write-message-to-file $COMMIT_MSG_FILE || true
-```
+- Commits can be created using both `cz commit` and the regular `git commit`
+- The hooks automatically create a backup of the commit message that can be reused if
+  the commit failed
+- The commit message backup can also be used via `cz commit --retry`
 
-See the Git hooks documentation on [`prepare-commit-msg` hooks][prepare-commit-msg-docs] for details on how this works.
-
+[post-commit-docs]: https://git-scm.com/docs/githooks#_post_commit
 [prepare-commit-msg-docs]: https://git-scm.com/docs/githooks#_prepare_commit_msg
-
-## Drawbacks
-
-If additional hooks are used (e.g. pre-commit) that prevent a commit from being created,
-the message has to be created from scratch when commiting again.

--- a/docs/tutorials/auto_prepare_commit_message.md
+++ b/docs/tutorials/auto_prepare_commit_message.md
@@ -1,0 +1,27 @@
+# Automatically prepare message before commit
+
+## About
+
+To automatically prepare a commit message prior to committing, you can use a [Git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).
+
+## How to
+
+- Step 1: Create a new [`prepare-commit-msg`][prepare-commit-msg-docs] Git hook by running the following commands from the root of the Git repository:
+
+```sh
+cd .git/hooks
+touch prepare-commit-msg
+chmod +x prepare-commit-msg
+```
+
+- Step 2: Edit the newly created file and add the following content:
+
+```sh
+#!/bin/sh
+COMMIT_MSG_FILE=$1
+exec < /dev/tty && cz commit --dry-run --write-message-to-file $COMMIT_MSG_FILE || true
+```
+
+See the Git hooks documentation on [`prepare-commit-msg` hooks][prepare-commit-msg-docs] for details on how this works.
+
+[prepare-commit-msg-docs]: https://git-scm.com/docs/githooks#_prepare_commit_msg

--- a/hooks/post-commit.py
+++ b/hooks/post-commit.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+import os
+import tempfile
+from pathlib import Path
+
+
+def post_commit():
+    backup_file = Path(
+        tempfile.gettempdir(), f"cz.commit{os.environ.get('USER', '')}.backup"
+    )
+
+    # remove backup file if it exists
+    if backup_file.is_file():
+        backup_file.unlink()
+
+
+if __name__ == "__main__":
+    exit(post_commit())

--- a/hooks/prepare-commit-msg.py
+++ b/hooks/prepare-commit-msg.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from subprocess import CalledProcessError
+
+
+def prepare_commit_msg(commit_msg_file: Path) -> int:
+    # check that commitizen is installed
+    if shutil.which("cz") is None:
+        print("commitizen is not installed!")
+        return 0
+
+    # check if the commit message needs to be generated using commitizen
+    if (
+        subprocess.run(
+            [
+                "cz",
+                "check",
+                "--commit-msg-file",
+                commit_msg_file,
+            ],
+            capture_output=True,
+        ).returncode
+        != 0
+    ):
+        backup_file = Path(
+            tempfile.gettempdir(), f"cz.commit{os.environ.get('USER', '')}.backup"
+        )
+
+        if backup_file.is_file():
+            # confirm if commit message from backup file should be reused
+            answer = input("retry with previous message? [y/N]: ")
+            if answer.lower() == "y":
+                shutil.copyfile(backup_file, commit_msg_file)
+                return 0
+
+        # use commitizen to generate the commit message
+        try:
+            subprocess.run(
+                [
+                    "cz",
+                    "commit",
+                    "--dry-run",
+                    "--write-message-to-file",
+                    commit_msg_file,
+                ],
+                stdin=sys.stdin,
+                stdout=sys.stdout,
+            ).check_returncode()
+        except CalledProcessError as error:
+            return error.returncode
+
+        # write message to backup file
+        shutil.copyfile(commit_msg_file, backup_file)
+
+
+if __name__ == "__main__":
+    # make hook interactive by attaching /dev/tty to stdin
+    with open("/dev/tty") as tty:
+        sys.stdin = tty
+        exit(prepare_commit_msg(sys.argv[1]))

--- a/hooks/prepare-commit-msg.sh
+++ b/hooks/prepare-commit-msg.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-COMMIT_MSG_FILE=$1
-exec < /dev/tty && cz commit --dry-run --write-message-to-file $COMMIT_MSG_FILE || true

--- a/hooks/prepare-commit-msg.sh
+++ b/hooks/prepare-commit-msg.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+COMMIT_MSG_FILE=$1
+exec < /dev/tty && cz commit --dry-run --write-message-to-file $COMMIT_MSG_FILE || true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - Tutorials:
       - Writing commits: "tutorials/writing_commits.md"
       - Auto check commits: "tutorials/auto_check.md"
+      - Auto prepare commit message: "tutorials/auto_prepare_commit_message.md"
       - GitLab CI: "tutorials/gitlab_ci.md"
       - Github Actions: "tutorials/github_actions.md"
       - Jenkins pipeline: "tutorials/jenkins_pipeline.md"

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -130,16 +130,15 @@ def test_commit_command_with_write_message_to_file_option(
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    commands.Commit(config, {"write_message_to_file": str(tmp_file)})()
+    commands.Commit(config, {"write_message_to_file": tmp_file})()
     success_mock.assert_called_once()
     assert tmp_file.exists()
     assert tmp_file.read_text() == "feat: user created"
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-@pytest.mark.parametrize("message_file", [True, False, 0, 1])
 def test_commit_command_with_invalid_write_message_to_file_option(
-    config, message_file, mocker: MockFixture
+    config, tmp_path, mocker: MockFixture
 ):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
@@ -152,8 +151,7 @@ def test_commit_command_with_invalid_write_message_to_file_option(
     }
 
     with pytest.raises(NotAllowed):
-        print(isinstance(message_file, str))
-        commit_cmd = commands.Commit(config, {"write_message_to_file": message_file})
+        commit_cmd = commands.Commit(config, {"write_message_to_file": tmp_path})
         commit_cmd()
 
 

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -12,6 +12,7 @@ from commitizen.exceptions import (
     NoAnswersError,
     NoCommitBackupError,
     NotAGitProjectError,
+    NotAllowed,
     NothingToCommitError,
 )
 
@@ -133,6 +134,27 @@ def test_commit_command_with_write_message_to_file_option(
     success_mock.assert_called_once()
     assert tmp_file.exists()
     assert tmp_file.read_text() == "feat: user created"
+
+
+@pytest.mark.usefixtures("staging_is_clean")
+@pytest.mark.parametrize("message_file", [True, False, 0, 1])
+def test_commit_command_with_invalid_write_message_to_file_option(
+    config, message_file, mocker: MockFixture
+):
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "",
+        "footer": "",
+    }
+
+    with pytest.raises(NotAllowed):
+        print(isinstance(message_file, str))
+        commit_cmd = commands.Commit(config, {"write_message_to_file": message_file})
+        commit_cmd()
 
 
 @pytest.mark.usefixtures("staging_is_clean")

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -110,6 +110,32 @@ def test_commit_command_with_dry_run_option(config, mocker: MockFixture):
 
 
 @pytest.mark.usefixtures("staging_is_clean")
+def test_commit_command_with_write_message_to_file_option(
+    config, tmp_path, mocker: MockFixture
+):
+    tmp_file = tmp_path / "message"
+
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "",
+        "footer": "",
+    }
+
+    commit_mock = mocker.patch("commitizen.git.commit")
+    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
+    success_mock = mocker.patch("commitizen.out.success")
+
+    commands.Commit(config, {"write_message_to_file": str(tmp_file)})()
+    success_mock.assert_called_once()
+    assert tmp_file.exists()
+    assert tmp_file.read_text() == "feat: user created"
+
+
+@pytest.mark.usefixtures("staging_is_clean")
 def test_commit_command_with_signoff_option(config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
This pull request resolves #689 by implementing my proposal for it.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
See https://github.com/commitizen-tools/commitizen/issues/689#issuecomment-1526221321.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
New option:
1. Run `cz commit --write-message-to-file message.txt` in a Git repository with staged changes and complete interactive dialog
1. The content of `message.txt` should be the generated commit message
1. The other behavior of `cz commit` is unchanged

Git hook:
1. Follow the tutorial in `docs/tutorials/auto_prepare_commit_message.md` in a Git repository with staged changes
1. When running `git commit` or `git commit -m "..."`, the usual `cz commit` interactive dialog runs
1. After completing the dialog (and exiting the GIT_EDITOR if it opened), a new commit with the generate commit message is created

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
These changes supersede #249 and #250.
