### PR TITLE
docs: fix Markdown link on Contributing page

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -20,7 +20,7 @@ If you're a first-time contributor, you can check the issues with [good first is
 5. Check out a new branch and add your modification.
 6. Add test cases for all your changes.
    (We use [CodeCov](https://codecov.io/) to ensure our test coverage does not drop.)
-7. Use [commitizen](https://github.com/commitizen-tools/commitizen) to do git commit. We follow [conventional commits][conventional-commits]
+7. Use [commitizen](https://github.com/commitizen-tools/commitizen) to do git commit. We follow [conventional commits](https://www.conventionalcommits.org/).
 8. Run `./scripts/format` and `./scripts/test` to ensure you follow the coding style and the tests pass.
 9. Optionally, update the `./docs/README.md`.
 9. **Do not** update the `CHANGELOG.md`, it will be automatically created after merging to `master`.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

Fix a Markdown link on the **Contributing** page [here](https://commitizen-tools.github.io/commitizen/contributing/#before-making-a-pull-request) (point 7).

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [X] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
n/a

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

n/a

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
n/a