### PR TITLE
fix(changelog): handle custom tag_format in changelog generation

### DIFF
--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -44,6 +44,7 @@ from jinja2 import (
 from commitizen import out
 from commitizen.bump import normalize_tag
 from commitizen.cz.base import ChangelogReleaseHook
+from commitizen.defaults import get_tag_regexes
 from commitizen.exceptions import InvalidConfigurationError, NoCommitsFoundError
 from commitizen.git import GitCommit, GitTag
 from commitizen.version_schemes import (
@@ -97,20 +98,7 @@ def get_version_tags(
     scheme: type[BaseVersion], tags: list[GitTag], tag_format: str
 ) -> list[GitTag]:
     valid_tags: list[GitTag] = []
-    TAG_FORMAT_REGEXS = {
-        "$version": scheme.parser.pattern,
-        "$major": r"(?P<major>\d+)",
-        "$minor": r"(?P<minor>\d+)",
-        "$patch": r"(?P<patch>\d+)",
-        "$prerelease": r"(?P<prerelease>\w+\d+)?",
-        "$devrelease": r"(?P<devrelease>\.dev\d+)?",
-        "${version}": scheme.parser.pattern,
-        "${major}": r"(?P<major>\d+)",
-        "${minor}": r"(?P<minor>\d+)",
-        "${patch}": r"(?P<patch>\d+)",
-        "${prerelease}": r"(?P<prerelease>\w+\d+)?",
-        "${devrelease}": r"(?P<devrelease>\.dev\d+)?",
-    }
+    TAG_FORMAT_REGEXS = get_tag_regexes(scheme.parser.pattern)
     tag_format_regex = tag_format
     for pattern, regex in TAG_FORMAT_REGEXS.items():
         tag_format_regex = tag_format_regex.replace(pattern, regex)

--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -98,13 +98,13 @@ def get_version_tags(
 ) -> list[GitTag]:
     valid_tags: list[GitTag] = []
     TAG_FORMAT_REGEXS = {
-        "$version": str(scheme.parser.pattern),
+        "$version": scheme.parser.pattern,
         "$major": r"(?P<major>\d+)",
         "$minor": r"(?P<minor>\d+)",
         "$patch": r"(?P<patch>\d+)",
         "$prerelease": r"(?P<prerelease>\w+\d+)?",
         "$devrelease": r"(?P<devrelease>\.dev\d+)?",
-        "${version}": str(scheme.parser.pattern),
+        "${version}": scheme.parser.pattern,
         "${major}": r"(?P<major>\d+)",
         "${minor}": r"(?P<minor>\d+)",
         "${patch}": r"(?P<patch>\d+)",

--- a/commitizen/changelog_formats/asciidoc.py
+++ b/commitizen/changelog_formats/asciidoc.py
@@ -27,9 +27,9 @@ class AsciiDoc(BaseFormat):
             return None
 
         if partial_matches.get("prerelease"):
-            partial_version += f"-{partial_matches['prerelease']}"
+            partial_version = f"{partial_version}-{partial_matches['prerelease']}"
         if partial_matches.get("devrelease"):
-            partial_version += f"{partial_matches['devrelease']}"
+            partial_version = f"{partial_version}{partial_matches['devrelease']}"
         return partial_version
 
     def parse_title_level(self, line: str) -> int | None:

--- a/commitizen/changelog_formats/asciidoc.py
+++ b/commitizen/changelog_formats/asciidoc.py
@@ -18,7 +18,19 @@ class AsciiDoc(BaseFormat):
         matches = list(re.finditer(self.version_parser, m.group("title")))
         if not matches:
             return None
-        return matches[-1].group("version")
+        if "version" in matches[-1].groupdict():
+            return matches[-1].group("version")
+        partial_matches = matches[-1].groupdict()
+        try:
+            partial_version = f"{partial_matches['major']}.{partial_matches['minor']}.{partial_matches['patch']}"
+        except KeyError:
+            return None
+
+        if partial_matches.get("prerelease"):
+            partial_version += f"-{partial_matches['prerelease']}"
+        if partial_matches.get("devrelease"):
+            partial_version += f"{partial_matches['devrelease']}"
+        return partial_version
 
     def parse_title_level(self, line: str) -> int | None:
         m = self.RE_TITLE.match(line)

--- a/commitizen/changelog_formats/base.py
+++ b/commitizen/changelog_formats/base.py
@@ -8,8 +8,8 @@ from typing import IO, Any, ClassVar
 
 from commitizen.changelog import Metadata
 from commitizen.config.base_config import BaseConfig
-from commitizen.version_schemes import get_version_scheme
 from commitizen.defaults import get_tag_regexes
+from commitizen.version_schemes import get_version_scheme
 
 from . import ChangelogFormat
 

--- a/commitizen/changelog_formats/base.py
+++ b/commitizen/changelog_formats/base.py
@@ -9,6 +9,7 @@ from typing import IO, Any, ClassVar
 from commitizen.changelog import Metadata
 from commitizen.config.base_config import BaseConfig
 from commitizen.version_schemes import get_version_scheme
+from commitizen.defaults import get_tag_regexes
 
 from . import ChangelogFormat
 
@@ -32,20 +33,7 @@ class BaseFormat(ChangelogFormat, metaclass=ABCMeta):
     def version_parser(self) -> Pattern:
         tag_regex: str = self.tag_format
         version_regex = get_version_scheme(self.config).parser.pattern
-        TAG_FORMAT_REGEXS = {
-            "$version": version_regex,
-            "$major": r"(?P<major>\d+)",
-            "$minor": r"(?P<minor>\d+)",
-            "$patch": r"(?P<patch>\d+)",
-            "$prerelease": r"(?P<prerelease>\w+\d+)?",
-            "$devrelease": r"(?P<devrelease>\.dev\d+)?",
-            "${version}": version_regex,
-            "${major}": r"(?P<major>\d+)",
-            "${minor}": r"(?P<minor>\d+)",
-            "${patch}": r"(?P<patch>\d+)",
-            "${prerelease}": r"(?P<prerelease>\w+\d+)?",
-            "${devrelease}": r"(?P<devrelease>\.dev\d+)?",
-        }
+        TAG_FORMAT_REGEXS = get_tag_regexes(version_regex)
         for pattern, regex in TAG_FORMAT_REGEXS.items():
             tag_regex = tag_regex.replace(pattern, regex)
         return re.compile(tag_regex)

--- a/commitizen/changelog_formats/markdown.py
+++ b/commitizen/changelog_formats/markdown.py
@@ -30,9 +30,9 @@ class Markdown(BaseFormat):
             return None
 
         if matches.get("prerelease"):
-            partial_version += f"-{matches['prerelease']}"
+            partial_version = f"{partial_version}-{matches['prerelease']}"
         if matches.get("devrelease"):
-            partial_version += f"{matches['devrelease']}"
+            partial_version = f"{partial_version}{matches['devrelease']}"
         return partial_version
 
     def parse_title_level(self, line: str) -> int | None:

--- a/commitizen/changelog_formats/markdown.py
+++ b/commitizen/changelog_formats/markdown.py
@@ -19,7 +19,21 @@ class Markdown(BaseFormat):
         m = re.search(self.version_parser, m.group("title"))
         if not m:
             return None
-        return m.group("version")
+        if "version" in m.groupdict():
+            return m.group("version")
+        matches = m.groupdict()
+        try:
+            partial_version = (
+                f"{matches['major']}.{matches['minor']}.{matches['patch']}"
+            )
+        except KeyError:
+            return None
+
+        if matches.get("prerelease"):
+            partial_version += f"-{matches['prerelease']}"
+        if matches.get("devrelease"):
+            partial_version += f"{matches['devrelease']}"
+        return partial_version
 
     def parse_title_level(self, line: str) -> int | None:
         m = self.RE_TITLE.match(line)

--- a/commitizen/changelog_formats/restructuredtext.py
+++ b/commitizen/changelog_formats/restructuredtext.py
@@ -46,7 +46,6 @@ class RestructuredText(BaseFormat):
             third = third.strip().lower()
             title: str | None = None
             kind: TitleKind | None = None
-
             if self.is_overlined_title(first, second, third):
                 title = second
                 kind = (first[0], third[0])
@@ -67,10 +66,25 @@ class RestructuredText(BaseFormat):
                 # Try to find the latest release done
                 m = re.search(self.version_parser, title)
                 if m:
-                    version = m.group("version")
-                    meta.latest_version = version
-                    meta.latest_version_position = index
-                    break  # there's no need for more info
+                    matches = m.groupdict()
+                    if "version" in matches:
+                        version = m.group("version")
+                        meta.latest_version = version
+                        meta.latest_version_position = index
+                        break  # there's no need for more info
+                    try:
+                        partial_version = (
+                            f"{matches['major']}.{matches['minor']}.{matches['patch']}"
+                        )
+                        if matches.get("prerelease"):
+                            partial_version += f"-{matches['prerelease']}"
+                        if matches.get("devrelease"):
+                            partial_version += f"{matches['devrelease']}"
+                        meta.latest_version = partial_version
+                        meta.latest_version_position = index
+                        break
+                    except KeyError:
+                        pass
         if meta.unreleased_start is not None and meta.unreleased_end is None:
             meta.unreleased_end = (
                 meta.latest_version_position if meta.latest_version else index + 1

--- a/commitizen/changelog_formats/restructuredtext.py
+++ b/commitizen/changelog_formats/restructuredtext.py
@@ -77,9 +77,13 @@ class RestructuredText(BaseFormat):
                             f"{matches['major']}.{matches['minor']}.{matches['patch']}"
                         )
                         if matches.get("prerelease"):
-                            partial_version += f"-{matches['prerelease']}"
+                            partial_version = (
+                                f"{partial_version}-{matches['prerelease']}"
+                            )
                         if matches.get("devrelease"):
-                            partial_version += f"{matches['devrelease']}"
+                            partial_version = (
+                                f"{partial_version}{matches['devrelease']}"
+                            )
                         meta.latest_version = partial_version
                         meta.latest_version_position = index
                         break

--- a/commitizen/changelog_formats/textile.py
+++ b/commitizen/changelog_formats/textile.py
@@ -16,7 +16,21 @@ class Textile(BaseFormat):
         m = re.search(self.version_parser, line)
         if not m:
             return None
-        return m.group("version")
+        if "version" in m.groupdict():
+            return m.group("version")
+        matches = m.groupdict()
+        try:
+            partial_version = (
+                f"{matches['major']}.{matches['minor']}.{matches['patch']}"
+            )
+        except KeyError:
+            return None
+
+        if matches.get("prerelease"):
+            partial_version += f"-{matches['prerelease']}"
+        if matches.get("devrelease"):
+            partial_version += f"{matches['devrelease']}"
+        return partial_version
 
     def parse_title_level(self, line: str) -> int | None:
         m = self.RE_TITLE.match(line)

--- a/commitizen/changelog_formats/textile.py
+++ b/commitizen/changelog_formats/textile.py
@@ -19,17 +19,20 @@ class Textile(BaseFormat):
         if "version" in m.groupdict():
             return m.group("version")
         matches = m.groupdict()
-        try:
-            partial_version = (
-                f"{matches['major']}.{matches['minor']}.{matches['patch']}"
-            )
-        except KeyError:
+        if not all(
+            [
+                version_segment in matches
+                for version_segment in ("major", "minor", "patch")
+            ]
+        ):
             return None
 
+        partial_version = f"{matches['major']}.{matches['minor']}.{matches['patch']}"
+
         if matches.get("prerelease"):
-            partial_version += f"-{matches['prerelease']}"
+            partial_version = f"{partial_version}-{matches['prerelease']}"
         if matches.get("devrelease"):
-            partial_version += f"{matches['devrelease']}"
+            partial_version = f"{partial_version}{matches['devrelease']}"
         return partial_version
 
     def parse_title_level(self, line: str) -> int | None:

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -168,8 +168,10 @@ class Changelog:
         # Don't continue if no `file_name` specified.
         assert self.file_name
 
-        tags = changelog.get_version_tags(self.scheme, git.get_tags()) or []
-
+        tags = (
+            changelog.get_version_tags(self.scheme, git.get_tags(), self.tag_format)
+            or []
+        )
         end_rev = ""
         if self.incremental:
             changelog_meta = self.changelog_format.get_metadata(self.file_name)
@@ -182,7 +184,6 @@ class Changelog:
                 start_rev = self._find_incremental_rev(
                     strip_local_version(latest_tag_version), tags
                 )
-
         if self.rev_range:
             start_rev, end_rev = changelog.get_oldest_and_newest_rev(
                 tags,
@@ -190,13 +191,11 @@ class Changelog:
                 tag_format=self.tag_format,
                 scheme=self.scheme,
             )
-
         commits = git.get_commits(start=start_rev, end=end_rev, args="--topo-order")
         if not commits and (
             self.current_version is None or not self.current_version.is_prerelease
         ):
             raise NoCommitsFoundError("No commits found")
-
         tree = changelog.generate_tree_from_commits(
             commits,
             tags,

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -132,3 +132,20 @@ bump_map_major_version_zero = OrderedDict(
 )
 change_type_order = ["BREAKING CHANGE", "Feat", "Fix", "Refactor", "Perf"]
 bump_message = "bump: version $current_version → $new_version"
+
+
+def get_tag_regexes(version_regex: str) -> dict[str | Any, str | Any]:
+    return {
+        "$version": version_regex,
+        "$major": r"(?P<major>\d+)",
+        "$minor": r"(?P<minor>\d+)",
+        "$patch": r"(?P<patch>\d+)",
+        "$prerelease": r"(?P<prerelease>\w+\d+)?",
+        "$devrelease": r"(?P<devrelease>\.dev\d+)?",
+        "${version}": version_regex,
+        "${major}": r"(?P<major>\d+)",
+        "${minor}": r"(?P<minor>\d+)",
+        "${patch}": r"(?P<patch>\d+)",
+        "${prerelease}": r"(?P<prerelease>\w+\d+)?",
+        "${devrelease}": r"(?P<devrelease>\.dev\d+)?",
+    }

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -134,7 +134,9 @@ change_type_order = ["BREAKING CHANGE", "Feat", "Fix", "Refactor", "Perf"]
 bump_message = "bump: version $current_version → $new_version"
 
 
-def get_tag_regexes(version_regex: str) -> dict[str | Any, str | Any]:
+def get_tag_regexes(
+    version_regex: str,
+) -> dict[str, str]:
     return {
         "$version": version_regex,
         "$major": r"(?P<major>\d+)",

--- a/commitizen/providers/scm_provider.py
+++ b/commitizen/providers/scm_provider.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from typing import Callable
 
+from commitizen.defaults import get_tag_regexes
 from commitizen.git import get_tags
 from commitizen.providers.base_provider import VersionProvider
 from commitizen.version_schemes import (
@@ -22,20 +23,7 @@ class ScmProvider(VersionProvider):
     It is meant for `setuptools-scm` or any package manager `*-scm` provider.
     """
 
-    TAG_FORMAT_REGEXS = {
-        "$version": r"(?P<version>.+)",
-        "$major": r"(?P<major>\d+)",
-        "$minor": r"(?P<minor>\d+)",
-        "$patch": r"(?P<patch>\d+)",
-        "$prerelease": r"(?P<prerelease>\w+\d+)?",
-        "$devrelease": r"(?P<devrelease>\.dev\d+)?",
-        "${version}": r"(?P<version>.+)",
-        "${major}": r"(?P<major>\d+)",
-        "${minor}": r"(?P<minor>\d+)",
-        "${patch}": r"(?P<patch>\d+)",
-        "${prerelease}": r"(?P<prerelease>\w+\d+)?",
-        "${devrelease}": r"(?P<devrelease>\.dev\d+)?",
-    }
+    TAG_FORMAT_REGEXS = get_tag_regexes(r"(?P<version>.+)")
 
     def _tag_format_matcher(self) -> Callable[[str], VersionProtocol | None]:
         version_scheme = get_version_scheme(self.config)

--- a/commitizen/providers/scm_provider.py
+++ b/commitizen/providers/scm_provider.py
@@ -29,6 +29,12 @@ class ScmProvider(VersionProvider):
         "$patch": r"(?P<patch>\d+)",
         "$prerelease": r"(?P<prerelease>\w+\d+)?",
         "$devrelease": r"(?P<devrelease>\.dev\d+)?",
+        "${version}": r"(?P<version>.+)",
+        "${major}": r"(?P<major>\d+)",
+        "${minor}": r"(?P<minor>\d+)",
+        "${patch}": r"(?P<patch>\d+)",
+        "${prerelease}": r"(?P<prerelease>\w+\d+)?",
+        "${devrelease}": r"(?P<devrelease>\.dev\d+)?",
     }
 
     def _tag_format_matcher(self) -> Callable[[str], VersionProtocol | None]:

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -414,18 +414,24 @@ In your `pyproject.toml` or `.cz.toml`
 tag_format = "v$major.$minor.$patch$prerelease"
 ```
 
-The variables must be preceded by a `$` sign. Default is `$version`.
+The variables must be preceded by a `$` sign and optionally can be wrapped in `{}` . Default is `$version`.
 
 Supported variables:
 
-| Variable      | Description                                 |
-| ------------- | ------------------------------------------- |
-| `$version`    | full generated version                      |
-| `$major`      | MAJOR increment                             |
-| `$minor`      | MINOR increment                             |
-| `$patch`      | PATCH increment                             |
-| `$prerelease` | Prerelease (alpha, beta, release candidate) |
-| `$devrelease` | Development release                         |
+| Variable        | Description                                 |
+|-----------------|---------------------------------------------|
+| `$version`      | full generated version                      |
+| `$major`        | MAJOR increment                             |
+| `$minor`        | MINOR increment                             |
+| `$patch`        | PATCH increment                             |
+| `$prerelease`   | Prerelease (alpha, beta, release candidate) |
+| `$devrelease`   | Development release                         |
+| `${version}`    | full generated version                      |
+| `${major}`      | MAJOR increment                             |
+| `${minor}`      | MINOR increment                             |
+| `${patch}`      | PATCH increment                             |
+| `${prerelease}` | Prerelease (alpha, beta, release candidate) |
+| `${devrelease}` | Development release                         |
 
 ---
 

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -418,20 +418,14 @@ The variables must be preceded by a `$` sign and optionally can be wrapped in `{
 
 Supported variables:
 
-| Variable        | Description                                 |
-|-----------------|---------------------------------------------|
-| `$version`      | full generated version                      |
-| `$major`        | MAJOR increment                             |
-| `$minor`        | MINOR increment                             |
-| `$patch`        | PATCH increment                             |
-| `$prerelease`   | Prerelease (alpha, beta, release candidate) |
-| `$devrelease`   | Development release                         |
-| `${version}`    | full generated version                      |
-| `${major}`      | MAJOR increment                             |
-| `${minor}`      | MINOR increment                             |
-| `${patch}`      | PATCH increment                             |
-| `${prerelease}` | Prerelease (alpha, beta, release candidate) |
-| `${devrelease}` | Development release                         |
+| Variable                       | Description                                 |
+|--------------------------------|---------------------------------------------|
+| `$version`, `${version}`       | full generated version                      |
+| `$major`, `${major}`           | MAJOR increment                             |
+| `$minor`, `${minor}`           | MINOR increment                             |
+| `$patch`, `${patch}`           | PATCH increment                             |
+| `$prerelease`, `${prerelease}` | Prerelease (alpha, beta, release candidate) |
+| `$devrelease`, ${devrelease}`  | Development release                         |
 
 ---
 

--- a/docs/tutorials/monorepo_guidance.md
+++ b/docs/tutorials/monorepo_guidance.md
@@ -1,0 +1,40 @@
+# Configuring commitizen in a monorepo
+
+This tutorial assumes the monorepo layout is designed with multiple components that can be released independently of each other,
+some suggested layouts:
+
+```
+library-a
+  .cz.toml
+library-b
+  .cz.toml
+```
+
+```
+src
+    library-b
+      .cz.toml
+    library-z
+      .cz.toml
+```
+
+Each component will have its own changelog, commits will need to use scopes so only relevant commits are included in the
+appropriate change log for a given component. Example config and commit for `library-b`
+
+```toml
+[tool.commitizen]
+name = "cz_customize"
+version = "0.0.0"
+tag_format = "${version}-library-b" # the component name can be a prefix or suffix with or without a separator
+update_changelog_on_bump = true
+
+[tool.commitizen.customize]
+changelog_pattern = "^(feat|fix)\\(library-b\\)(!)?:" #the pattern on types can be a wild card or any types you wish to include
+```
+
+example commit message for the above
+
+`fix:(library-b) Some awesome message`
+
+If the above is followed and the `cz bump --changelog` is run in the directory containing the component the changelog
+should be generated in the same directory with only commits scoped to the component.

--- a/docs/tutorials/monorepo_guidance.md
+++ b/docs/tutorials/monorepo_guidance.md
@@ -1,21 +1,22 @@
 # Configuring commitizen in a monorepo
 
-This tutorial assumes the monorepo layout is designed with multiple components that can be released independently of each other,
-some suggested layouts:
+This tutorial assumes the monorepo layout is designed with multiple components that can be released independently of each
+other, it also assumes that conventional commits with scopes are in use. Some suggested layouts:
 
 ```
-library-a
-  .cz.toml
-library-b
-  .cz.toml
+.
+├── library-b
+│   └── .cz.toml
+└── library-z
+    └── .cz.toml
 ```
 
 ```
 src
-    library-b
-      .cz.toml
-    library-z
-      .cz.toml
+├── library-b
+│   └── .cz.toml
+└── library-z
+    └── .cz.toml
 ```
 
 Each component will have its own changelog, commits will need to use scopes so only relevant commits are included in the

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -1597,9 +1597,11 @@ def test_changelog_only_tag_matching_tag_format_included_suffix(
     git.tag("random0.2.0")
     testargs = ["cz", "bump", "--changelog", "--yes"]
     mocker.patch.object(sys, "argv", testargs)
+    # bump to 0.2.0custom
     cli.main()
     wait_for_tag()
     create_file_and_commit("feat: another new file")
+    # bump to 0.3.0custom
     cli.main()
     wait_for_tag()
     with open(changelog_path) as f:

--- a/tests/test_changelog_format_markdown.py
+++ b/tests/test_changelog_format_markdown.py
@@ -72,9 +72,39 @@ EXPECTED_D = Metadata(
     unreleased_start=1,
 )
 
+CHANGELOG_E = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- Start using "changelog" over "change log" since it's the common usage.
+
+## {tag_formatted_version} - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+""".strip()
+
+EXPECTED_E = Metadata(
+    latest_version="1.0.0",
+    latest_version_position=10,
+    unreleased_end=10,
+    unreleased_start=7,
+)
+
 
 @pytest.fixture
 def format(config: BaseConfig) -> Markdown:
+    return Markdown(config)
+
+
+@pytest.fixture
+def format_with_tags(config: BaseConfig, request) -> Markdown:
+    config.settings["tag_format"] = request.param
     return Markdown(config)
 
 
@@ -135,3 +165,40 @@ def test_get_matadata(
     changelog.write_text(content)
 
     assert format.get_metadata(str(changelog)) == expected
+
+
+@pytest.mark.parametrize(
+    "format_with_tags, tag_string, expected, ",
+    (
+        pytest.param("${version}-example", "1.0.0-example", "1.0.0"),
+        pytest.param("${version}example", "1.0.0example", "1.0.0"),
+        pytest.param("example${version}", "example1.0.0", "1.0.0"),
+        pytest.param("example-${version}", "example-1.0.0", "1.0.0"),
+        pytest.param("example-${major}-${minor}-${patch}", "example-1-0-0", "1.0.0"),
+        pytest.param("example-${major}-${minor}", "example-1-0-0", None),
+        pytest.param(
+            "${major}-${minor}-${patch}-${prerelease}-example",
+            "1-0-0-rc1-example",
+            "1.0.0-rc1",
+        ),
+        pytest.param(
+            "${major}-${minor}-${patch}-${prerelease}-example",
+            "1-0-0-a1-example",
+            "1.0.0-a1",
+        ),
+        pytest.param(
+            "${major}-${minor}-${patch}-${prerelease}${devrelease}-example",
+            "1-0-0-a1.dev1-example",
+            "1.0.0-a1.dev1",
+        ),
+    ),
+    indirect=["format_with_tags"],
+)
+def test_get_metadata_custom_tag_format(
+    tmp_path: Path, format_with_tags: Markdown, tag_string: str, expected: Metadata
+):
+    content = CHANGELOG_E.format(tag_formatted_version=tag_string)
+    changelog = tmp_path / format_with_tags.default_changelog_file
+    changelog.write_text(content)
+
+    assert format_with_tags.get_metadata(str(changelog)).latest_version == expected

--- a/tests/test_changelog_format_textile.py
+++ b/tests/test_changelog_format_textile.py
@@ -72,9 +72,32 @@ EXPECTED_D = Metadata(
     unreleased_start=1,
 )
 
+CHANGELOG_E = """
+h1. Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on "Keep a Changelog":https://keepachangelog.com/en/1.0.0/,
+and this project adheres to "Semantic Versioning":https://semver.org/spec/v2.0.0.html.
+
+h2. [Unreleased]
+- Start using "changelog" over "change log" since it's the common usage.
+
+h2. [{tag_formatted_version}] - 2017-06-20
+h3. Added
+* New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+* Version navigation.
+""".strip()
+
 
 @pytest.fixture
 def format(config: BaseConfig) -> Textile:
+    return Textile(config)
+
+
+@pytest.fixture
+def format_with_tags(config: BaseConfig, request) -> Textile:
+    config.settings["tag_format"] = request.param
     return Textile(config)
 
 
@@ -135,3 +158,35 @@ def test_get_matadata(
     changelog.write_text(content)
 
     assert format.get_metadata(str(changelog)) == expected
+
+
+@pytest.mark.parametrize(
+    "format_with_tags, tag_string, expected, ",
+    (
+        pytest.param("${version}-example", "1.0.0-example", "1.0.0"),
+        pytest.param("${version}example", "1.0.0example", "1.0.0"),
+        pytest.param("example${version}", "example1.0.0", "1.0.0"),
+        pytest.param("example-${version}", "example-1.0.0", "1.0.0"),
+        pytest.param("example-${major}-${minor}-${patch}", "example-1-0-0", "1.0.0"),
+        pytest.param("example-${major}-${minor}", "example-1-0-0", None),
+        pytest.param(
+            "${major}-${minor}-${patch}-${prerelease}-example",
+            "1-0-0-rc1-example",
+            "1.0.0-rc1",
+        ),
+        pytest.param(
+            "${major}-${minor}-${patch}-${prerelease}${devrelease}-example",
+            "1-0-0-a1.dev1-example",
+            "1.0.0-a1.dev1",
+        ),
+    ),
+    indirect=["format_with_tags"],
+)
+def test_get_metadata_custom_tag_format(
+    tmp_path: Path, format_with_tags: Textile, tag_string: str, expected: Metadata
+):
+    content = CHANGELOG_E.format(tag_formatted_version=tag_string)
+    changelog = tmp_path / format_with_tags.default_changelog_file
+    changelog.write_text(content)
+
+    assert format_with_tags.get_metadata(str(changelog)).latest_version == expected


### PR DESCRIPTION
When the tag_format does not follow the allowed schemas patterns then changlog generation fails.

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
I am working in a mono repo with multiple `.cz.toml` configs (one per component) using `tag_format` to create tags for each component so they can be released independent of each other. When trying to generate the changelog for each component errors are generated see #845.

I was unsure how to add a test case for this if you have ideas please let me know and I will be happy to add.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
changelogs will now be generated correctly when running `cz bump --changelog`

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. Create a monorepo with multiple components and .cz.toml
2. create change in a component and run cz bump --changelog
3. create change in a different component and run cz bump --changelog
4. change logs should be created with labels for the component tags


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
