### PR TITLE
ci(github-actions): fix laber-pr by adding necessary checkout step

### DIFF
--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -9,4 +9,5 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
     - uses: actions/labeler@v5


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
some of our PR are not correctly labeled, which is due to missing "checkout" step
https://github.com/actions/labeler#using-configuration-path-input-together-with-the-actionscheckout-action

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
