### PR TITLE
feat(commands): add cz commit arg to automatically stage every tracked and un-staged file

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -76,9 +76,9 @@ data = {
                         "help": "sign off the commit",
                     },
                     {
-                        "name": ["-a", "--add"],
+                        "name": ["-a", "--all"],
                         "action": "store_true",
-                        "help": "automatically stage every tracked and un-staged file",
+                        "help": "Tell the command to automatically stage files that have been modified and deleted, but new files you have not told Git about are not affected.",
                     },
                 ],
             },

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -75,6 +75,11 @@ data = {
                         "action": "store_true",
                         "help": "sign off the commit",
                     },
+                    {
+                        "name": ["-a", "--add"],
+                        "action": "store_true",
+                        "help": "automatically stage every tracked and un-staged file",
+                    },
                 ],
             },
             {

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -67,9 +67,9 @@ class Commit:
         dry_run: bool = self.arguments.get("dry_run")
         write_message_to_file = self.arguments.get("write_message_to_file")
 
-        is_git_add: bool = self.arguments.get("add")
-        if is_git_add:
-            c = git.add()
+        is_all: bool = self.arguments.get("all")
+        if is_all:
+            c = git.add("-u")
 
         if git.is_staging_clean() and not dry_run:
             raise NothingToCommitError("No files added to staging!")

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -67,6 +67,10 @@ class Commit:
         dry_run: bool = self.arguments.get("dry_run")
         write_message_to_file = self.arguments.get("write_message_to_file")
 
+        is_git_add: bool = self.arguments.get("add")
+        if is_git_add:
+            c = git.add()
+
         if git.is_staging_clean() and not dry_run:
             raise NothingToCommitError("No files added to staging!")
 

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -92,8 +92,8 @@ def tag(tag: str, annotated: bool = False, signed: bool = False) -> cmd.Command:
     return c
 
 
-def add() -> cmd.Command:
-    c = cmd.run("git add .")
+def add(args: str = "") -> cmd.Command:
+    c = cmd.run(f"git add {args}")
     return c
 
 

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -92,7 +92,7 @@ def tag(tag: str, annotated: bool = False, signed: bool = False) -> cmd.Command:
     return c
 
 
-def add():
+def add() -> cmd.Command:
     c = cmd.run("git add .")
     return c
 

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -92,6 +92,11 @@ def tag(tag: str, annotated: bool = False, signed: bool = False) -> cmd.Command:
     return c
 
 
+def add():
+    c = cmd.run("git add .")
+    return c
+
+
 def commit(
     message: str, args: str = "", committer_date: str | None = None
 ) -> cmd.Command:

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -273,6 +273,6 @@ def test_commit_command_with_all_option(config, mocker: MockFixture):
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
     add_mock = mocker.patch("commitizen.git.add")
-    commands.Commit(config, {"add": True})()
+    commands.Commit(config, {"all": True})()
     add_mock.assert_called()
     success_mock.assert_called_once()

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -255,3 +255,24 @@ def test_commit_in_non_git_project(tmpdir, config):
     with tmpdir.as_cwd():
         with pytest.raises(NotAGitProjectError):
             commands.Commit(config, {})
+
+
+@pytest.mark.usefixtures("staging_is_clean")
+def test_commit_command_with_add_option(config, mocker: MockFixture):
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "",
+        "footer": "",
+    }
+
+    commit_mock = mocker.patch("commitizen.git.commit")
+    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
+    success_mock = mocker.patch("commitizen.out.success")
+    add_mock = mocker.patch("commitizen.git.add")
+    commands.Commit(config, {"add": True})()
+    add_mock.assert_called()
+    success_mock.assert_called_once()

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -258,7 +258,7 @@ def test_commit_in_non_git_project(tmpdir, config):
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_with_add_option(config, mocker: MockFixture):
+def test_commit_command_with_all_option(config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Adding `cz commit` arg to  automatically stage every tracked and un-staged file


## Checklist

- [x] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
command `cz commit -a` will automatically stage every tracked and un-staged file .

## Steps to Test This Pull Request
1. cz commit -a
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
#554 