### PR TITLE
fix: properly bump versions between prereleases

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -230,29 +230,12 @@ class Bump:
                     "To avoid this error, manually specify the type of increment with `--increment`"
                 )
 
-            # Increment is removed when current and next version
-            # are expected to be prereleases.
-            force_bump = False
-            if current_version.is_prerelease:
-                last_final = self.find_previous_final_version(current_version)
-                if last_final is not None:
-                    commits = git.get_commits(last_final)
-                    increment = self.find_increment(commits)
-                    base = last_final.increment_base(
-                        increment=increment, force_bump=True
-                    )
-                    if base != current_version.base_version:
-                        force_bump = True
-                elif prerelease:
-                    increment = None
-
             new_version = current_version.bump(
                 increment,
                 prerelease=prerelease,
                 prerelease_offset=prerelease_offset,
                 devrelease=devrelease,
                 is_local_version=is_local_version,
-                force_bump=force_bump,
             )
 
         new_tag_version = bump.normalize_tag(

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -238,10 +238,10 @@ class Bump:
                 if last_final is not None:
                     commits = git.get_commits(last_final)
                     increment = self.find_increment(commits)
-                    semver = last_final.increment_base(
+                    base = last_final.increment_base(
                         increment=increment, force_bump=True
                     )
-                    if semver != current_version.base_version:
+                    if base != current_version.base_version:
                         force_bump = True
                 elif prerelease:
                     increment = None

--- a/commitizen/version_schemes.py
+++ b/commitizen/version_schemes.py
@@ -221,8 +221,8 @@ class BaseVersion(_BaseVersion):
             release = list(self.release)
             if len(release) < 3:
                 release += [0] * (3 - len(release))
-            current_semver = ".".join(str(part) for part in release)
-            if base == current_semver:
+            current_base = ".".join(str(part) for part in release)
+            if base == current_base:
                 pre_version = self.generate_prerelease(
                     prerelease, offset=prerelease_offset
                 )

--- a/commitizen/version_schemes.py
+++ b/commitizen/version_schemes.py
@@ -147,6 +147,12 @@ class BaseVersion(_BaseVersion):
         if not prerelease:
             return ""
 
+        # prevent down-bumping the pre-release phase, e.g. from 'b1' to 'a2'
+        # https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases
+        # https://semver.org/#spec-item-11
+        if self.is_prerelease and self.pre:
+            prerelease = max(prerelease, self.pre[0])
+
         # version.pre is needed for mypy check
         if self.is_prerelease and self.pre and prerelease.startswith(self.pre[0]):
             prev_prerelease: int = self.pre[1]

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -113,6 +113,34 @@ Generate a **changelog** along with the new version and tag when bumping.
 cz bump --changelog
 ```
 
+### `--prerelease`
+
+The bump is a pre-release bump, meaning that in addition to a possible version bump the new version receives a
+pre-release segment compatible with the bump’s version scheme, where the segment consist of a _phase_ and a
+non-negative number. Supported options for `--prerelease` are the following phase names  `alpha`, `beta`, or
+`rc` (release candidate). For more details, refer to the
+[Python Packaging User Guide](https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-releases).
+
+Note that as per [semantic versioning spec](https://semver.org/#spec-item-9)
+
+> Pre-release versions have a lower precedence than the associated normal version. A pre-release version
+> indicates that the version is unstable and might not satisfy the intended compatibility requirements
+> as denoted by its associated normal version.
+
+For example, the following versions (using the [PEP 440](https://peps.python.org/pep-0440/) scheme) are ordered
+by their precedence and showcase how a release might flow through a development cycle:
+
+- `1.0.0` is the current published version
+- `1.0.1a0` after committing a `fix:` for pre-release
+- `1.1.0a1` after committing an additional `feat:` for pre-release
+- `1.1.0b0` after bumping a beta release
+- `1.1.0rc0` after bumping the release candidate
+- `1.1.0` next feature release
+
+Also note that bumping pre-releases _maintains linearity_: bumping of a pre-release with lower precedence than
+the current pre-release phase maintains the current phase of higher precedence. For example, if the current
+version is `1.0.0b1` then bumping with `--prerelease alpha` will continue to bump the “beta” phase.
+
 ### `--check-consistency`
 
 Check whether the versions defined in `version_files` and the version in commitizen

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -228,6 +228,42 @@ def test_bump_command_prelease(mocker: MockFixture):
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_command_prelease_increment(mocker: MockFixture):
+    # FINAL RELEASE
+    create_file_and_commit("fix: location")
+
+    testargs = ["cz", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    assert git.tag_exist("0.1.1")
+
+    # PRERELEASE
+    create_file_and_commit("fix: location")
+
+    testargs = ["cz", "bump", "--prerelease", "alpha", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    assert git.tag_exist("0.1.2a0")
+
+    create_file_and_commit("feat: location")
+
+    testargs = ["cz", "bump", "--prerelease", "alpha", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    assert git.tag_exist("0.2.0a0")
+
+    create_file_and_commit("feat!: breaking")
+
+    testargs = ["cz", "bump", "--prerelease", "alpha", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    assert git.tag_exist("1.0.0a0")
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
 def test_bump_on_git_with_hooks_no_verify_disabled(mocker: MockFixture):
     """Bump commit without --no-verify"""
     cmd.run("mkdir .git/hooks")

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -208,9 +208,9 @@ def test_bump_command_increment_option(
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
 def test_bump_command_prelease(mocker: MockFixture):
-    # PRERELEASE
     create_file_and_commit("feat: location")
 
+    # Create an alpha pre-release.
     testargs = ["cz", "bump", "--prerelease", "alpha", "--yes"]
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
@@ -218,7 +218,58 @@ def test_bump_command_prelease(mocker: MockFixture):
     tag_exists = git.tag_exist("0.2.0a0")
     assert tag_exists is True
 
-    # PRERELEASE BUMP CREATES VERSION WITHOUT PRERELEASE
+    # Create a beta pre-release.
+    testargs = ["cz", "bump", "--prerelease", "beta", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    tag_exists = git.tag_exist("0.2.0b0")
+    assert tag_exists is True
+
+    # With a current beta pre-release, bumping alpha must bump beta
+    # because we can't bump "backwards".
+    testargs = ["cz", "bump", "--prerelease", "alpha", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    tag_exists = git.tag_exist("0.2.0a1")
+    assert tag_exists is False
+    tag_exists = git.tag_exist("0.2.0b1")
+    assert tag_exists is True
+
+    # Create a rc pre-release.
+    testargs = ["cz", "bump", "--prerelease", "rc", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    tag_exists = git.tag_exist("0.2.0rc0")
+    assert tag_exists is True
+
+    # With a current rc pre-release, bumping alpha must bump rc.
+    testargs = ["cz", "bump", "--prerelease", "alpha", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    tag_exists = git.tag_exist("0.2.0a1")
+    assert tag_exists is False
+    tag_exists = git.tag_exist("0.2.0b2")
+    assert tag_exists is False
+    tag_exists = git.tag_exist("0.2.0rc1")
+    assert tag_exists is True
+
+    # With a current rc pre-release, bumping beta must bump rc.
+    testargs = ["cz", "bump", "--prerelease", "beta", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    tag_exists = git.tag_exist("0.2.0a2")
+    assert tag_exists is False
+    tag_exists = git.tag_exist("0.2.0b2")
+    assert tag_exists is False
+    tag_exists = git.tag_exist("0.2.0rc2")
+    assert tag_exists is True
+
+    # Create a final release from the current pre-release.
     testargs = ["cz", "bump"]
     mocker.patch.object(sys, "argv", testargs)
     cli.main()

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_beta_alpha_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_beta_alpha_.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0a0 (2021-06-11)
+## 0.2.0b1 (2021-06-11)
 
 ## 0.2.0b0 (2021-06-11)
 

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_alpha_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_alpha_.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0a0 (2021-06-11)
+## 0.2.0rc1 (2021-06-11)
 
 ## 0.2.0rc0 (2021-06-11)
 

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_beta_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_beta_.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0b0 (2021-06-11)
+## 0.2.0rc1 (2021-06-11)
 
 ## 0.2.0rc0 (2021-06-11)
 

--- a/tests/test_version_scheme_pep440.py
+++ b/tests/test_version_scheme_pep440.py
@@ -43,10 +43,11 @@ local_versions = [
     (("4.5.0+0.2.0", "MAJOR", None, 0, None), "4.5.0+1.0.0"),
 ]
 
-# this cases should be handled gracefully
-unexpected_cases = [
-    (("0.1.1rc0", None, "alpha", 0, None), "0.1.1a0"),
-    (("0.1.1b1", None, "alpha", 0, None), "0.1.1a0"),
+# never bump backwards on pre-releases
+linear_prerelease_cases = [
+    (("0.1.1b1", None, "alpha", 0, None), "0.1.1b2"),
+    (("0.1.1rc0", None, "alpha", 0, None), "0.1.1rc1"),
+    (("0.1.1rc0", None, "beta", 0, None), "0.1.1rc1"),
 ]
 
 weird_cases = [
@@ -145,7 +146,7 @@ prerelease_cases = [
         tdd_cases,
         weird_cases,
         simple_flow,
-        unexpected_cases,
+        linear_prerelease_cases,
         prerelease_cases,
     ),
 )

--- a/tests/test_version_scheme_pep440.py
+++ b/tests/test_version_scheme_pep440.py
@@ -78,10 +78,76 @@ tdd_cases = [
     (("1.0.0rc1", None, "rc", 0, None), "1.0.0rc2"),
 ]
 
+# additional pre-release tests run through various release scenarios
+prerelease_cases = [
+    #
+    (("3.3.3", "PATCH", "alpha", 0, None), "3.3.4a0"),
+    (("3.3.4a0", "PATCH", "alpha", 0, None), "3.3.4a1"),
+    (("3.3.4a1", "MINOR", "alpha", 0, None), "3.4.0a0"),
+    (("3.4.0a0", "PATCH", "alpha", 0, None), "3.4.0a1"),
+    (("3.4.0a1", "MINOR", "alpha", 0, None), "3.4.0a2"),
+    (("3.4.0a2", "MAJOR", "alpha", 0, None), "4.0.0a0"),
+    (("4.0.0a0", "PATCH", "alpha", 0, None), "4.0.0a1"),
+    (("4.0.0a1", "MINOR", "alpha", 0, None), "4.0.0a2"),
+    (("4.0.0a2", "MAJOR", "alpha", 0, None), "4.0.0a3"),
+    #
+    (("1.0.0", "PATCH", "alpha", 0, None), "1.0.1a0"),
+    (("1.0.1a0", "PATCH", "alpha", 0, None), "1.0.1a1"),
+    (("1.0.1a1", "MINOR", "alpha", 0, None), "1.1.0a0"),
+    (("1.1.0a0", "PATCH", "alpha", 0, None), "1.1.0a1"),
+    (("1.1.0a1", "MINOR", "alpha", 0, None), "1.1.0a2"),
+    (("1.1.0a2", "MAJOR", "alpha", 0, None), "2.0.0a0"),
+    #
+    (("1.0.0", "MINOR", "alpha", 0, None), "1.1.0a0"),
+    (("1.1.0a0", "PATCH", "alpha", 0, None), "1.1.0a1"),
+    (("1.1.0a1", "MINOR", "alpha", 0, None), "1.1.0a2"),
+    (("1.1.0a2", "PATCH", "alpha", 0, None), "1.1.0a3"),
+    (("1.1.0a3", "MAJOR", "alpha", 0, None), "2.0.0a0"),
+    #
+    (("1.0.0", "MAJOR", "alpha", 0, None), "2.0.0a0"),
+    (("2.0.0a0", "MINOR", "alpha", 0, None), "2.0.0a1"),
+    (("2.0.0a1", "PATCH", "alpha", 0, None), "2.0.0a2"),
+    (("2.0.0a2", "MAJOR", "alpha", 0, None), "2.0.0a3"),
+    (("2.0.0a3", "MINOR", "alpha", 0, None), "2.0.0a4"),
+    (("2.0.0a4", "PATCH", "alpha", 0, None), "2.0.0a5"),
+    (("2.0.0a5", "MAJOR", "alpha", 0, None), "2.0.0a6"),
+    #
+    (("1.0.1a0", "PATCH", None, 0, None), "1.0.1"),
+    (("1.0.1a0", "MINOR", None, 0, None), "1.1.0"),
+    (("1.0.1a0", "MAJOR", None, 0, None), "2.0.0"),
+    #
+    (("1.1.0a0", "PATCH", None, 0, None), "1.1.0"),
+    (("1.1.0a0", "MINOR", None, 0, None), "1.1.0"),
+    (("1.1.0a0", "MAJOR", None, 0, None), "2.0.0"),
+    #
+    (("2.0.0a0", "MINOR", None, 0, None), "2.0.0"),
+    (("2.0.0a0", "MAJOR", None, 0, None), "2.0.0"),
+    (("2.0.0a0", "PATCH", None, 0, None), "2.0.0"),
+    #
+    (("3.0.0a1", None, None, 0, None), "3.0.0"),
+    (("3.0.0b1", None, None, 0, None), "3.0.0"),
+    (("3.0.0rc1", None, None, 0, None), "3.0.0"),
+    #
+    (("3.1.4", None, "alpha", 0, None), "3.1.4a0"),
+    (("3.1.4", None, "beta", 0, None), "3.1.4b0"),
+    (("3.1.4", None, "rc", 0, None), "3.1.4rc0"),
+    #
+    (("3.1.4", None, "alpha", 0, None), "3.1.4a0"),
+    (("3.1.4a0", "PATCH", "alpha", 0, None), "3.1.4a1"),  # UNEXPECTED!
+    (("3.1.4a0", "MINOR", "alpha", 0, None), "3.2.0a0"),
+    (("3.1.4a0", "MAJOR", "alpha", 0, None), "4.0.0a0"),
+]
+
 
 @pytest.mark.parametrize(
     "test_input,expected",
-    itertools.chain(tdd_cases, weird_cases, simple_flow, unexpected_cases),
+    itertools.chain(
+        tdd_cases,
+        weird_cases,
+        simple_flow,
+        unexpected_cases,
+        prerelease_cases,
+    ),
 )
 def test_bump_pep440_version(test_input, expected):
     current_version = test_input[0]

--- a/tests/test_version_scheme_semver.py
+++ b/tests/test_version_scheme_semver.py
@@ -44,10 +44,11 @@ local_versions = [
     (("4.5.0+0.2.0", "MAJOR", None, 0, None), "4.5.0+1.0.0"),
 ]
 
-# this cases should be handled gracefully
-unexpected_cases = [
-    (("0.1.1rc0", None, "alpha", 0, None), "0.1.1-a0"),
-    (("0.1.1b1", None, "alpha", 0, None), "0.1.1-a0"),
+# never bump backwards on pre-releases
+linear_prerelease_cases = [
+    (("0.1.1b1", None, "alpha", 0, None), "0.1.1-b2"),
+    (("0.1.1rc0", None, "alpha", 0, None), "0.1.1-rc1"),
+    (("0.1.1rc0", None, "beta", 0, None), "0.1.1-rc1"),
 ]
 
 weird_cases = [
@@ -84,7 +85,7 @@ tdd_cases = [
 
 @pytest.mark.parametrize(
     "test_input, expected",
-    itertools.chain(tdd_cases, weird_cases, simple_flow, unexpected_cases),
+    itertools.chain(tdd_cases, weird_cases, simple_flow, linear_prerelease_cases),
 )
 def test_bump_semver_version(test_input, expected):
     current_version = test_input[0]


### PR DESCRIPTION
## Description

Properly bump version numbers between prereleases respecting the commit messages bump levels.


## Checklist

- [X] Add test cases to all the changes you introduce
- [X] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior

Bump command should bump the version number according to the commit messages since the last final version when bumping between prereleases.


## Steps to Test This Pull Request

start at version 0.1.0

1. git commit --allow-empty --message 'fix: a fix'
2. cz bump --prerelease alpha → bumps to `0.1.1a0`
3. git commit --allow-empty --message 'feat: a feature'
4. cz bump --prerelease alpha → bumps to `0.2.0a0` instead of `0.1.1a1`

## Additional context
#688 
