### PR TITLE
Revert "ci(deps): bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
       - name: Upload coverage to Codecov
         if: runner.os == 'Linux'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: ./coverage.xml


### PR DESCRIPTION
Reverts commitizen-tools/commitizen#846

There appears to be [an issue with this](https://github.com/codecov/codecov-action/issues/1091) release, which is currently still in beta. Suggesting this commit is reverted, as it's causing all new pull requests, [including mine](https://github.com/commitizen-tools/commitizen/pull/848), to fail. Can update to `v4` once the release is stable.