### PR TITLE
move cz_conventional_commit defaults out of project wide default

### DIFF
--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -31,7 +31,7 @@ class ConventionalCommitsCz(BaseCommitizen):
     bump_pattern = defaults.bump_pattern
     bump_map = defaults.bump_map
     bump_map_major_version_zero = defaults.bump_map_major_version_zero
-    commit_parser = defaults.commit_parser
+    commit_parser = r"^((?P<change_type>feat|fix|refactor|perf|BREAKING CHANGE)(?:\((?P<scope>[^()\r\n]*)\)|\()?(?P<breaking>!)?|\w+!):\s(?P<message>.*)?"  # noqa
     change_type_map = {
         "feat": "Feat",
         "fix": "Fix",

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -131,5 +131,3 @@ bump_map_major_version_zero = OrderedDict(
 )
 change_type_order = ["BREAKING CHANGE", "Feat", "Fix", "Refactor", "Perf"]
 bump_message = "bump: version $current_version → $new_version"
-
-commit_parser = r"^((?P<change_type>feat|fix|refactor|perf|BREAKING CHANGE)(?:\((?P<scope>[^()\r\n]*)\)|\()?(?P<breaking>!)?|\w+!):\s(?P<message>.*)?"  # noqa

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -6,7 +6,7 @@ from typing import Optional
 import pytest
 from jinja2 import FileSystemLoader
 
-from commitizen import changelog, defaults, git
+from commitizen import changelog, git
 from commitizen.cz.conventional_commits.conventional_commits import (
     ConventionalCommitsCz,
 )
@@ -1079,8 +1079,8 @@ COMMITS_TREE_AFTER_MERGED_PRERELEASES = (
 
 @pytest.mark.parametrize("merge_prereleases", (True, False))
 def test_generate_tree_from_commits(gitcommits, tags, merge_prereleases):
-    parser = defaults.commit_parser
-    changelog_pattern = defaults.bump_pattern
+    parser = ConventionalCommitsCz.commit_parser
+    changelog_pattern = ConventionalCommitsCz.bump_pattern
     tree = changelog.generate_tree_from_commits(
         gitcommits, tags, parser, changelog_pattern, merge_prerelease=merge_prereleases
     )
@@ -1106,8 +1106,8 @@ def test_generate_tree_from_commits(gitcommits, tags, merge_prereleases):
 
 def test_generate_tree_from_commits_with_no_commits(tags):
     gitcommits = []
-    parser = defaults.commit_parser
-    changelog_pattern = defaults.bump_pattern
+    parser = ConventionalCommitsCz.commit_parser
+    changelog_pattern = ConventionalCommitsCz.bump_pattern
     tree = changelog.generate_tree_from_commits(
         gitcommits, tags, parser, changelog_pattern
     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
commit_parser in [commitizen/defaults.py](https://github.com/commitizen-tools/commitizen/blob/master/commitizen/defaults.py) is only for cz_conventional_commit rather than all commitizens. This PR is to move commit_parser from commitizen/defaults.py to [conventional_commits.py](https://github.com/commitizen-tools/commitizen/blob/master/commitizen/cz/conventional_commits/conventional_commits.py)

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
commit_parser in commitizen/defaults.py is removed, and will be directly retrieved from ConventionalCommitsCz.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
Related to #818 
