### PR TITLE
ci(github-actions): skip release action if no version is bumped

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -26,3 +26,4 @@ jobs:
         with:
           tag: v${{ env.REVISION }}
           bodyFile: "body.md"
+          skipIfReleaseExists: true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

By default, `ncipollo/release-action@v1` fails if no release happens, but we do not always make a release each time we merge a branch, which creates a lot of false alerts.


## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

`ncipollo/release-action@v1`  should not fail when release already exists.


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
