### PR TITLE
feat: preserve prerelease linearity

### DIFF
--- a/commitizen/version_schemes.py
+++ b/commitizen/version_schemes.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, ClassVar, Type, cast
 import importlib_metadata as metadata
 from packaging.version import InvalidVersion  # noqa: F401: Rexpose the common exception
 from packaging.version import Version as _BaseVersion
+from packaging.version import _parse_letter_version
 
 from commitizen.config.base_config import BaseConfig
 from commitizen.defaults import MAJOR, MINOR, PATCH
@@ -148,10 +149,21 @@ class BaseVersion(_BaseVersion):
         This function might return something like 'alpha1'
         but it will be handled by Version.
         """
+
+        pre_order = ["a", "b", "rc"]
+
         if not prerelease:
             return ""
 
         # version.pre is needed for mypy check
+
+        if self.is_prerelease and self.pre:
+            letter_version = _parse_letter_version(prerelease, offset)
+            if letter_version:
+                current_index = pre_order.index(self.pre[0])
+                new_index = pre_order.index(letter_version[0])
+                prerelease = pre_order[max(current_index, new_index)]
+
         if self.is_prerelease and self.pre and prerelease.startswith(self.pre[0]):
             prev_prerelease: int = self.pre[1]
             new_prerelease_number = prev_prerelease + 1

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -211,8 +211,20 @@ def test_bump_command_prelease(mocker: MockFixture):
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    tag_exists = git.tag_exist("0.2.0a0")
-    assert tag_exists is True
+    assert git.tag_exist("0.2.0a0")
+
+    testargs = ["cz", "bump", "--prerelease", "rc", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    assert git.tag_exist("0.2.0rc0")
+
+    testargs = ["cz", "bump", "--prerelease", "alpha", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    assert not git.tag_exist("0.2.0a1")
+    assert git.tag_exist("0.2.0rc1")
 
     # PRERELEASE BUMP CREATES VERSION WITHOUT PRERELEASE
     testargs = ["cz", "bump"]

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_beta_alpha_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_beta_alpha_.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0a0 (2021-06-11)
+## 0.2.0b1 (2021-06-11)
 
 ## 0.2.0b0 (2021-06-11)
 

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_alpha_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_alpha_.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0a0 (2021-06-11)
+## 0.2.0rc1 (2021-06-11)
 
 ## 0.2.0rc0 (2021-06-11)
 

--- a/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_beta_.md
+++ b/tests/commands/test_changelog_command/test_changelog_incremental_with_prerelease_version_to_prerelease_version_rc_beta_.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0b0 (2021-06-11)
+## 0.2.0rc1 (2021-06-11)
 
 ## 0.2.0rc0 (2021-06-11)
 

--- a/tests/test_version_scheme_pep440.py
+++ b/tests/test_version_scheme_pep440.py
@@ -45,8 +45,8 @@ local_versions = [
 
 # this cases should be handled gracefully
 unexpected_cases = [
-    (("0.1.1rc0", None, "alpha", 0, None), "0.1.1a0"),
-    (("0.1.1b1", None, "alpha", 0, None), "0.1.1a0"),
+    (("0.1.1rc0", None, "alpha", 0, None), "0.1.1rc1"),
+    (("0.1.1b1", None, "alpha", 0, None), "0.1.1b2"),
 ]
 
 weird_cases = [

--- a/tests/test_version_scheme_semver.py
+++ b/tests/test_version_scheme_semver.py
@@ -46,8 +46,8 @@ local_versions = [
 
 # this cases should be handled gracefully
 unexpected_cases = [
-    (("0.1.1rc0", None, "alpha", 0, None), "0.1.1-a0"),
-    (("0.1.1b1", None, "alpha", 0, None), "0.1.1-a0"),
+    (("0.1.1rc0", None, "alpha", 0, None), "0.1.1-rc1"),
+    (("0.1.1b1", None, "alpha", 0, None), "0.1.1-b2"),
 ]
 
 weird_cases = [


### PR DESCRIPTION
## Description

Forbid going back in prerelease level, after a `beta` or `rc` prerelease is made the next prerelease without a version number bump will be the same type if a lower or equal level is provided.
a -> b -> rc

## Checklist

- [X] Add test cases to all the changes you introduce
- [X] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior

After a prerelease it will only allow to keep or increase the prerelease level.
A bump from `b0` with `--prerelease alpha` will generata a `b1` release instead of going back to `a0`.


## Steps to Test This Pull Request

Start at versions 0.1.0
1. `git commit --allow-empty -m 'fix: bug'`
2. `cz bump --prerelease alpha` → bumps to `0.1.1a0`
3. `cz bump --prerelease beta` → bumps to `0.1.1b0`
4. `cz bump --prerelease alpha` → bumps to `0.1.1b1`
5. `cz bump --prerelease rc` → bumps to `0.1.1rc0`
6. `cz bump --prerelease alpha` → bumps to `0.1.1rc1`
7. `cz bump --prerelease beta` → bumps to `0.1.1rc2`

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
