### PR TITLE
Fix cz bump with custom type, scope and exclamation mark

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -10,6 +10,8 @@ from commitizen.exceptions import CurrentVersionNotFoundError
 from commitizen.git import GitCommit, smart_open
 from commitizen.version_schemes import DEFAULT_SCHEME, Version, VersionScheme
 
+VERSION_TYPES = [None, PATCH, MINOR, MAJOR]
+
 
 def find_increment(
     commits: list[GitCommit], regex: str, increments_map: dict | OrderedDict
@@ -34,12 +36,11 @@ def find_increment(
                         new_increment = increments_map[match_pattern]
                         break
 
+                if VERSION_TYPES.index(increment) < VERSION_TYPES.index(new_increment):
+                    increment = new_increment
+
                 if increment == MAJOR:
                     break
-                elif increment == MINOR and new_increment == MAJOR:
-                    increment = new_increment
-                elif increment == PATCH or increment is None:
-                    increment = new_increment
 
     return increment
 

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -104,7 +104,7 @@ MAJOR = "MAJOR"
 MINOR = "MINOR"
 PATCH = "PATCH"
 
-bump_pattern = r"^(((BREAKING[\-\ ]CHANGE|feat|fix|refactor|perf)(\(.+\))?(!)?)|\w+!):"
+bump_pattern = r"^((BREAKING[\-\ ]CHANGE|\w+)(\(.+\))?!?):"
 bump_map = OrderedDict(
     (
         (r"^.+!$", MAJOR),

--- a/tests/test_bump_find_increment.py
+++ b/tests/test_bump_find_increment.py
@@ -58,6 +58,12 @@ MAJOR_INCREMENTS_EXCLAMATION_OTHER_TYPE_CC = [
     "fix(setup.py): future is now required for every python version",
 ]
 
+MAJOR_INCREMENTS_EXCLAMATION_OTHER_TYPE_WITH_SCOPE_CC = [
+    "chore(deps)!: drop support for Python 3.9",
+    "docs(README): motivation",
+    "fix(setup.py): future is now required for every python version",
+]
+
 PATCH_INCREMENTS_SVE = ["readme motivation PATCH", "fix setup.py PATCH"]
 
 MINOR_INCREMENTS_SVE = [
@@ -85,6 +91,7 @@ semantic_version_map = {"MAJOR": "MAJOR", "MINOR": "MINOR", "PATCH": "PATCH"}
         (MAJOR_INCREMENTS_BREAKING_CHANGE_CC, "MAJOR"),
         (MAJOR_INCREMENTS_BREAKING_CHANGE_ALT_CC, "MAJOR"),
         (MAJOR_INCREMENTS_EXCLAMATION_OTHER_TYPE_CC, "MAJOR"),
+        (MAJOR_INCREMENTS_EXCLAMATION_OTHER_TYPE_WITH_SCOPE_CC, "MAJOR"),
         (MAJOR_INCREMENTS_EXCLAMATION_CC, "MAJOR"),
         (MAJOR_INCREMENTS_EXCLAMATION_CC_SAMPLE_2, "MAJOR"),
         (NONE_INCREMENT_CC, None),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

This change adds support for version bumping for custom types with a scope. Previously, a commit with the following message didn't increment the version.

```
$ git commit --allow-empty -m 'chore(scope)!: major change'
[master 0567ca4] chore(scope)!: major change
$ python ./commitizen/cli.py bump --dry-run
bump: version 3.5.2 → 3.5.2
tag to create: v3.5.2

[NO_COMMITS_TO_BUMP]
The commits found are not eligible to be bumped
```

Also, there is a minor bugfix in the bump command, that resulted in a wrongly calculated increment. (It's separated into a commit)

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

Not sure if I have to update the documentation, because I'd say it's the expected behavior from the conventional commit specification.

## Expected behavior

See steps to reproduce.


## Steps to Test This Pull Request

1. Add a commit 
   ```
   git commit --allow-empty -m 'chore(scope)!: major change'
   ```
1. Check that bump increments the major version
   ```
   $ python ./commitizen/cli.py bump --dry-run
   bump: version 3.5.2 → 4.0.0
   tag to create: v4.0.0
   increment detected: MAJOR
   ```

## Additional context

Related to https://github.com/commitizen-tools/commitizen/issues/673