### PR TITLE
feat: add support for cargo workspaces

### DIFF
--- a/commitizen/providers.py
+++ b/commitizen/providers.py
@@ -115,14 +115,25 @@ class PoetryProvider(TomlProvider):
 class CargoProvider(TomlProvider):
     """
     Cargo version management
+
+    With support for `workspaces`
     """
 
     filename = "Cargo.toml"
 
     def get(self, document: tomlkit.TOMLDocument) -> str:
-        return document["package"]["version"]  # type: ignore
+        try:
+            return document["package"]["version"]  # type: ignore
+        except tomlkit.exceptions.NonExistentKey:
+            ...
+        return document["workspace"]["package"]["version"]  # type: ignore
 
     def set(self, document: tomlkit.TOMLDocument, version: str):
+        try:
+            document["workspace"]["package"]["version"] = version  # type: ignore
+            return
+        except tomlkit.exceptions.NonExistentKey:
+            ...
         document["package"]["version"] = version  # type: ignore
 
 

--- a/tests/test_version_providers.py
+++ b/tests/test_version_providers.py
@@ -57,8 +57,9 @@ def test_commitizen_provider(config: BaseConfig, mocker: MockerFixture):
     mock.assert_called_once_with("version", "43.1")
 
 
-FILE_PROVIDERS = dict(
-    pep621=(
+FILE_PROVIDERS = [
+    (
+        "pep621",
         "pyproject.toml",
         Pep621Provider,
         """\
@@ -70,7 +71,8 @@ FILE_PROVIDERS = dict(
         version = "42.1"
         """,
     ),
-    poetry=(
+    (
+        "poetry",
         "pyproject.toml",
         PoetryProvider,
         """\
@@ -82,7 +84,21 @@ FILE_PROVIDERS = dict(
         version = "42.1"
         """,
     ),
-    cargo=(
+    (
+        "cargo",
+        "Cargo.toml",
+        CargoProvider,
+        """\
+        [workspace.package]
+        version = "0.1.0"
+        """,
+        """\
+        [workspace.package]
+        version = "42.1"
+        """,
+    ),
+    (
+        "cargo",
         "Cargo.toml",
         CargoProvider,
         """\
@@ -94,7 +110,8 @@ FILE_PROVIDERS = dict(
         version = "42.1"
         """,
     ),
-    npm=(
+    (
+        "npm",
         "package.json",
         NpmProvider,
         """\
@@ -110,7 +127,8 @@ FILE_PROVIDERS = dict(
         }
         """,
     ),
-    composer=(
+    (
+        "composer",
         "composer.json",
         ComposerProvider,
         """\
@@ -126,12 +144,12 @@ FILE_PROVIDERS = dict(
         }
         """,
     ),
-)
+]
 
 
 @pytest.mark.parametrize(
     "id,filename,cls,content,expected",
-    (pytest.param(id, *FILE_PROVIDERS[id], id=id) for id in FILE_PROVIDERS),
+    FILE_PROVIDERS,
 )
 def test_file_providers(
     config: BaseConfig,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
This PR adds support for `Cargo.toml` workspaces.

When the root `Cargo.toml` of a project is:

```
[workspace.package]
version = "0.1.0"
```
In your apps you can have a `Cargo.toml` with:

```
[package]
version = { workspace = true }
```


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually

