### PR TITLE
fix: add cz-conventional-gitmoji to the third party docs

### DIFF
--- a/docs/third-party-commitizen.md
+++ b/docs/third-party-commitizen.md
@@ -46,6 +46,24 @@ pip install cz-emoji
 cz --name cz_emoji commit
 ```
 
+### [cz-conventional-gitmoji](https://github.com/ljnsn/cz-conventional-gitmoji)
+
+*conventional commit*s, but with [gitmojis](https://gitmoji.dev).
+
+Includes a pre-commit hook that automatically adds the correct gitmoji to the commit message based on the conventional type.
+
+### Installation
+
+```bash
+pip install cz-conventional-gitmoji
+```
+
+### Usage
+
+```bash
+cz --name cz_gitmoji commit
+```
+
 
 ### [Commitizen emoji](https://pypi.org/project/commitizen-emoji/) (Unmaintained)
 


### PR DESCRIPTION
## Description

Adding my plugin [cz-conventional-gitmoji](https://github.com/ljnsn/cz-conventional-gitmoji) to the third party tools section in the docs.


## Checklist

~- [ ] Add test cases to all the changes you introduce~
~- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test~
~- [ ] Test the changes on the local machine manually~
- [x] Update the documentation for the changes
