### PR TITLE
feat(changelog): adds a `changelog_release_hook` called for each release in the changelog

### DIFF
--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -9,7 +9,7 @@ from typing import Callable
 from commitizen import bump, changelog, defaults, factory, git, out
 
 from commitizen.config import BaseConfig
-from commitizen.cz.base import MessageBuilderHook
+from commitizen.cz.base import MessageBuilderHook, ChangelogReleaseHook
 from commitizen.exceptions import (
     DryRunExit,
     NoCommitsFoundError,
@@ -154,6 +154,9 @@ class Changelog:
         changelog_message_builder_hook: MessageBuilderHook | None = (
             self.cz.changelog_message_builder_hook
         )
+        changelog_release_hook: ChangelogReleaseHook | None = (
+            self.cz.changelog_release_hook
+        )
         merge_prerelease = self.merge_prerelease
 
         if self.export_template_to:
@@ -207,6 +210,7 @@ class Changelog:
             unreleased_version,
             change_type_map=change_type_map,
             changelog_message_builder_hook=changelog_message_builder_hook,
+            changelog_release_hook=changelog_release_hook,
             merge_prerelease=merge_prerelease,
             scheme=self.scheme,
         )

--- a/commitizen/cz/base.py
+++ b/commitizen/cz/base.py
@@ -17,6 +17,12 @@ class MessageBuilderHook(Protocol):
     ) -> dict[str, Any] | Iterable[dict[str, Any]] | None: ...
 
 
+class ChangelogReleaseHook(Protocol):
+    def __call__(
+        self, release: dict[str, Any], tag: git.GitTag | None
+    ) -> dict[str, Any]: ...
+
+
 class BaseCommitizen(metaclass=ABCMeta):
     bump_pattern: str | None = None
     bump_map: dict[str, str] | None = None
@@ -47,6 +53,9 @@ class BaseCommitizen(metaclass=ABCMeta):
 
     # Executed only at the end of the changelog generation
     changelog_hook: Callable[[str, str | None], str] | None = None
+
+    # Executed for each release in the changelog
+    changelog_release_hook: ChangelogReleaseHook | None = None
 
     # Plugins can override templates and provide extra template data
     template_loader: BaseLoader = PackageLoader("commitizen", "templates")

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -320,6 +320,7 @@ You can customize it of course, and this are the variables you need to add to yo
 | `change_type_map`                | `dict`                                                                   | NO       | Convert the title of the change type that will appear in the changelog, if a value is not found, the original will be provided                                                                                      |
 | `changelog_message_builder_hook` | `method: (dict, git.GitCommit) -> dict | list | None`                                  | NO       | Customize with extra information your message output, like adding links, this function is executed per parsed commit. Each GitCommit contains the following attrs: `rev`, `title`, `body`, `author`, `author_email`. Returning a falsy value ignore the commit. |
 | `changelog_hook`                 | `method: (full_changelog: str, partial_changelog: Optional[str]) -> str` | NO       | Receives the whole and partial (if used incremental) changelog. Useful to send slack messages or notify a compliance department. Must return the full_changelog                                                     |
+| `changelog_release_hook` | `method: (release: dict, tag: git.GitTag) -> dict` | NO | Receives each generated changelog release and its associated tag. Useful to enrich a releases before they are rendered. Must return the update release
 
 ```python
 from commitizen.cz.base import BaseCommitizen
@@ -346,6 +347,10 @@ class StrangeCommitizen(BaseCommitizen):
             "message"
         ] = f"{m} {rev} [{commit.author}]({commit.author_email})"
         return parsed_message
+
+    def changelog_release_hook(self, release: dict, tag: git.GitTag) -> dict:
+        release["author"] = tag.author
+        return release
 
     def changelog_hook(
         self, full_changelog: str, partial_changelog: Optional[str]

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -324,6 +324,28 @@ def test_changelog_hook_customize(mocker: MockFixture, config_customize):
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
+def test_changelog_release_hook(mocker: MockFixture, config):
+    def changelog_release_hook(release: dict, tag: git.GitTag) -> dict:
+        return release
+
+    for i in range(3):
+        create_file_and_commit("feat: new file")
+        create_file_and_commit("refactor: is in changelog")
+        create_file_and_commit("Merge into master")
+        git.tag(f"0.{i + 1}.0")
+
+    # changelog = Changelog(config, {})
+    changelog = Changelog(
+        config, {"unreleased_version": None, "incremental": True, "dry_run": False}
+    )
+    mocker.patch.object(changelog.cz, "changelog_release_hook", changelog_release_hook)
+    spy = mocker.spy(changelog.cz, "changelog_release_hook")
+    changelog()
+
+    assert spy.call_count == 3
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
 def test_changelog_with_non_linear_merges_commit_order(
     mocker: MockFixture, config_customize
 ):

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,6 +1,7 @@
 import re
 
 from pathlib import Path
+from typing import Optional
 
 import pytest
 from jinja2 import FileSystemLoader
@@ -1402,6 +1403,26 @@ def test_changelog_message_builder_hook_can_access_and_modify_change_type(
             assert (
                 change_type == "overridden"
             ), f"Line {no}: type {change_type} should have been overridden"
+
+
+def test_render_changelog_with_changelog_release_hook(
+    gitcommits, tags, any_changelog_format: ChangelogFormat
+):
+    def changelog_release_hook(release: dict, tag: Optional[git.GitTag]) -> dict:
+        release["extra"] = "whatever"
+        return release
+
+    parser = ConventionalCommitsCz.commit_parser
+    changelog_pattern = ConventionalCommitsCz.changelog_pattern
+    tree = changelog.generate_tree_from_commits(
+        gitcommits,
+        tags,
+        parser,
+        changelog_pattern,
+        changelog_release_hook=changelog_release_hook,
+    )
+    for release in tree:
+        assert release["extra"] == "whatever"
 
 
 def test_get_smart_tag_range_returns_an_extra_for_a_range(tags):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
This PR adds an optional `changelog_release_hook` allowing to customize/enrich each changelog release the same way we can customize/enrich each commit

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
End user and plugin developers can add attributes to each release dict and use them in their changelog template


## Steps to Test This Pull Request
- add a `changelog_release_hook` to a plugin
- make it add some attributes to each release
- access/render them in the changelog template

