### PR TITLE
Add chore as an option to the default list of conventional commits

### DIFF
--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -53,6 +53,11 @@ class ConventionalCommitsCz(BaseCommitizen):
                         "key": "x",
                     },
                     {
+                        "value": "chore",
+                        "name": "chore: Other changes that don't modify src or test files",
+                        "key": "h",
+                    },
+                    {
                         "value": "feat",
                         "name": "feat: A new feature. Correlates with MINOR in SemVer",
                         "key": "f",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

As described in #917, I'd like to have the chore options in the default list of conventional commits options. I just added to the `questions` method. I think this is enough. I think I'm gonna need help to generate a demo [GIF](https://commitizen-tools.github.io/commitizen/images/demo.gif) showing the new output. My terminal is not as beauty as @woile's (I guess he generated that demo GIF)

## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

This is what the new list of options would look like:

![Screenshot from 2023-11-28 18-24-23](https://github.com/commitizen-tools/commitizen/assets/12239167/1c727ec3-d4b0-492f-a61c-0179577f52b4)


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

1. Pull this branch
2. Run `poetry install` this version
3. Get into the virtual environment by running `poetry shell`
4. run the `cz commit` command to see the new output

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
