### PR TITLE
feat(changelog): `changelog_message_build_hook` can now generate multiple changelog entries from a single commit

### DIFF
--- a/commitizen/cz/base.py
+++ b/commitizen/cz/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Protocol
+from typing import Any, Callable, Iterable, Protocol
 
 from jinja2 import BaseLoader, PackageLoader
 from prompt_toolkit.styles import Style, merge_styles
@@ -14,7 +14,7 @@ from commitizen.defaults import Questions
 class MessageBuilderHook(Protocol):
     def __call__(
         self, message: dict[str, Any], commit: git.GitCommit
-    ) -> dict[str, Any] | None: ...
+    ) -> dict[str, Any] | Iterable[dict[str, Any]] | None: ...
 
 
 class BaseCommitizen(metaclass=ABCMeta):

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -318,7 +318,7 @@ You can customize it of course, and this are the variables you need to add to yo
 | `commit_parser`                  | `str`                                                                    | NO       | Regex which should provide the variables explained in the [changelog description][changelog-des]                                                                                                                    |
 | `changelog_pattern`              | `str`                                                                    | NO       | Regex to validate the commits, this is useful to skip commits that don't meet your ruling standards like a Merge. Usually the same as bump_pattern                                                                  |
 | `change_type_map`                | `dict`                                                                   | NO       | Convert the title of the change type that will appear in the changelog, if a value is not found, the original will be provided                                                                                      |
-| `changelog_message_builder_hook` | `method: (dict, git.GitCommit) -> dict | None`                                  | NO       | Customize with extra information your message output, like adding links, this function is executed per parsed commit. Each GitCommit contains the following attrs: `rev`, `title`, `body`, `author`, `author_email`. Returning a falsy value ignore the commit. |
+| `changelog_message_builder_hook` | `method: (dict, git.GitCommit) -> dict | list | None`                                  | NO       | Customize with extra information your message output, like adding links, this function is executed per parsed commit. Each GitCommit contains the following attrs: `rev`, `title`, `body`, `author`, `author_email`. Returning a falsy value ignore the commit. |
 | `changelog_hook`                 | `method: (full_changelog: str, partial_changelog: Optional[str]) -> str` | NO       | Receives the whole and partial (if used incremental) changelog. Useful to send slack messages or notify a compliance department. Must return the full_changelog                                                     |
 
 ```python
@@ -339,7 +339,7 @@ class StrangeCommitizen(BaseCommitizen):
 
     def changelog_message_builder_hook(
         self, parsed_message: dict, commit: git.GitCommit
-    ) -> dict | None:
+    ) -> dict | list | None:
         rev = commit.rev
         m = parsed_message["message"]
         parsed_message[

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1347,6 +1347,32 @@ def test_changelog_message_builder_hook_can_remove_commits(
             assert RE_HEADER.match(line), f"Line {no} should not be there: {line}"
 
 
+def test_render_changelog_with_changelog_message_builder_hook_multiple_entries(
+    gitcommits, tags, any_changelog_format: ChangelogFormat
+):
+    def changelog_message_builder_hook(message: dict, commit: git.GitCommit):
+        messages = [message.copy(), message.copy(), message.copy()]
+        for idx, msg in enumerate(messages):
+            msg["message"] = "Message #{idx}"
+        return messages
+
+    parser = ConventionalCommitsCz.commit_parser
+    changelog_pattern = ConventionalCommitsCz.changelog_pattern
+    loader = ConventionalCommitsCz.template_loader
+    template = any_changelog_format.template
+    tree = changelog.generate_tree_from_commits(
+        gitcommits,
+        tags,
+        parser,
+        changelog_pattern,
+        changelog_message_builder_hook=changelog_message_builder_hook,
+    )
+    result = changelog.render_changelog(tree, loader, template)
+
+    for idx in range(3):
+        assert "Message #{idx}" in result
+
+
 def test_changelog_message_builder_hook_can_access_and_modify_change_type(
     gitcommits, tags, any_changelog_format: ChangelogFormat
 ):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
This PR allows to `changelog_message_builder_hook` to generate multiple changelog entries from a single commit (sequel to #1001).

This PR includes #1002 as it touches the same part (so first commit will automatically be removed as soon as #1002 is merged)

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

If you return an `Iterable` of parsed messages (aka. dicts) instead of a single one, you can add multiple changelog entries for the same commit.


## Steps to Test This Pull Request
1. Create a custom `changelog_message_build_hook`
2. Return an iterable of entries 
3. Generate changelog without failure
4. Check that all entries are in the changelog

## Additional context
Follow #1001 
Requires #1002 which is included