### PR TITLE
fix(command-init): "cz init" should list exisitng tag in reverse order

### DIFF
--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -186,9 +186,11 @@ class Init:
                 out.error("No Existing Tag. Set tag to v0.0.1")
                 return "0.0.1"
 
+            # the latest tag is most likely with the largest number. Thus list the tags in reverse order makes more sense
+            sorted_tags = sorted(tags, reverse=True)
             latest_tag = questionary.select(
                 "Please choose the latest tag: ",
-                choices=tags,
+                choices=sorted_tags,
                 style=self.cz.style,
             ).unsafe_ask()
 

--- a/tests/commands/test_init_command.py
+++ b/tests/commands/test_init_command.py
@@ -93,7 +93,7 @@ def test_init_when_config_already_exists(config, capsys):
 
 def test_init_without_choosing_tag(config, mocker: MockFixture, tmpdir):
     mocker.patch(
-        "commitizen.commands.init.get_tag_names", return_value=["0.0.1", "0.0.2"]
+        "commitizen.commands.init.get_tag_names", return_value=["0.0.2", "0.0.1"]
     )
     mocker.patch("commitizen.commands.init.get_latest_tag_name", return_value="0.0.2")
     mocker.patch(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
When we run cz init in a project with existing tags, when it comes to the question ?` Please choose the latest tag:  (Use arrow keys)`. We list the tags in ascending order. However, the latest tag is most likely with the largest number. Thus list the tags in reverse order makes more sense.

Closes: #760 

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
in `Please choose the latest tag: `
when latest tags are ["0.0.1", "0.0.2"],
the choices should be ["0.0.2", "0.0.1"] 

## Steps to Test This Pull Request
run test cases in
tests/commands/test_init_commands.py

