### PR TITLE
fix(conf): handle parse error when init

### DIFF
--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -47,8 +47,8 @@ class JsonConfig(BaseConfig):
         """
         try:
             doc = json.loads(data)
-        except json.JSONDecodeError:
-            raise InvalidConfigurationError(f"Failed to parse {self.path}")
+        except json.JSONDecodeError as e:
+            raise InvalidConfigurationError(f"Failed to parse {self.path}: {e}")
 
         try:
             self.settings.update(doc["commitizen"])

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from tomlkit import exceptions, parse, table
 
+from commitizen.exceptions import InvalidConfigurationError
 from .base_config import BaseConfig
 
 
@@ -12,8 +13,8 @@ class TomlConfig(BaseConfig):
     def __init__(self, *, data: bytes | str, path: Path | str):
         super(TomlConfig, self).__init__()
         self.is_empty_config = False
-        self._parse_setting(data)
         self.add_path(path)
+        self._parse_setting(data)
 
     def init_empty_config_content(self):
         if os.path.isfile(self.path):
@@ -50,7 +51,11 @@ class TomlConfig(BaseConfig):
         name = "cz_conventional_commits"
         ```
         """
-        doc = parse(data)
+        try:
+            doc = parse(data)
+        except exceptions.ParseError as e:
+            raise InvalidConfigurationError(f"Failed to parse {self.path}: {e}")
+
         try:
             self.settings.update(doc["tool"]["commitizen"])  # type: ignore
         except exceptions.NonExistentKey:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 from commitizen import config, defaults, git
+from commitizen.exceptions import InvalidConfigurationError
 
 PYPROJECT = """
 [tool.commitizen]
@@ -177,6 +178,13 @@ class TestTomlConfig:
         with open(path, "r", encoding="utf-8") as toml_file:
             assert toml_file.read() == existing_content + "\n[tool.commitizen]\n"
 
+    def test_init_with_invalid_config_content(self, tmpdir):
+        existing_content = "invalid toml content"
+        path = tmpdir.mkdir("commitizen").join(".cz.toml")
+
+        with pytest.raises(InvalidConfigurationError, match=r"\.cz\.toml"):
+            config.TomlConfig(data=existing_content, path=path)
+
 
 class TestJsonConfig:
     def test_init_empty_config_content(self, tmpdir):
@@ -187,6 +195,13 @@ class TestJsonConfig:
         with open(path, "r", encoding="utf-8") as json_file:
             assert json.load(json_file) == {"commitizen": {}}
 
+    def test_init_with_invalid_config_content(self, tmpdir):
+        existing_content = "invalid json content"
+        path = tmpdir.mkdir("commitizen").join(".cz.json")
+
+        with pytest.raises(InvalidConfigurationError, match=r"\.cz\.json"):
+            config.JsonConfig(data=existing_content, path=path)
+
 
 class TestYamlConfig:
     def test_init_empty_config_content(self, tmpdir):
@@ -196,3 +211,10 @@ class TestYamlConfig:
 
         with open(path, "r") as yaml_file:
             assert yaml.safe_load(yaml_file) == {"commitizen": {}}
+
+    def test_init_with_invalid_content(self, tmpdir):
+        existing_content = "invalid: .cz.yaml: content: maybe?"
+        path = tmpdir.mkdir("commitizen").join(".cz.yaml")
+
+        with pytest.raises(InvalidConfigurationError, match=r"\.cz\.yaml"):
+            config.YAMLConfig(data=existing_content, path=path)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

If there is already a config file with wrong format in cwd, `cz` would failed to parse and the exception is unhandled. #729 have fixed that for json config, but yaml and toml are not.

Fixes #577 

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

`cz` should report there is an error when parsing config file.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

Execute following commands:

```sh
mkdir /tmp/cz-init
cd /tmp/init
echo 'i am not toml' > .cz.toml
# or test yaml format
# echo 'i: am: not: yaml' > .cz.yaml
cz init
```

and you will see error message like this:

```
Failed to parse .cz.toml: Invalid key "invalid content" at line 1 col 15
```

or this:

```
Failed to parse .cz.yaml: mapping values are not allowed here
  in "<byte string>", line 1, column 6:
    i: am: not: yaml
         ^
```

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
