### PR TITLE
Fix SCM provider to only search tags that are reachable by the current commit

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -421,7 +421,7 @@ class Bump:
         if not final_versions:
             return None
 
-        final_versions = sorted(final_versions)  # type: ignore [type-var]
+        final_versions = sorted(final_versions)
         current_index = final_versions.index(current_version)
         previous_index = current_index - 1
         if previous_index < 0:

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -27,7 +27,6 @@ from commitizen.providers import get_provider
 from commitizen.version_schemes import (
     get_version_scheme,
     InvalidVersion,
-    VersionProtocol,
 )
 
 logger = getLogger("commitizen")
@@ -397,33 +396,3 @@ class Bump:
         if self.no_verify:
             commit_args.append("--no-verify")
         return " ".join(commit_args)
-
-    def find_previous_final_version(
-        self, current_version: VersionProtocol
-    ) -> VersionProtocol | None:
-        tag_format: str = self.bump_settings["tag_format"]
-        current = bump.normalize_tag(
-            current_version,
-            tag_format=tag_format,
-            scheme=self.scheme,
-        )
-
-        final_versions = []
-        for tag in git.get_tag_names():
-            assert tag
-            try:
-                version = self.scheme(tag)
-                if not version.is_prerelease or tag == current:
-                    final_versions.append(version)
-            except InvalidVersion:
-                continue
-
-        if not final_versions:
-            return None
-
-        final_versions = sorted(final_versions)
-        current_index = final_versions.index(current_version)
-        previous_index = current_index - 1
-        if previous_index < 0:
-            return None
-        return final_versions[previous_index]

--- a/commitizen/version_schemes.py
+++ b/commitizen/version_schemes.py
@@ -4,7 +4,7 @@ import re
 import sys
 import warnings
 from itertools import zip_longest
-from typing import TYPE_CHECKING, ClassVar, Protocol, Type, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Protocol, Type, cast, runtime_checkable
 
 import importlib_metadata as metadata
 from packaging.version import InvalidVersion  # noqa: F401: Rexpose the common exception
@@ -91,6 +91,24 @@ class VersionProtocol(Protocol):
     @property
     def micro(self) -> int:
         """The third item of :attr:`release` or ``0`` if unavailable."""
