### PR TITLE
Fix auto added label for newly created PR and add PR, issue life cycle to documentation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
-'issue-status: needs-triage':
+'pr-status: wait-for-review':
 - '**/*'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
       - id: check-merge-conflict
       - id: check-toml
       - id: check-yaml
+        args: ['--unsafe']  # for mkdocs.yml
       - id: detect-private-key
 
   - repo: https://github.com/asottile/blacken-docs

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,4 +28,81 @@ If you're a first-time contributor, you can check the issues with [good first is
 10. If your changes are about documentation. Run `poetry run mkdocs serve` to serve documentation locally and check whether there is any warning or error.
 11. Send a [pull request](https://github.com/commitizen-tools/commitizen/pulls) 🙏
 
+## Use of GitHub Labels
+
+* good-first-issue *(issue only)*
+* help-wanted
+* issue-status: needs-triage *(issue only)* **(default label for issues)**
+* issue-status: wont-fix
+* issue-status: wont-implement
+* issue-status: duplicate
+* issue-status: invalid
+* issue-status: wait-for-response
+* issue-status: wait-for-implementation
+* issue-status: pr-created
+* pr-status: wait-for-review **(default label for PRs)**
+* pr-status: reviewing
+* pr-status: wait-for-modification
+* pr-status: wait-for-response
+* pr-status: ready-to-merge
+* needs: test-case *(pr only)*
+* needs: documentation *(pr only)*
+* type: feature
+* type: bug
+* type: documentation
+* type: refactor
+* type: question *(issue only)*
+* os: Windows
+* os: Linux
+* os: macOS
+
+
+### Issue life cycle
+
+```mermaid
+graph TD
+    input[/issue created/] -->
+    needs-triage
+    needs-triage --triage--> close(wont-implement, wont-fix, duplicate, invalid)
+
+    needs-triage --triage--> wait-for-implementation
+    needs-triage --triage--> wait-for-response
+
+    wait-for-response --response--> needs-triage
+
+    wait-for-implementation --PR-created--> pr-created --PR-merged--> output[/close/]
+
+    close --> output[/close/]
+```
+
+### Pull request life cycle
+
+```mermaid
+flowchart TD
+    input[/pull request created/] -->
+    wait-for-review
+    --start reviewing -->
+    reviewing
+    --finish review -->
+    reviewed{approved}
+
+    reviewed --Y-->
+    wait-for-merge -->
+    output[/merge/]
+
+    reviewed --n-->
+    require-more-information{require more information}
+
+    require-more-information --y-->
+    wait-for-response
+    --response-->
+    require-more-information
+
+    require-more-information --n-->
+    wait-for-modification
+    --modification-received-->
+    review
+```
+
+
 [conventional-commmits]: https://www.conventionalcommits.org/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,3 +63,8 @@ markdown_extensions:
   - pymdownx.superfences
   - toc:
       permalink: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format


### PR DESCRIPTION
## Description
* Fix auto-added label for newly created PR (should be `pr-status: wait-for-review`)
* add PR, issue life cycle to documentation

## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
GitHub Actions add `pr-status: wait-for-review` label when PR created


## Steps to Test This Pull Request
1. create a PR after this PR is merged
2. go to the created PR to check whether label `pr-status: wait-for-review` is added

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
