### PR TITLE
feat: Add option in bump command to redirect git output to stderr

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -186,6 +186,12 @@ data = {
                         "help": "Output changelog to the stdout",
                     },
                     {
+                        "name": ["--git-output-to-stderr"],
+                        "action": "store_true",
+                        "default": False,
+                        "help": "Redirect git output to stderr",
+                    },
+                    {
                         "name": ["--retry"],
                         "action": "store_true",
                         "default": False,

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -57,6 +57,7 @@ class Bump:
             "update_changelog_on_bump"
         )
         self.changelog_to_stdout = arguments["changelog_to_stdout"]
+        self.git_output_to_stderr = arguments["git_output_to_stderr"]
         self.no_verify = arguments["no_verify"]
         self.check_consistency = arguments["check_consistency"]
         self.retry = arguments["retry"]
@@ -327,9 +328,15 @@ class Bump:
             raise BumpCommitFailedError(f'2nd git.commit error: "{c.err.strip()}"')
 
         if c.out:
-            out.write(c.out)
+            if self.git_output_to_stderr:
+                out.diagnostic(c.out)
+            else:
+                out.write(c.out)
         if c.err:
-            out.write(c.err)
+            if self.git_output_to_stderr:
+                out.diagnostic(c.err)
+            else:
+                out.write(c.err)
 
         c = git.tag(
             new_tag_version,

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -57,7 +57,7 @@ usage: cz bump [-h] [--dry-run] [--files-only] [--local-version] [--changelog]
                [--bump-message BUMP_MESSAGE] [--prerelease {alpha,beta,rc}]
                [--devrelease DEVRELEASE] [--increment {MAJOR,MINOR,PATCH}]
                [--check-consistency] [--annotated-tag] [--gpg-sign]
-               [--changelog-to-stdout] [--retry] [--major-version-zero]
+               [--changelog-to-stdout] [--git-output-to-stderr] [--retry] [--major-version-zero]
                [MANUAL_VERSION]
 
 positional arguments:
@@ -91,6 +91,8 @@ options:
   --gpg-sign, -s        sign tag instead of lightweight one
   --changelog-to-stdout
                         Output changelog to the stdout
+  --git-output-to-stderr
+                        Redirect git output to stderr
   --retry               retry commit if it fails the 1st time
   --major-version-zero  keep major version at zero, even for breaking changes
   --prerelease-offset   start pre-releases with this offset
@@ -195,6 +197,13 @@ Example:
 ```bash
 cz bump --changelog --changelog-to-stdout > body.md
 ```
+
+### `--git-output-to-stderr`
+
+If `--git-output-to-stderr` is used, git commands output is redirected to stderr.
+
+This command is useful when used with `--changelog-to-stdout` and piping the output to a file,
+and you don't want the `git commit` output polluting  the stdout.
 
 ### `--retry`
 

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 import sys
 from typing import Tuple
 from unittest.mock import MagicMock, call
@@ -594,6 +595,34 @@ def test_bump_with_changelog_to_stdout_dry_run_arg(
     assert out.startswith("#")
     assert "this should appear in stdout with dry-run enabled" in out
     assert "0.2.0" in out
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_without_git_to_stdout_arg(mocker: MockFixture, capsys, changelog_path):
+    create_file_and_commit("feat(user): this should appear in stdout")
+    testargs = ["cz", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    out, _ = capsys.readouterr()
+
+    assert (
+        re.search(r"^\[master \w+] bump: version 0.1.0 → 0.2.0", out, re.MULTILINE)
+        is not None
+    )
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_with_git_to_stdout_arg(mocker: MockFixture, capsys, changelog_path):
+    create_file_and_commit("feat(user): this should appear in stdout")
+    testargs = ["cz", "bump", "--yes", "--git-output-to-stderr"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    out, _ = capsys.readouterr()
+
+    assert (
+        re.search(r"^\[master \w+] bump: version 0.1.0 → 0.2.0", out, re.MULTILINE)
+        is None
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Add an option to redirect git command output to stderr instead of stdout.
This is useful used in conjunction with `--changelog-to-stdout` if you don't need/want the resulting output to contain the `git commit` log messages.


## Checklist

- [X] Add test cases to all the changes you introduce
- [X] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [X] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

When issuing `cz bump --changelog-to-stdout > file.md`, `file.md` will contain the git output of the `git commit` command (eg. something like `[<branche> <SHA>] bump: x.y.z -> a.b.c + diffstats`. When passing the `--git-output-to-stderr` option, this output is written to stderr instead of stdout allowing the resulting file to only contain changelog-related stuff.


## Steps to Test This Pull Request
1. `cz bump --changelog-to-stdout --git-output-to-stderr > body.md`
2. Ensure body.md does not contain git-related traces.

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
