### PR TITLE
docs: typo - version_provider vs provider

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -16,7 +16,7 @@ Type: `str`
 
 Default: `None`
 
-Current version. Example: "0.1.2". Required if you use `provider = "commitizen"`.
+Current version. Example: "0.1.2". Required if you use `version_provider = "commitizen"`.
 
 ### `version_files`
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Trivial error in the docs, but it caught me out setting up config for a library earlier. The configuration docs currently say that `version` is required if `provider = "commitizen"`, however, the correct key for this config value is `version_provider` (although such providers live in the `commitizen.provider` namespace and I wouldn't be surprised if choosing this name was discussed during the implementation of this feature, but haven't checked).

## Additional context

Please advise if I have misunderstood the config. Have read the relevant source code and got my implementation working nicely, but keen to be corrected if I have missed some nuance.