### PR TITLE
ci(github-actions): fix sponsorship action token used

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -15,12 +15,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
       - name: Generate Sponsors 💖
         uses: JamesIves/github-sponsors-readme-action@v1
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_FOR_ORG }}
-          file: 'docs/README.md'
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          file: "docs/README.md"
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
it should be PERSONAL_ACCESS_TOKEN instead of PERSONAL_ACCESS_TOKEN_FOR_ORG

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
