### PR TITLE
refactor: replace SemVer type literals by respective constants

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -5,7 +5,7 @@ import re
 from collections import OrderedDict
 from string import Template
 
-from commitizen.defaults import bump_message
+from commitizen.defaults import MAJOR, MINOR, PATCH, bump_message
 from commitizen.exceptions import CurrentVersionNotFoundError
 from commitizen.git import GitCommit, smart_open
 from commitizen.version_schemes import DEFAULT_SCHEME, VersionScheme, Version
@@ -34,11 +34,11 @@ def find_increment(
                         new_increment = increments_map[match_pattern]
                         break
 
-                if increment == "MAJOR":
+                if increment == MAJOR:
                     break
-                elif increment == "MINOR" and new_increment == "MAJOR":
+                elif increment == MINOR and new_increment == MAJOR:
                     increment = new_increment
-                elif increment == "PATCH" or increment is None:
+                elif increment == PATCH or increment is None:
                     increment = new_increment
 
     return increment

--- a/commitizen/version_schemes.py
+++ b/commitizen/version_schemes.py
@@ -191,7 +191,7 @@ class BaseVersion(_BaseVersion):
             elif increment == PATCH:
                 base[PATCH] += 1
 
-        return f"{base['MAJOR']}.{base['MINOR']}.{base['PATCH']}"
+        return f"{base[MAJOR]}.{base[MINOR]}.{base[PATCH]}"
 
     def bump(
         self,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

This is a small PR updating a few lines of code where SemVer types (major/minor/patch) are referred to as literal strings instead of constants defined in `commitizen.defaults` module.

I guess the changes made do not require tests.

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes
