### PR TITLE
ci(github-actions): move the generate sponsor step to docpublish workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,3 @@
 'pr-status: wait-for-review':
-- '**/*'
+- changed-files:
+  - any-glob-to-any-file: '**'

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -16,11 +16,6 @@ jobs:
         with:
           fetch-depth: 0
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
-      - name: Generate Sponsors 💖
-        uses: JamesIves/github-sponsors-readme-action@v1
-        with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN_FOR_ORG }}
-          file: 'docs/README.md'
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:

--- a/.github/workflows/docspublish.yml
+++ b/.github/workflows/docspublish.yml
@@ -25,6 +25,11 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         python -m mkdocs build
+    - name: Generate Sponsors 💖
+      uses: JamesIves/github-sponsors-readme-action@v1
+      with:
+        token: ${{ secrets.PERSONAL_ACCESS_TOKEN_FOR_ORG }}
+        file: 'docs/README.md'
     - name: Push doc to Github Page
       uses: peaceiris/actions-gh-pages@v2
       env:

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -10,4 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          .github/labeler.yaml
+        sparse-checkout-cone-mode: false
     - uses: actions/labeler@v5
+      with:
+        configuration-path: .github/labeler.yaml


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

move the "generate sponsor" step to docpublish workflow (not sure whether it's the root cause 🤔)

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
the sponsorship list generated correctly

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
