### PR TITLE
Resolve tempfile path spaces issue in git commit function

### DIFF
--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -112,7 +112,7 @@ def commit(
     f.write(message.encode("utf-8"))
     f.close()
 
-    command = f"git commit {args} -F {f.name}"
+    command = f'git commit {args} -F "{f.name}"'
 
     if committer_date and os.name == "nt":  # pragma: no cover
         # Using `cmd /v /c "{command}"` sets environment variables only for that command

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -301,15 +301,20 @@ def test_create_tag_with_message(tmp_commitizen_project):
         (
             "/tmp/temp file",
             'git commit --signoff -F "/tmp/temp file"',
-        ),  # File contains spaces
+        ),
         (
             "/tmp dir/temp file",
             'git commit --signoff -F "/tmp dir/temp file"',
-        ),  # Path contains spaces
+        ),
         (
             "/tmp/tempfile",
             'git commit --signoff -F "/tmp/tempfile"',
-        ),  # Path does not contain spaces
+        ),
+    ],
+    ids=[
+        "File contains spaces",
+        "Path contains spaces",
+        "Path does not contain spaces",
     ],
 )
 def test_commit_with_spaces_in_path(mocker, file_path, expected_cmd):


### PR DESCRIPTION

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
When the file path used in a commit contains spaces, the commit command should execute correctly. This fix addresses the issue where spaces in file names or paths previously caused errors with the git commit command.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
1. Create a file with spaces in its name or path using touch "temp file".
2. Add the file to git with git add "temp file".
3. Execute the commit using cz c.


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
The test included here serves as a straightforward workaround, employing mocker for testing.
@Cliying94 is on the path to crafting a detailed integration test that begins with the commit operation.

Related: #572 