### PR TITLE
fix(init): fix is_pre_commit_installed method

### DIFF
--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -4,8 +4,6 @@ from typing import Any, Dict, List, Optional
 
 import questionary
 import yaml
-from packaging.version import Version
-
 from commitizen import cmd, factory, out
 from commitizen.__version__ import __version__
 from commitizen.config import BaseConfig, JsonConfig, TomlConfig, YAMLConfig
@@ -14,6 +12,7 @@ from commitizen.defaults import config_files
 from commitizen.exceptions import InitFailedError, NoAnswersError
 from commitizen.git import get_latest_tag_name, get_tag_names, smart_open
 from commitizen.version_types import VERSION_TYPES
+from packaging.version import Version
 
 
 class ProjectInfo:
@@ -66,7 +65,7 @@ class ProjectInfo:
 
     @property
     def is_pre_commit_installed(self) -> bool:
-        return not shutil.which("pre-commit")
+        return bool(shutil.which("pre-commit"))
 
 
 class Init:


### PR DESCRIPTION
the logic of the original method is "pre_commit_not_installed"

## Description
Closes #743 

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
Run `cz init` and choose to install pre-commit hook without encountering error


## Steps to Test This Pull Request
1. Run `cz init`
2. Choose to install pre-commit hook


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
