### PR TITLE
docs(github_actions.md): fix typo crendetial -> credential

### DIFF
--- a/docs/tutorials/github_actions.md
+++ b/docs/tutorials/github_actions.md
@@ -72,7 +72,7 @@ newely created version.
 
 Once the new tag is created, triggering an automatic publish command would be desired.
 
-In order to do so, the crendetial needs to be added with the information of our PyPI account.
+In order to do so, the credential needs to be added with the information of our PyPI account.
 
 Instead of using username and password, we suggest using [api token](https://pypi.org/help/#apitoken) generated from PyPI.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Fixing a simple typo in the `github_actions.md` doc
## Checklist

-  [x]  Test the changes on the local machine manually
-  [x]  Update the documentation for the changes
