### PR TITLE
fix(changelog): ensure `changelog_message_builder_hook` can access and modify `change_type`

### DIFF
--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -159,14 +159,13 @@ def generate_tree_from_commits(
         message = map_pat.match(commit.message)
         if message:
             parsed_message: dict = message.groupdict()
-            # change_type becomes optional by providing None
-            change_type = parsed_message.pop("change_type", None)
 
-            if change_type_map:
-                change_type = change_type_map.get(change_type, change_type)
             if changelog_message_builder_hook:
                 parsed_message = changelog_message_builder_hook(parsed_message, commit)
             if parsed_message:
+                change_type = parsed_message.pop("change_type", None)
+                if change_type_map:
+                    change_type = change_type_map.get(change_type, change_type)
                 changes[change_type].append(parsed_message)
 
         # Process body from commit message
@@ -177,14 +176,14 @@ def generate_tree_from_commits(
                 continue
             parsed_message_body: dict = message_body.groupdict()
 
-            change_type = parsed_message_body.pop("change_type", None)
-            if change_type_map:
-                change_type = change_type_map.get(change_type, change_type)
             if changelog_message_builder_hook:
                 parsed_message_body = changelog_message_builder_hook(
                     parsed_message_body, commit
                 )
             if parsed_message_body:
+                change_type = parsed_message_body.pop("change_type", None)
+                if change_type_map:
+                    change_type = change_type_map.get(change_type, change_type)
                 changes[change_type].append(parsed_message_body)
 
     yield {"version": current_tag_name, "date": current_tag_date, "changes": changes}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
This PR ensure that `changelog_message_builder_hook` has access to `change_type` and can modify it.

Also, change type remap is only tried if we actually have a parsed message (save a few dict iterations)

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes (N/A)

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
`changelog_message_builder_hook` can access the `change_type` field (which was removed before the hook was called) and modify it (it was stored and remapped before the hook can modify it).


## Steps to Test This Pull Request
1. write a custom `changelog_message_builder_hook`
2. make it read (it should be present) and optionally update the `change_type`
3. check that the rendered changelog has the updated change type


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
