### PR TITLE
docs: add developmental releases tutorial

### DIFF
--- a/docs/tutorials/dev_releases.md
+++ b/docs/tutorials/dev_releases.md
@@ -1,0 +1,78 @@
+# Dev Releases
+
+## About
+
+To make use of a `.dev` suffix, as per
+[PEP440](https://peps.python.org/pep-0440/#developmental-releases).
+
+If more than one active branch attempts to create a tag, relative to the main
+branch, there is the possibility that each will attempt to create the _same_
+tag, resulting in a collision.
+
+Developmental releases aim to avoid this by including a `.dev` segment which
+includes a non-negative integer unique to that workflow:
+
+```txt
+X.Y.devN
+```
+
+!!! note
+    As noted in
+    [PEP440](https://peps.python.org/pep-0440/#developmental-releases),
+    although developmental releases are useful in avoiding the situation
+    described above, depending on the value passed as the developmental
+    release, they can be _"difficult to parse for human readers"_.
+
+## How to
+
+### Example 1: CircleCI
+
+For example, CircleCI [provides](https://circleci.com/docs/variables/)
+`CIRCLE_BUILD_NUM`, a unique number for each job which will increment with each
+run:
+
+```sh
+--devrelease ${CIRCLE_BUILD_NUM}
+```
+
+This will result in a unique developmental release of, for example:
+
+```sh
+1.3.2.dev2478
+```
+
+### Example 2: GitHub
+
+GitHub also
+[provides](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
+`GITHUB_RUN_ID`, a _"unique number for each workflow run"_ which will also
+provide a unique number for each workflow:
+
+```sh
+--devrelease ${GITHUB_RUN_ID}
+```
+
+This will result in a unique developmental release of, for example:
+
+```sh
+1.3.2.dev6048584598
+```
+
+### Example 3: Unix time
+
+Equally, as the developmental release needs only a non-negative integer, it is
+possible to use the Unix time (i.e. the number of seconds since 1st January
+1970 UTC).
+
+This would create the possibility of a collision if two builds occur at
+precisely the same second but this may be sufficient for many cases:
+
+```sh
+--devrelease $(date +%s)
+```
+
+This will result in a unique developmental release of, for example:
+
+```sh
+1.3.2.dev1696238452
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - GitLab CI: "tutorials/gitlab_ci.md"
       - Github Actions: "tutorials/github_actions.md"
       - Jenkins pipeline: "tutorials/jenkins_pipeline.md"
+      - Developmental releases: "tutorials/dev_releases.md"
   - FAQ: "faq.md"
   - Exit Codes: "exit_codes.md"
   - Third-Party Commitizen Templates: "third-party-commitizen.md"


### PR DESCRIPTION
## Description

As requested in the comments for [#570](https://github.com/commitizen-tools/commitizen/issues/570#issuecomment-1527529968), added a tutorial for "developmental releases".

## Checklist

- [N/A] Add test cases to all the changes you introduce
- [X] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [X] Update the documentation for the changes

## Expected behavior

Addition to the "Tutorials" menu in the documentation.

## Steps to Test This Pull Request

1. Run `poetry run mkdocs serve`.
2. Visit <http://127.0.0.1:8000/>
3. Click on _Tutorials_ in the left-hand menu.
4. Click on _Developmental releases_ in the drop-down menu.

## Additional context

I've added examples for CircleCI (as this was the service I originally referenced), GitHub (as this would seem relevant to the current environment) and a catch-all using Unix time (which I've used elsewhere).