### PR TITLE
feat(changelog): expose commits `sha1`, `author` and `author_email` in changelog tree (fix #987)

### DIFF
--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -188,7 +188,12 @@ def process_commit_message(
     changes: dict[str | None, list],
     change_type_map: dict[str, str] | None = None,
 ):
-    message: dict = parsed.groupdict()
+    message: dict = {
+        "sha1": commit.rev,
+        "author": commit.author,
+        "author_email": commit.author_email,
+        **parsed.groupdict(),
+    }
 
     if processed := hook(message, commit) if hook else message:
         messages = [processed] if isinstance(processed, dict) else processed

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -500,6 +500,9 @@ Each `Change` has the following fields:
 | ---- | ---- | ----------- |
 | scope | `str | None` | An optional scope |
 | message | `str` | The commit message body |
+| sha1 | `str` | The commit `sha1` |
+| author | `str` | The commit author name |
+| author_email | `str` | The commit author email |
 
 !!! Note
     The field values depend on the customization class and/or the settings you provide

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1083,10 +1083,24 @@ def test_generate_tree_from_commits(gitcommits, tags, merge_prereleases):
     tree = changelog.generate_tree_from_commits(
         gitcommits, tags, parser, changelog_pattern, merge_prerelease=merge_prereleases
     )
-    if merge_prereleases:
-        assert tuple(tree) == COMMITS_TREE_AFTER_MERGED_PRERELEASES
-    else:
-        assert tuple(tree) == COMMITS_TREE
+    expected = (
+        COMMITS_TREE_AFTER_MERGED_PRERELEASES if merge_prereleases else COMMITS_TREE
+    )
+
+    for release, expected_release in zip(tree, expected):
+        assert release["version"] == expected_release["version"]
+        assert release["date"] == expected_release["date"]
+        assert release["changes"].keys() == expected_release["changes"].keys()
+        for change_type in release["changes"]:
+            changes = release["changes"][change_type]
+            expected_changes = expected_release["changes"][change_type]
+            for change, expected_change in zip(changes, expected_changes):
+                assert change["scope"] == expected_change["scope"]
+                assert change["breaking"] == expected_change["breaking"]
+                assert change["message"] == expected_change["message"]
+                assert change["author"] == "Commitizen"
+                assert change["author_email"] in "author@cz.dev"
+                assert "sha1" in change
 
 
 def test_generate_tree_from_commits_with_no_commits(tags):


### PR DESCRIPTION
…

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
This PR adds the `sha1`, `author` and `author_email` field to each commit/changelog change.

Fixes #987 


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
Template can access `sha1`, `author` and `author_email` on each changelog entry

## Steps to Test This Pull Request
Override the changelog template and try using `change.sha1`, `change.author` and `change.author_email`, it should be defined for each.

## Additional context
This change is easy but comes with a drawback which needs discussion before merge:
this is really increasing memory usage by commit. While it is impact-less on small repositories, it can make commitizen not fit in memory on big repositories (might need an estimation to measure impact).

So we need to discuss whether the overhead is acceptable or not and if this is OK should be merged as it is, opt-in and protected by a flag, a plugin only feature (consistent with the fact that we need a template to benefit from those variables) or just something to add as a `changelog_message_builder_hook` (and we just provide the recipe)

My opinion: I am OK with this change, I just need to make an estimation of the overhead to decide.
