### PR TITLE
fix: empty error on bump failure

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -329,7 +329,8 @@ class Bump:
             cmd.run(git_add_changelog_and_version_files_command)
             c = git.commit(message, args=self._get_commit_args())
         if c.return_code != 0:
-            raise BumpCommitFailedError(f'2nd git.commit error: "{c.err.strip()}"')
+            err = c.err.strip() or c.out
+            raise BumpCommitFailedError(f'2nd git.commit error: "{err}"')
 
         if c.out:
             if self.git_output_to_stderr:


### PR DESCRIPTION
## Description

before:

```
2nd git.commit error: ""
```

after

```
2nd git.commit error: "On branch master
Your branch is ahead of 'origin/master' by 1 commit.
  (use "git push" to publish your local commits)

nothing to commit, working tree clean
"
```

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

<!-- Describe what the change is -->


## Checklist

- [-] Add test cases to all the changes you introduce
- [-] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [-] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
1. create a commit
2. `cz bump`



## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