+        raise NotImplementedError("must be implemented")
+
+    def __lt__(self, other: Any) -> bool:
+        raise NotImplementedError("must be implemented")
+
+    def __le__(self, other: Any) -> bool:
+        raise NotImplementedError("must be implemented")
+
+    def __eq__(self, other: object) -> bool:
+        raise NotImplementedError("must be implemented")
+
+    def __ge__(self, other: Any) -> bool:
+        raise NotImplementedError("must be implemented")
+
+    def __gt__(self, other: Any) -> bool:
+        raise NotImplementedError("must be implemented")
+
+    def __ne__(self, other: object) -> bool:
         raise NotImplementedError("must be implemented")
 
     def bump(

--- a/tests/test_version_scheme_pep440.py
+++ b/tests/test_version_scheme_pep440.py
@@ -1,6 +1,8 @@
 import itertools
+import random
 
 import pytest
+
 from commitizen.version_schemes import Pep440, VersionProtocol
 
 simple_flow = [
@@ -140,6 +142,29 @@ prerelease_cases = [
 ]
 
 
+# test driven development
+sortability = [
+    "0.10.0a0",
+    "0.1.1",
+    "0.1.2",
+    "2.1.1",
+    "3.0.0",
+    "0.9.1a0",
+    "1.0.0a1",
+    "1.0.0b1",
+    "1.0.0a1",
+    "1.0.0a2.dev1",
+    "1.0.0rc2",
+    "1.0.0a3.dev0",
+    "1.0.0a2.dev0",
+    "1.0.0a3.dev1",
+    "1.0.0a2.dev0",
+    "1.0.0b0",
+    "1.0.0rc0",
+    "1.0.0rc1",
+]
+
+
 @pytest.mark.parametrize(
     "test_input,expected",
     itertools.chain(
@@ -198,3 +223,76 @@ def test_pep440_scheme_property():
 
 def test_pep440_implement_version_protocol():
     assert isinstance(Pep440("0.0.1"), VersionProtocol)
+
+
+def test_pep440_sortable():
+    test_input = [x[0][0] for x in simple_flow]
+    test_input.extend([x[1] for x in simple_flow])
+    # randomize
+    random_input = [Pep440(x) for x in random.sample(test_input, len(test_input))]
+    assert len(random_input) == len(test_input)
+    sorted_result = [str(x) for x in sorted(random_input)]
+    assert sorted_result == [
+        "0.1.0",
+        "0.1.0",
+        "0.1.1.dev1",
+        "0.1.1",
+        "0.1.1",
+        "0.2.0",
+        "0.2.0",
+        "0.2.0",
+        "0.3.0.dev1",
+        "0.3.0",
+        "0.3.0",
+        "0.3.0",
+        "0.3.0",
+        "0.3.1a0",
+        "0.3.1a0",
+        "0.3.1a0",
+        "0.3.1a0",
+        "0.3.1a1",
+        "0.3.1a1",
+        "0.3.1a1",
+        "0.3.1",
+        "0.3.1",
+        "0.3.1",
+        "0.3.2",
+        "0.4.2",
+        "1.0.0a0",
+        "1.0.0a0",
+        "1.0.0a1",
+        "1.0.0a1",
+        "1.0.0a1",
+        "1.0.0a1",
+        "1.0.0a2.dev0",
+        "1.0.0a2.dev0",
+        "1.0.0a2.dev1",
+        "1.0.0a2",
+        "1.0.0a3.dev0",
+        "1.0.0a3.dev0",
+        "1.0.0a3.dev1",
+        "1.0.0b0",
+        "1.0.0b0",
+        "1.0.0b0",
+        "1.0.0b1",
+        "1.0.0b1",
+        "1.0.0rc0",
+        "1.0.0rc0",
+        "1.0.0rc0",
+        "1.0.0rc0",
+        "1.0.0rc1.dev1",
+        "1.0.0rc1",
+        "1.0.0",
+        "1.0.0",
+        "1.0.1",
+        "1.0.1",
+        "1.0.2",
+        "1.0.2",
+        "1.1.0",
+        "1.1.0",
+        "1.2.0",
+        "1.2.0",
+        "1.2.1",
+        "1.2.1",
+        "2.0.0",
+    ]

--- a/tests/test_version_scheme_semver.py
+++ b/tests/test_version_scheme_semver.py
@@ -1,4 +1,5 @@
 import itertools
+import random
 
 import pytest
 
@@ -135,3 +136,76 @@ def test_semver_scheme_property():
 
 def test_semver_implement_version_protocol():
     assert isinstance(SemVer("0.0.1"), VersionProtocol)
+
+
+def test_semver_sortable():
+    test_input = [x[0][0] for x in simple_flow]
+    test_input.extend([x[1] for x in simple_flow])
+    # randomize
+    random_input = [SemVer(x) for x in random.sample(test_input, len(test_input))]
+    assert len(random_input) == len(test_input)
+    sorted_result = [str(x) for x in sorted(random_input)]
+    assert sorted_result == [
+        "0.1.0",
+        "0.1.0",
+        "0.1.1-dev1",
+        "0.1.1",
+        "0.1.1",
+        "0.2.0",
+        "0.2.0",
+        "0.2.0",
+        "0.3.0-dev1",
+        "0.3.0",
+        "0.3.0",
+        "0.3.0",
+        "0.3.0",
+        "0.3.1-a0",
+        "0.3.1-a0",
+        "0.3.1-a0",
+        "0.3.1-a0",
+        "0.3.1-a1",
+        "0.3.1-a1",
+        "0.3.1-a1",
+        "0.3.1",
+        "0.3.1",
+        "0.3.1",
+        "0.3.2",
+        "0.4.2",
+        "1.0.0-a0",
+        "1.0.0-a0",
+        "1.0.0-a1",
+        "1.0.0-a1",
+        "1.0.0-a1",
+        "1.0.0-a1",
+        "1.0.0-a2-dev0",
+        "1.0.0-a2-dev0",
+        "1.0.0-a2-dev1",
+        "1.0.0-a2",
+        "1.0.0-a3-dev0",
+        "1.0.0-a3-dev0",
+        "1.0.0-a3-dev1",
+        "1.0.0-b0",
+        "1.0.0-b0",
+        "1.0.0-b0",
+        "1.0.0-b1",
+        "1.0.0-b1",
+        "1.0.0-rc0",
+        "1.0.0-rc0",
+        "1.0.0-rc0",
+        "1.0.0-rc0",
+        "1.0.0-rc1-dev1",
+        "1.0.0-rc1",
+        "1.0.0",
+        "1.0.0",
+        "1.0.1",
+        "1.0.1",
+        "1.0.2",
+        "1.0.2",
+        "1.1.0",
+        "1.1.0",
+        "1.2.0",
+        "1.2.0",
+        "1.2.1",
+        "1.2.1",
+        "2.0.0",
+    ]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

The scm provider currently uses _all_ of the tags in the repo to determine the current version, but it should instead only consider tags that are upstream from the current commit.   This means commitizen currently consider tags that are in the future or on other branches when determining the version.  This doesn't make sense.  The pep621 provider doesn't determine the current version from the _latest_ commit of `pyproject.toml` or from commits on other branches, it looks at the current state of the repo. 

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

The expected behavior is that the current version should be determined by the "highest" version tag reachable by the current commit.  In order to determine "highest" I had to add sortability to `VersionProtocol`, but luckily this is already implemented by `BaseVersion`. 

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
