### PR TITLE
fix(bump): pre and post bump hooks were failing when an increment was provided (fix #1004)

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -209,6 +209,8 @@ class Bump:
             scheme=self.scheme,
         )
 
+        is_initial = self.is_initial_tag(current_tag_version, is_yes)
+
         # If user specified changelog_to_stdout, they probably want the
         # changelog to be generated as well, this is the most intuitive solution
         self.changelog = self.changelog or bool(self.changelog_to_stdout)
@@ -223,7 +225,6 @@ class Bump:
                 ) from exc
         else:
             if increment is None:
-                is_initial = self.is_initial_tag(current_tag_version, is_yes)
                 if is_initial:
                     commits = git.get_commits()
                 else:

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1007,6 +1007,29 @@ def test_bump_with_pre_bump_hooks(
     )
 
 
+def test_bump_with_hooks_and_increment(mocker: MockFixture, tmp_commitizen_project):
+    pre_bump_hook = "scripts/pre_bump_hook.sh"
+    post_bump_hook = "scripts/post_bump_hook.sh"
+
+    tmp_commitizen_cfg_file = tmp_commitizen_project.join("pyproject.toml")
+    tmp_commitizen_cfg_file.write(
+        f"{tmp_commitizen_cfg_file.read()}\n"
+        f'pre_bump_hooks = ["{pre_bump_hook}"]\n'
+        f'post_bump_hooks = ["{post_bump_hook}"]\n'
+    )
+
+    run_mock = mocker.Mock()
+    mocker.patch.object(hooks, "run", run_mock)
+
+    create_file_and_commit("test: some test")
+    testargs = ["cz", "bump", "--yes", "--increment", "MINOR"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+
+    tag_exists = git.tag_exist("0.2.0")
+    assert tag_exists is True
+
+
 @pytest.mark.usefixtures("tmp_commitizen_project")
 def test_bump_manual_version_disallows_prerelease_offset(mocker):
     create_file_and_commit("feat: new file")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Since c245b14c834818b0a434aac6e45fc298cbb93222, `cz bump` with pre or post hook and a `--increment` provided were failing it no tag were existing (cf. #1004).

This PR add a test reproducing the issue and fix it.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes (N/A)

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
Run `cz bump --yes --increment PATCH|MINOR|MAJOR` on a repository with either a pre or post hook and without existing version tag, it should not fail.


## Steps to Test This Pull Request

Run `cz bump --yes --increment PATCH|MINOR|MAJOR` on a repository with either a pre or post hook and without existing version tag, with `commitizen>=3.16`. It should fail without this patch and succeed with (cf. test case) 


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
