### PR TITLE
feat(defaults.py): add always_signoff config option for commits

### DIFF
--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -89,7 +89,9 @@ class Commit:
         if dry_run:
             raise DryRunExit()
 
-        signoff: bool = self.arguments.get("signoff") or self.config.settings["always_signoff"]
+        signoff: bool = (
+            self.arguments.get("signoff") or self.config.settings["always_signoff"]
+        )
 
         if signoff:
             c = git.commit(m, "-s")

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -89,7 +89,7 @@ class Commit:
         if dry_run:
             raise DryRunExit()
 
-        signoff: bool = self.arguments.get("signoff")
+        signoff: bool = self.arguments.get("signoff") or self.config.settings["always_signoff"]
 
         if signoff:
             c = git.commit(m, "-s")

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -56,6 +56,7 @@ class Settings(TypedDict, total=False):
     post_bump_hooks: list[str] | None
     prerelease_offset: int
     encoding: str
+    always_signoff: bool
 
 
 name: str = "cz_conventional_commits"
@@ -96,6 +97,7 @@ DEFAULT_SETTINGS: Settings = {
     "post_bump_hooks": [],
     "prerelease_offset": 0,
     "encoding": encoding,
+    "always_signoff": False,
 }
 
 MAJOR = "MAJOR"

--- a/docs/commit.md
+++ b/docs/commit.md
@@ -12,5 +12,20 @@ write the message to a file and not modify files and create a commit. A possible
 case for this is to [automatically prepare a commit message](./tutorials/auto_prepare_commit_message.md).
 
 !!! note
-    To maintain platform compatibility, the `commit` command disable ANSI escaping in its output.
-    In particular pre-commit hooks coloring will be deactivated as discussed in [commitizen-tools/commitizen#417](https://github.com/commitizen-tools/commitizen/issues/417).
+    To maintain platform compatibility, the `commit` command disables ANSI escaping in its output.
+    In particular, pre-commit hooks coloring will be deactivated as discussed in [commitizen-tools/commitizen#417](https://github.com/commitizen-tools/commitizen/issues/417).
+
+## Configuration
+
+### `always_signoff`
+
+When set to `true`, each commit message created by `cz commit` will be signed off.
+
+Defaults to: `false`.
+
+In your `pyproject.toml` or `.cz.toml`:
+
+```toml
+[tool.commitizen]
+always_signoff = true
+```

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 from pytest_mock import MockFixture
+from unittest.mock import ANY
 
 from commitizen import cmd, commands
 from commitizen.cz.exceptions import CzException
@@ -172,6 +173,31 @@ def test_commit_command_with_signoff_option(config, mocker: MockFixture):
     success_mock = mocker.patch("commitizen.out.success")
 
     commands.Commit(config, {"signoff": True})()
+
+    commit_mock.assert_called_once_with(ANY, "-s")
+    success_mock.assert_called_once()
+
+
+@pytest.mark.usefixtures("staging_is_clean")
+def test_commit_command_with_always_signoff_enabled(config, mocker: MockFixture):
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "",
+        "footer": "",
+    }
+
+    commit_mock = mocker.patch("commitizen.git.commit")
+    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
+    success_mock = mocker.patch("commitizen.out.success")
+
+    config.settings["always_signoff"] = True
+    commands.Commit(config, {})()
+
+    commit_mock.assert_called_once_with(ANY, "-s")
     success_mock.assert_called_once()
 
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -63,6 +63,7 @@ _settings = {
     "post_bump_hooks": ["scripts/slack_notification.sh"],
     "prerelease_offset": 0,
     "encoding": "utf-8",
+    "always_signoff": False,
 }
 
 _new_settings = {
@@ -87,6 +88,7 @@ _new_settings = {
     "post_bump_hooks": ["scripts/slack_notification.sh"],
     "prerelease_offset": 0,
     "encoding": "utf-8",
+    "always_signoff": False,
 }
 
 _read_settings = {


### PR DESCRIPTION
## Description
Add new configuration option `always_signoff`. When is set to `true`, commits will be always signed off. The `-s` option does not have to specified to `cz commit`.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
* When `always_signoff` configuration option is set to `true`, always sign off commits created with `cz commit`, even if `-s` option has not been specified.

## Steps to Test This Pull Request
1. Add `always_signoff` option to `true` in configuration file.
2. Create commit using `cz commit` (without `-s` option).
3. Verify the resulting commit message contains `Signed-off-by:`. 

## Additional context
#785