### PR TITLE
Update auto_prepare_commit_message.md

### DIFF
--- a/docs/tutorials/auto_prepare_commit_message.md
+++ b/docs/tutorials/auto_prepare_commit_message.md
@@ -29,9 +29,9 @@ Copy the hooks from [here](https://github.com/commitizen-tools/hooks) into the `
   executable by running the following commands from the root of your Git repository:
 
 ```bash
-wget -o .git/hooks/prepare-commit-msg https://github.com/commitizen-tools/hooks/prepare-commit-msg.py
+wget -O .git/hooks/prepare-commit-msg https://raw.githubusercontent.com/commitizen-tools/commitizen/master/hooks/prepare-commit-msg.py
 chmod +x .git/hooks/prepare-commit-msg
-wget -o .git/hooks/post-commit https://github.com/commitizen-tools/hooks/post-commit.py
+wget -O .git/hooks/post-commit https://raw.githubusercontent.com/commitizen-tools/commitizen/master/hooks/post-commit.py
 chmod +x .git/hooks/post-commit
 ```
 


### PR DESCRIPTION
docs(auto_prepare_commit_message.md): fixing hook URLs

## Description
Fixing the pre- and post-commit message hook URLs to their new locations


## Checklist

- [X ] Add test cases to all the changes you introduce
- [X ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X ] Test the changes on the local machine manually
- [X ] Update the documentation for the changes

## Expected behavior
That the URLs would work


## Steps to Test This Pull Request
1. `wget -O .git/hooks/post-commit https://raw.githubusercontent.com/commitizen-tools/commitizen/master/hooks/post-commit.py` 


## Additional context
None
