### PR TITLE
docs(docs): modify the wrong content in contributing md

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,7 +22,7 @@ If you're a first-time contributor, you can check the issues with [good first is
    (We use [CodeCov](https://codecov.io/) to ensure our test coverage does not drop.)
 7. Use [commitizen](https://github.com/commitizen-tools/commitizen) to do git commit. We follow [conventional commits][conventional-commits]
 8. Run `./scripts/format` and `./scripts/test` to ensure you follow the coding style and the tests pass.
-9. Optionally, update the `README.md`.
+9. Optionally, update the `./docs/README.md`.
 9. **Do not** update the `CHANGELOG.md`, it will be automatically created after merging to `master`.
 10. **Do not** update the versions in the project, they will be automatically updated.
 10. If your changes are about documentation. Run `poetry run mkdocs serve` to serve documentation locally and check whether there is any warning or error.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Modifing the wrong README.md path to the correct path in the `docs/contributing.md`


## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
1. execute `mkdocs serve`
2. http://127.0.0.1:8000/contributing/
<!-- Steps to reproduce the behavior:
1. ...
3. ...
4. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
