### PR TITLE
fix(changelog): changelog hook was not called on dry run

### DIFF
--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -132,6 +132,11 @@ class Changelog:
 
             if changelog_hook:
                 changelog_out = changelog_hook(changelog_out, partial_changelog)
+
+            if self.dry_run:
+                out.write(changelog_out)
+                raise DryRunExit()
+
             changelog_file.write(changelog_out)
 
     def export_template(self):
@@ -215,10 +220,6 @@ class Changelog:
             tree, loader=self.cz.template_loader, template=self.template, **extras
         )
         changelog_out = changelog_out.lstrip("\n")
-
-        if self.dry_run:
-            out.write(changelog_out)
-            raise DryRunExit()
 
         lines = []
         if self.incremental and os.path.isfile(self.file_name):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Ensures that changelog hook is executed with `dry_run=True`

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes (N/A)

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
As a user, when I run the `changelog` or `bump` command with `dry_run=True`, I want my `changelog_hook` to be executed, so the preview includes changes from the hook.

## Steps to Test This Pull Request
1. Register a changelog hook which is modifying the result
2. run the `bump` or the `changelog` command
3. see the changelog changes in the resulting preview

