### PR TITLE
style(ruff): enable `pyupgrade` (`UP`) rules and fix them all

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -97,7 +97,7 @@ def _bump_with_regex(
     current_version_found = False
     lines = []
     pattern = re.compile(regex)
-    with open(version_filepath, "r", encoding=encoding) as f:
+    with open(version_filepath, encoding=encoding) as f:
         for line in f:
             if pattern.search(line):
                 bumped_line = line.replace(current_version, new_version)

--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -30,7 +30,7 @@ import os
 import re
 from collections import OrderedDict, defaultdict
 from datetime import date
-from typing import TYPE_CHECKING, Callable, Iterable, Type, cast
+from typing import TYPE_CHECKING, Callable, Iterable, cast
 
 from jinja2 import Environment, PackageLoader
 
@@ -74,7 +74,7 @@ def tag_included_in_changelog(
     return True
 
 
-def get_version_tags(scheme: Type[BaseVersion], tags: list[GitTag]) -> list[GitTag]:
+def get_version_tags(scheme: type[BaseVersion], tags: list[GitTag]) -> list[GitTag]:
     valid_tags: list[GitTag] = []
     for tag in tags:
         try:
@@ -230,7 +230,7 @@ def get_metadata(
             "latest_version_position": None,
         }
 
-    with open(filepath, "r", encoding=encoding) as changelog_file:
+    with open(filepath, encoding=encoding) as changelog_file:
         for index, line in enumerate(changelog_file):
             line = line.strip().lower()
 

--- a/commitizen/changelog_parser.py
+++ b/commitizen/changelog_parser.py
@@ -55,7 +55,7 @@ def find_version_blocks(filepath: str, encoding: str = encoding) -> Generator:
 
     ```
     """
-    with open(filepath, "r", encoding=encoding) as f:
+    with open(filepath, encoding=encoding) as f:
         block: list = []
         for line in f:
             line = line.strip("\n")

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -87,11 +87,9 @@ class Bump:
             else:
                 out.info(f"Tag {current_tag_version} could not be found. ")
                 out.info(
-                    (
-                        "Possible causes:\n"
-                        "- version in configuration is not the current version\n"
-                        "- tag_format is missing, check them using 'git tag --list'\n"
-                    )
+                    "Possible causes:\n"
+                    "- version in configuration is not the current version\n"
+                    "- tag_format is missing, check them using 'git tag --list'\n"
                 )
                 is_initial = questionary.confirm("Is this the first tag created?").ask()
         return is_initial

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -192,7 +192,7 @@ class Changelog:
 
         lines = []
         if self.incremental and os.path.isfile(self.file_name):
-            with open(self.file_name, "r", encoding=self.encoding) as changelog_file:
+            with open(self.file_name, encoding=self.encoding) as changelog_file:
                 lines = changelog_file.readlines()
 
         self.write_changelog(changelog_out, lines, changelog_meta)

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 import sys
-from typing import Any, List
+from typing import Any
 
 from commitizen import factory, git, out
 from commitizen.config import BaseConfig
@@ -35,7 +35,7 @@ class Check:
         # we need to distinguish between None and [], which is a valid value
 
         allowed_prefixes = arguments.get("allowed_prefixes")
-        self.allowed_prefixes: List[str] = (
+        self.allowed_prefixes: list[str] = (
             allowed_prefixes
             if allowed_prefixes is not None
             else config.settings["allowed_prefixes"]
@@ -56,10 +56,8 @@ class Check:
             self.commit_msg: str | None = sys.stdin.read()
         elif num_exclusive_args_provided != 1:
             raise InvalidCommandArgumentError(
-                (
-                    "Only one of --rev-range, --message, and --commit-msg-file is permitted by check command! "
-                    "See 'cz check -h' for more information"
-                )
+                "Only one of --rev-range, --message, and --commit-msg-file is permitted by check command! "
+                "See 'cz check -h' for more information"
             )
 
     def __call__(self):
@@ -98,7 +96,7 @@ class Check:
         # Get commit message from file (--commit-msg-file)
         if self.commit_msg_file is not None:
             # Enter this branch if commit_msg_file is "".
-            with open(self.commit_msg_file, "r", encoding=self.encoding) as commit_file:
+            with open(self.commit_msg_file, encoding=self.encoding) as commit_file:
                 msg = commit_file.read()
         # Get commit message from command line (--message)
         elif self.commit_msg is not None:

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -42,7 +42,7 @@ class Commit:
             raise NoCommitBackupError()
 
         # Read commit message from backup
-        with open(self.temp_file, "r", encoding=self.encoding) as f:
+        with open(self.temp_file, encoding=self.encoding) as f:
             return f.read().strip()
 
     def prompt_commit_questions(self) -> str:

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -11,7 +11,7 @@ from .base_config import BaseConfig
 
 class JsonConfig(BaseConfig):
     def __init__(self, *, data: bytes | str, path: Path | str):
-        super(JsonConfig, self).__init__()
+        super().__init__()
         self.is_empty_config = False
         self.add_path(path)
         self._parse_setting(data)

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -11,7 +11,7 @@ from .base_config import BaseConfig
 
 class TomlConfig(BaseConfig):
     def __init__(self, *, data: bytes | str, path: Path | str):
-        super(TomlConfig, self).__init__()
+        super().__init__()
         self.is_empty_config = False
         self.add_path(path)
         self._parse_setting(data)

--- a/commitizen/config/yaml_config.py
+++ b/commitizen/config/yaml_config.py
@@ -12,7 +12,7 @@ from .base_config import BaseConfig
 
 class YAMLConfig(BaseConfig):
     def __init__(self, *, data: bytes | str, path: Path | str):
-        super(YAMLConfig, self).__init__()
+        super().__init__()
         self.is_empty_config = False
         self.add_path(path)
         self._parse_setting(data)

--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -202,7 +202,7 @@ class ConventionalCommitsCz(BaseCommitizen):
     def info(self) -> str:
         dir_path = os.path.dirname(os.path.realpath(__file__))
         filepath = os.path.join(dir_path, "conventional_commits_info.txt")
-        with open(filepath, "r", encoding=self.config.settings["encoding"]) as f:
+        with open(filepath, encoding=self.config.settings["encoding"]) as f:
             content = f.read()
         return content
 

--- a/commitizen/cz/customize/customize.py
+++ b/commitizen/cz/customize/customize.py
@@ -22,7 +22,7 @@ class CustomizeCommitsCz(BaseCommitizen):
     change_type_order = defaults.change_type_order
 
     def __init__(self, config: BaseConfig):
-        super(CustomizeCommitsCz, self).__init__(config)
+        super().__init__(config)
 
         if "customize" not in self.config.settings:
             raise MissingCzCustomizeConfigError()
@@ -81,7 +81,7 @@ class CustomizeCommitsCz(BaseCommitizen):
         info_path = self.custom_settings.get("info_path")
         info = self.custom_settings.get("info")
         if info_path:
-            with open(info_path, "r", encoding=self.config.settings["encoding"]) as f:
+            with open(info_path, encoding=self.config.settings["encoding"]) as f:
                 content = f.read()
             return content
         elif info:

--- a/commitizen/cz/jira/jira.py
+++ b/commitizen/cz/jira/jira.py
@@ -76,6 +76,6 @@ class JiraSmartCz(BaseCommitizen):
     def info(self) -> str:
         dir_path = os.path.dirname(os.path.realpath(__file__))
         filepath = os.path.join(dir_path, "jira_info.txt")
-        with open(filepath, "r", encoding=self.config.settings["encoding"]) as f:
+        with open(filepath, encoding=self.config.settings["encoding"]) as f:
             content = f.read()
         return content

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 import pathlib
-import sys
 from collections import OrderedDict
 from typing import Any, Iterable, MutableMapping
 
-if sys.version_info < (3, 8):
-    from typing_extensions import TypedDict
-else:
-    from typing import TypedDict
+from typing import TypedDict
 
 # Type
 Questions = Iterable[MutableMapping[str, Any]]

--- a/commitizen/version_schemes.py
+++ b/commitizen/version_schemes.py
@@ -4,7 +4,7 @@ import re
 import sys
 import warnings
 from itertools import zip_longest
-from typing import TYPE_CHECKING, ClassVar, Type, cast
+from typing import TYPE_CHECKING, ClassVar, Protocol, Type, cast, runtime_checkable
 
 import importlib_metadata as metadata
 from packaging.version import InvalidVersion  # noqa: F401: Rexpose the common exception
@@ -13,11 +13,6 @@ from packaging.version import Version as _BaseVersion
 from commitizen.config.base_config import BaseConfig
 from commitizen.defaults import MAJOR, MINOR, PATCH
 from commitizen.exceptions import VersionSchemeUnknown
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol, runtime_checkable
-else:
-    from typing_extensions import Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     # TypeAlias is Python 3.10+ but backported in typing-extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ addopts = "--strict-markers"
 
 [tool.ruff]
 line-length = 88
+select = ["E", "F", "UP"]
 ignore = [
     "E501",
     "D1",

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -406,10 +406,10 @@ def test_bump_files_only(mocker: MockFixture, tmp_commitizen_project):
     tag_exists = git.tag_exist("0.3.0")
     assert tag_exists is False
 
-    with open(tmp_version_file, "r", encoding="utf-8") as f:
+    with open(tmp_version_file, encoding="utf-8") as f:
         assert "0.3.0" in f.read()
 
-    with open(tmp_commitizen_cfg_file, "r", encoding="utf-8") as f:
+    with open(tmp_commitizen_cfg_file, encoding="utf-8") as f:
         assert "0.3.0" in f.read()
 
 
@@ -431,7 +431,7 @@ def test_bump_local_version(mocker: MockFixture, tmp_commitizen_project):
     tag_exists = git.tag_exist("4.5.1+0.2.0")
     assert tag_exists is True
 
-    with open(tmp_version_file, "r", encoding="utf-8") as f:
+    with open(tmp_version_file, encoding="utf-8") as f:
         assert "4.5.1+0.2.0" in f.read()
 
 
@@ -511,7 +511,7 @@ def test_bump_with_changelog_arg(mocker: MockFixture, changelog_path):
     tag_exists = git.tag_exist("0.2.0")
     assert tag_exists is True
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
     assert out.startswith("#")
     assert "0.2.0" in out
@@ -529,7 +529,7 @@ def test_bump_with_changelog_config(mocker: MockFixture, changelog_path, config_
     tag_exists = git.tag_exist("0.2.0")
     assert tag_exists is True
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
     assert out.startswith("#")
     assert "0.2.0" in out
@@ -572,7 +572,7 @@ def test_bump_with_changelog_to_stdout_arg(mocker: MockFixture, capsys, changelo
     tag_exists = git.tag_exist("0.2.0")
     assert tag_exists is True
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
     assert out.startswith("#")
     assert "0.2.0" in out
@@ -911,7 +911,7 @@ def test_bump_command_prelease_scheme_via_cli(
     assert tag_exists is True
 
     for version_file in [tmp_version_file, tmp_commitizen_cfg_file]:
-        with open(version_file, "r") as f:
+        with open(version_file) as f:
             assert "0.2.0-a0" in f.read()
 
     # PRERELEASE BUMP CREATES VERSION WITHOUT PRERELEASE
@@ -923,7 +923,7 @@ def test_bump_command_prelease_scheme_via_cli(
     assert tag_exists is True
 
     for version_file in [tmp_version_file, tmp_commitizen_cfg_file]:
-        with open(version_file, "r") as f:
+        with open(version_file) as f:
             assert "0.2.0" in f.read()
 
 
@@ -944,7 +944,7 @@ def test_bump_command_prelease_scheme_via_config(
     assert tag_exists is True
 
     for version_file in [tmp_version_file, tmp_commitizen_cfg_file]:
-        with open(version_file, "r") as f:
+        with open(version_file) as f:
             assert "0.2.0-a0" in f.read()
 
     testargs = ["cz", "bump", "--prerelease", "alpha", "--yes"]
@@ -955,7 +955,7 @@ def test_bump_command_prelease_scheme_via_config(
     assert tag_exists is True
 
     for version_file in [tmp_version_file, tmp_commitizen_cfg_file]:
-        with open(version_file, "r") as f:
+        with open(version_file) as f:
             assert "0.2.0-a1" in f.read()
 
     # PRERELEASE BUMP CREATES VERSION WITHOUT PRERELEASE
@@ -967,7 +967,7 @@ def test_bump_command_prelease_scheme_via_config(
     assert tag_exists is True
 
     for version_file in [tmp_version_file, tmp_commitizen_cfg_file]:
-        with open(version_file, "r") as f:
+        with open(version_file) as f:
             assert "0.2.0" in f.read()
 
 
@@ -988,7 +988,7 @@ def test_bump_command_prelease_scheme_check_old_tags(
     assert tag_exists is True
 
     for version_file in [tmp_version_file, tmp_commitizen_cfg_file]:
-        with open(version_file, "r") as f:
+        with open(version_file) as f:
             assert "0.2.0-a0" in f.read()
 
     testargs = ["cz", "bump", "--prerelease", "alpha"]
@@ -999,7 +999,7 @@ def test_bump_command_prelease_scheme_check_old_tags(
     assert tag_exists is True
 
     for version_file in [tmp_version_file, tmp_commitizen_cfg_file]:
-        with open(version_file, "r") as f:
+        with open(version_file) as f:
             assert "0.2.0-a1" in f.read()
 
     # PRERELEASE BUMP CREATES VERSION WITHOUT PRERELEASE
@@ -1011,7 +1011,7 @@ def test_bump_command_prelease_scheme_check_old_tags(
     assert tag_exists is True
 
     for version_file in [tmp_version_file, tmp_commitizen_cfg_file]:
-        with open(version_file, "r") as f:
+        with open(version_file) as f:
             assert "0.2.0" in f.read()
 
 

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -77,7 +77,7 @@ def test_changelog_from_start(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
     file_regression.check(out, extension=".md")
 
@@ -106,7 +106,7 @@ def test_changelog_replacing_unreleased_using_incremental(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read().replace(
             datetime.strftime(datetime.now(), "%Y-%m-%d"), "2022-08-14"
         )
@@ -142,7 +142,7 @@ def test_changelog_is_persisted_using_incremental(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read().replace(
             datetime.strftime(datetime.now(), "%Y-%m-%d"), "2022-08-14"
         )
@@ -176,7 +176,7 @@ def test_changelog_incremental_angular_sample(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -227,7 +227,7 @@ def test_changelog_incremental_keep_a_changelog_sample(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -375,7 +375,7 @@ def test_changelog_multiple_incremental_do_not_add_new_lines(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -396,7 +396,7 @@ def test_changelog_incremental_newline_separates_new_content_from_old(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
 
     assert (
@@ -562,7 +562,7 @@ def test_changelog_config_flag_increment(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
 
     assert "this should be persisted using increment" in out
@@ -597,7 +597,7 @@ def test_changelog_config_flag_merge_prerelease(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r") as f:
+    with open(changelog_path) as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -650,7 +650,7 @@ def test_changelog_incremental_keep_a_changelog_sample_with_annotated_tag(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -684,7 +684,7 @@ def test_changelog_incremental_with_release_candidate_version(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -714,7 +714,7 @@ def test_changelog_incremental_with_prerelease_version_to_prerelease_version(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r") as f:
+    with open(changelog_path) as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -748,7 +748,7 @@ def test_changelog_release_candidate_version_with_merge_prerelease(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r") as f:
+    with open(changelog_path) as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -788,7 +788,7 @@ def test_changelog_incremental_with_merge_prerelease(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r") as f:
+    with open(changelog_path) as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -837,7 +837,7 @@ def test_changelog_from_rev_first_version_from_arg(
     testargs = ["cz", "changelog", "0.2.0"]
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -873,7 +873,7 @@ def test_changelog_from_rev_latest_version_from_arg(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r") as f:
+    with open(changelog_path) as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -937,7 +937,7 @@ def test_changelog_from_rev_range_default_tag_format(
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
 
-    with open(changelog_path, "r") as f:
+    with open(changelog_path) as f:
         out = f.read()
 
     assert "new file" not in out
@@ -997,7 +997,7 @@ def test_changelog_from_rev_version_range_including_first_tag(
     testargs = ["cz", "changelog", "0.2.0..0.3.0"]
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -1037,7 +1037,7 @@ def test_changelog_from_rev_version_range_from_arg(
     testargs = ["cz", "changelog", "0.3.0..0.4.0"]
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
-    with open(changelog_path, "r") as f:
+    with open(changelog_path) as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -1097,7 +1097,7 @@ def test_changelog_from_rev_version_with_big_range_from_arg(
     testargs = ["cz", "changelog", "0.3.0..0.5.0"]
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
-    with open(changelog_path, "r") as f:
+    with open(changelog_path) as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")
@@ -1196,7 +1196,7 @@ def test_changelog_with_customized_change_type_order(
     testargs = ["cz", "changelog", "0.3.0..0.4.0"]
     mocker.patch.object(sys, "argv", testargs)
     cli.main()
-    with open(changelog_path, "r") as f:
+    with open(changelog_path) as f:
         out = f.read()
 
     file_regression.check(out, extension=".md")

--- a/tests/commands/test_init_command.py
+++ b/tests/commands/test_init_command.py
@@ -74,7 +74,7 @@ def test_init_without_setup_pre_commit_hook(tmpdir, mocker: MockFixture, config)
     with tmpdir.as_cwd():
         commands.Init(config)()
 
-        with open("pyproject.toml", "r", encoding="utf-8") as toml_file:
+        with open("pyproject.toml", encoding="utf-8") as toml_file:
             config_data = toml_file.read()
         assert config_data == expected_config
 
@@ -160,7 +160,7 @@ def check_cz_config(config: str):
     Args:
         config: The config path
     """
-    with open(config, "r") as file:
+    with open(config) as file:
         if "json" in config:
             assert json.load(file) == EXPECTED_DICT_CONFIG
         elif "yaml" in config:
@@ -174,7 +174,7 @@ def check_pre_commit_config(expected: list[dict[str, Any]]):
     """
     Check the content of pre-commit config is as expected
     """
-    with open(pre_commit_config_filename, "r") as pre_commit_file:
+    with open(pre_commit_config_filename) as pre_commit_file:
         pre_commit_config_data = yaml.safe_load(pre_commit_file.read())
     assert pre_commit_config_data == {"repos": expected}
 

--- a/tests/test_bump_update_version_in_files.py
+++ b/tests/test_bump_update_version_in_files.py
@@ -108,7 +108,7 @@ def test_update_version_in_files(version_files, file_regression):
 
     file_contents = ""
     for filepath in version_files:
-        with open(filepath, "r", encoding="utf-8") as f:
+        with open(filepath, encoding="utf-8") as f:
             file_contents += f.read()
     file_regression.check(file_contents, extension=".txt")
 
@@ -120,7 +120,7 @@ def test_partial_update_of_file(version_repeated_file, file_regression):
     location = f"{version_repeated_file}:{regex}"
 
     bump.update_version_in_files(old_version, new_version, [location], encoding="utf-8")
-    with open(version_repeated_file, "r", encoding="utf-8") as f:
+    with open(version_repeated_file, encoding="utf-8") as f:
         file_regression.check(f.read(), extension=".json")
 
 
@@ -130,7 +130,7 @@ def test_random_location(random_location_version_file, file_regression):
     location = f"{random_location_version_file}:version.+Commitizen"
 
     bump.update_version_in_files(old_version, new_version, [location], encoding="utf-8")
-    with open(random_location_version_file, "r", encoding="utf-8") as f:
+    with open(random_location_version_file, encoding="utf-8") as f:
         file_regression.check(f.read(), extension=".lock")
 
 
@@ -142,7 +142,7 @@ def test_duplicates_are_change_with_no_regex(
     location = f"{random_location_version_file}:version"
 
     bump.update_version_in_files(old_version, new_version, [location], encoding="utf-8")
-    with open(random_location_version_file, "r", encoding="utf-8") as f:
+    with open(random_location_version_file, encoding="utf-8") as f:
         file_regression.check(f.read(), extension=".lock")
 
 
@@ -154,7 +154,7 @@ def test_version_bump_increase_string_length(
     location = f"{multiple_versions_increase_string}:version"
 
     bump.update_version_in_files(old_version, new_version, [location], encoding="utf-8")
-    with open(multiple_versions_increase_string, "r", encoding="utf-8") as f:
+    with open(multiple_versions_increase_string, encoding="utf-8") as f:
         file_regression.check(f.read(), extension=".txt")
 
 
@@ -166,7 +166,7 @@ def test_version_bump_reduce_string_length(
     location = f"{multiple_versions_reduce_string}:version"
 
     bump.update_version_in_files(old_version, new_version, [location], encoding="utf-8")
-    with open(multiple_versions_reduce_string, "r", encoding="utf-8") as f:
+    with open(multiple_versions_reduce_string, encoding="utf-8") as f:
         file_regression.check(f.read(), extension=".txt")
 
 
@@ -205,5 +205,5 @@ def test_multiplt_versions_to_bump(
     location = f"{multiple_versions_to_update_poetry_lock}:version"
 
     bump.update_version_in_files(old_version, new_version, [location], encoding="utf-8")
-    with open(multiple_versions_to_update_poetry_lock, "r", encoding="utf-8") as f:
+    with open(multiple_versions_to_update_poetry_lock, encoding="utf-8") as f:
         file_regression.check(f.read(), extension=".toml")

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -496,7 +496,7 @@ def tags() -> list:
 @pytest.fixture
 def changelog_content() -> str:
     changelog_path = "tests/CHANGELOG_FOR_TEST.md"
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/test_changelog_parser.py
+++ b/tests/test_changelog_parser.py
@@ -28,7 +28,7 @@ CHANGELOG_TEMPLATE = """
 @pytest.fixture
 def changelog_content() -> str:
     changelog_path = "tests/CHANGELOG_FOR_TEST.md"
-    with open(changelog_path, "r", encoding="utf-8") as f:
+    with open(changelog_path, encoding="utf-8") as f:
         return f.read()
 
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -164,7 +164,7 @@ class TestTomlConfig:
         toml_config = config.TomlConfig(data="", path=path)
         toml_config.init_empty_config_content()
 
-        with open(path, "r", encoding="utf-8") as toml_file:
+        with open(path, encoding="utf-8") as toml_file:
             assert toml_file.read() == "[tool.commitizen]\n"
 
     def test_init_empty_config_content_with_existing_content(self, tmpdir):
@@ -175,7 +175,7 @@ class TestTomlConfig:
         toml_config = config.TomlConfig(data="", path=path)
         toml_config.init_empty_config_content()
 
-        with open(path, "r", encoding="utf-8") as toml_file:
+        with open(path, encoding="utf-8") as toml_file:
             assert toml_file.read() == existing_content + "\n[tool.commitizen]\n"
 
     def test_init_with_invalid_config_content(self, tmpdir):
@@ -192,7 +192,7 @@ class TestJsonConfig:
         json_config = config.JsonConfig(data="{}", path=path)
         json_config.init_empty_config_content()
 
-        with open(path, "r", encoding="utf-8") as json_file:
+        with open(path, encoding="utf-8") as json_file:
             assert json.load(json_file) == {"commitizen": {}}
 
     def test_init_with_invalid_config_content(self, tmpdir):
@@ -209,7 +209,7 @@ class TestYamlConfig:
         yaml_config = config.YAMLConfig(data="{}", path=path)
         yaml_config.init_empty_config_content()
 
-        with open(path, "r") as yaml_file:
+        with open(path) as yaml_file:
             assert yaml.safe_load(yaml_file) == {"commitizen": {}}
 
     def test_init_with_invalid_content(self, tmpdir):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Enable [pyupgrade rules](https://docs.astral.sh/ruff/rules/#pyupgrade-up) in `ruff` to automatically update syntax according to supported Python version.
Then apply it on all the repository.


## Checklist

- [ ] Add test cases to all the changes you introduce (N/A)
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes (N/A)

## Expected behavior
No changes

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
