### PR TITLE
feat(cli): add config option to specify config file path

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -94,7 +94,7 @@ data = {
     "arguments": [
         {
             "name": "--config",
-            "help": "specify file path if config file is not in root folder",
+            "help": "the path of configuration file",
         },
         {"name": "--debug", "action": "store_true", "help": "use debug mode"},
         {

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -92,6 +92,10 @@ data = {
     ),
     "formatter_class": argparse.RawDescriptionHelpFormatter,
     "arguments": [
+        {
+            "name": "--config",
+            "help": "specify file path if config file is not in root folder",
+        },
         {"name": "--debug", "action": "store_true", "help": "use debug mode"},
         {
             "name": ["-n", "--name"],
@@ -534,9 +538,7 @@ def parse_no_raise(comma_separated_no_raise: str) -> list[int]:
 
 
 def main():
-    conf = config.read_cfg()
     parser = cli(data)
-
     argcomplete.autocomplete(parser)
     # Show help if no arg provided
     if len(sys.argv) == 1:
@@ -575,6 +577,11 @@ def main():
             )
         extra_args = " ".join(unknown_args[1:])
         arguments["extra_cli_args"] = extra_args
+
+    if args.config:
+        conf = config.read_cfg(args.config)
+    else:
+        conf = config.read_cfg()
 
     if args.name:
         conf.update({"name": args.name})

--- a/commitizen/config/__init__.py
+++ b/commitizen/config/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from commitizen import defaults, git
-from commitizen.exceptions import ConfigFileNotFound
+from commitizen.exceptions import ConfigFileNotFound, ConfigFileIsEmpty
 
 from .base_config import BaseConfig
 from .json_config import JsonConfig
@@ -14,37 +14,23 @@ from .yaml_config import YAMLConfig
 def read_cfg(filepath: str | None = None) -> BaseConfig:
     conf = BaseConfig()
 
-    git_project_root = git.find_git_project_root()
-
     if filepath is not None:
-        given_cfg_path = Path(filepath)
-
-        if not given_cfg_path.exists():
+        if not Path(filepath).exists():
             raise ConfigFileNotFound()
 
-        with open(given_cfg_path, "rb") as f:
-            given_cfg_data: bytes = f.read()
+        cfg_paths = (path for path in (Path(filepath),))
+    else:
+        git_project_root = git.find_git_project_root()
+        cfg_search_paths = [Path(".")]
+        if git_project_root:
+            cfg_search_paths.append(git_project_root)
 
-        given_cfg: TomlConfig | JsonConfig | YAMLConfig
+        cfg_paths = (
+            path / Path(filename)
+            for path in cfg_search_paths
+            for filename in defaults.config_files
+        )
 
-        if "toml" in given_cfg_path.suffix:
-            given_cfg = TomlConfig(data=given_cfg_data, path=given_cfg_path)
-        elif "json" in given_cfg_path.suffix:
-            given_cfg = JsonConfig(data=given_cfg_data, path=given_cfg_path)
-        elif "yaml" in given_cfg_path.suffix:
-            given_cfg = YAMLConfig(data=given_cfg_data, path=given_cfg_path)
-
-        return given_cfg
-
-    cfg_search_paths = [Path(".")]
-    if git_project_root:
-        cfg_search_paths.append(git_project_root)
-
-    cfg_paths = (
-        path / Path(filename)
-        for path in cfg_search_paths
-        for filename in defaults.config_files
-    )
     for filename in cfg_paths:
         if not filename.exists():
             continue
@@ -61,7 +47,9 @@ def read_cfg(filepath: str | None = None) -> BaseConfig:
         elif "yaml" in filename.suffix:
             _conf = YAMLConfig(data=data, path=filename)
 
-        if _conf.is_empty_config:
+        if filepath is not None and _conf.is_empty_config:
+            raise ConfigFileIsEmpty()
+        elif _conf.is_empty_config:
             continue
         else:
             conf = _conf

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -34,6 +34,7 @@ class ExitCode(enum.IntEnum):
     VERSION_PROVIDER_UNKNOWN = 27
     VERSION_SCHEME_UNKNOWN = 28
     CHANGELOG_FORMAT_UNKNOWN = 29
+    CONFIG_FILE_NOT_FOUND = 30
 
 
 class CommitizenException(Exception):
@@ -189,3 +190,8 @@ class VersionSchemeUnknown(CommitizenException):
 class ChangelogFormatUnknown(CommitizenException):
     exit_code = ExitCode.CHANGELOG_FORMAT_UNKNOWN
     message = "Unknown changelog format identifier"
+
+
+class ConfigFileNotFound(CommitizenException):
+    exit_code = ExitCode.CONFIG_FILE_NOT_FOUND
+    message = "Cannot found the config file, please check your file path again."

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -35,6 +35,7 @@ class ExitCode(enum.IntEnum):
     VERSION_SCHEME_UNKNOWN = 28
     CHANGELOG_FORMAT_UNKNOWN = 29
     CONFIG_FILE_NOT_FOUND = 30
+    CONFIG_FILE_IS_EMPTY = 31
 
 
 class CommitizenException(Exception):
@@ -195,3 +196,8 @@ class ChangelogFormatUnknown(CommitizenException):
 class ConfigFileNotFound(CommitizenException):
     exit_code = ExitCode.CONFIG_FILE_NOT_FOUND
     message = "Cannot found the config file, please check your file path again."
+
+
+class ConfigFileIsEmpty(CommitizenException):
+    exit_code = ExitCode.CONFIG_FILE_IS_EMPTY
+    message = "Config file is empty, please check your file path again."

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,7 +107,7 @@ For more information about the topic go to https://conventionalcommits.org/
 
 optional arguments:
   -h, --help            show this help message and exit
-  --config              specify file path if config file is not in root folder
+  --config              the path of configuration file
   --debug               use debug mode
   -n NAME, --name NAME  use the given commitizen (default: cz_conventional_commits)
   -nr NO_RAISE, --no-raise NO_RAISE

--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,7 @@ For more information about the topic go to https://conventionalcommits.org/
 
 optional arguments:
   -h, --help            show this help message and exit
+  --config              specify file path if config file is not in root folder
   --debug               use debug mode
   -n NAME, --name NAME  use the given commitizen (default: cz_conventional_commits)
   -nr NO_RAISE, --no-raise NO_RAISE

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from commitizen.exceptions import (
     NoCommandFoundError,
     NotAGitProjectError,
     InvalidCommandArgumentError,
+    ConfigFileNotFound,
 )
 
 
@@ -23,6 +24,15 @@ def test_sysexit_no_argv(mocker: MockFixture, capsys):
         cli.main()
         out, _ = capsys.readouterr()
         assert out.startswith("usage")
+
+
+def test_cz_config_file_without_correct_file_path(mocker: MockFixture, capsys):
+    testargs = ["cz", "--config", "./config/pyproject.toml", "example"]
+    mocker.patch.object(sys, "argv", testargs)
+
+    with pytest.raises(ConfigFileNotFound) as excinfo:
+        cli.main()
+    assert "Cannot found the config file" in str(excinfo.value)
 
 
 def test_cz_with_arg_but_without_command(mocker: MockFixture):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -44,6 +44,27 @@ DICT_CONFIG = {
     }
 }
 
+JSON_STR = r"""
+    {
+        "commitizen": {
+            "name": "cz_jira",
+            "version": "1.0.0",
+            "version_files": [
+                "commitizen/__version__.py",
+                "pyproject.toml"
+            ]
+        }
+    }
+"""
+
+YAML_STR = """
+commitizen:
+  name: cz_jira
+  version: 1.0.0
+  version_files:
+  - commitizen/__version__.py
+  - pyproject.toml
+"""
 
 _settings: dict[str, Any] = {
     "name": "cz_jira",
@@ -160,12 +181,29 @@ class TestReadCfg:
 
     def test_load_pyproject_toml_not_in_root_folder(_, tmpdir):
         with tmpdir.as_cwd():
-            _not_root_path = tmpdir.mkdir("not_in_root")
-            p = tmpdir.join("./not_in_root/pyproject.toml")
-            p.write(PYPROJECT)
+            _not_root_path = tmpdir.mkdir("not_in_root").join("pyproject.toml")
+            _not_root_path.write(PYPROJECT)
 
             cfg = config.read_cfg(filepath="./not_in_root/pyproject.toml")
             assert cfg.settings == _settings
+
+    def test_load_cz_json_not_in_root_folder(_, tmpdir):
+        with tmpdir.as_cwd():
+            _not_root_path = tmpdir.mkdir("not_in_root").join(".cz.json")
+            _not_root_path.write(JSON_STR)
+
+            cfg = config.read_cfg(filepath="./not_in_root/.cz.json")
+            json_cfg_by_class = config.JsonConfig(data=JSON_STR, path=_not_root_path)
+            assert cfg.settings == json_cfg_by_class.settings
+
+    def test_load_cz_yaml_not_in_root_folder(_, tmpdir):
+        with tmpdir.as_cwd():
+            _not_root_path = tmpdir.mkdir("not_in_root").join(".cz.yaml")
+            _not_root_path.write(YAML_STR)
+
+            cfg = config.read_cfg(filepath="./not_in_root/.cz.yaml")
+            yaml_cfg_by_class = config.YAMLConfig(data=JSON_STR, path=_not_root_path)
+            assert cfg.settings == yaml_cfg_by_class._settings
 
 
 class TestTomlConfig:

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -158,6 +158,15 @@ class TestReadCfg:
             cfg = config.read_cfg()
             assert cfg.settings == _settings
 
+    def test_load_pyproject_toml_not_in_root_folder(_, tmpdir):
+        with tmpdir.as_cwd():
+            _not_root_path = tmpdir.mkdir("not_in_root")
+            p = tmpdir.join("./not_in_root/pyproject.toml")
+            p.write(PYPROJECT)
+
+            cfg = config.read_cfg(filepath="./not_in_root/pyproject.toml")
+            assert cfg.settings == _settings
+
 
 class TestTomlConfig:
     def test_init_empty_config_content(self, tmpdir):

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 
 from commitizen import config, defaults, git
-from commitizen.exceptions import InvalidConfigurationError
+from commitizen.exceptions import InvalidConfigurationError, ConfigFileIsEmpty
 
 PYPROJECT = """
 [tool.commitizen]
@@ -179,7 +179,7 @@ class TestReadCfg:
             cfg = config.read_cfg()
             assert cfg.settings == _settings
 
-    def test_load_pyproject_toml_not_in_root_folder(_, tmpdir):
+    def test_load_pyproject_toml_from_config_argument(_, tmpdir):
         with tmpdir.as_cwd():
             _not_root_path = tmpdir.mkdir("not_in_root").join("pyproject.toml")
             _not_root_path.write(PYPROJECT)
@@ -187,7 +187,7 @@ class TestReadCfg:
             cfg = config.read_cfg(filepath="./not_in_root/pyproject.toml")
             assert cfg.settings == _settings
 
-    def test_load_cz_json_not_in_root_folder(_, tmpdir):
+    def test_load_cz_json_not_from_config_argument(_, tmpdir):
         with tmpdir.as_cwd():
             _not_root_path = tmpdir.mkdir("not_in_root").join(".cz.json")
             _not_root_path.write(JSON_STR)
@@ -196,14 +196,22 @@ class TestReadCfg:
             json_cfg_by_class = config.JsonConfig(data=JSON_STR, path=_not_root_path)
             assert cfg.settings == json_cfg_by_class.settings
 
-    def test_load_cz_yaml_not_in_root_folder(_, tmpdir):
+    def test_load_cz_yaml_not_from_config_argument(_, tmpdir):
         with tmpdir.as_cwd():
             _not_root_path = tmpdir.mkdir("not_in_root").join(".cz.yaml")
             _not_root_path.write(YAML_STR)
 
             cfg = config.read_cfg(filepath="./not_in_root/.cz.yaml")
-            yaml_cfg_by_class = config.YAMLConfig(data=JSON_STR, path=_not_root_path)
+            yaml_cfg_by_class = config.YAMLConfig(data=YAML_STR, path=_not_root_path)
             assert cfg.settings == yaml_cfg_by_class._settings
+
+    def test_load_empty_pyproject_toml_from_config_argument(_, tmpdir):
+        with tmpdir.as_cwd():
+            _not_root_path = tmpdir.mkdir("not_in_root").join("pyproject.toml")
+            _not_root_path.write("")
+
+            with pytest.raises(ConfigFileIsEmpty):
+                config.read_cfg(filepath="./not_in_root/pyproject.toml")
 
 
 class TestTomlConfig:


### PR DESCRIPTION
## Description

CLI now have an option `--config` can specify the config file path,
if the config file is not in root folder, user can specify the located file as well. 

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior

`cz` now have an option to specify config file,
if the given file is existed, will only read configuration from the given file,
else, a error would be raise since the given file do not exist.

## Steps to Test This Pull Request

Execute any `cz` command with `--config` option, if the config file do not exist, a error would raised.

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->

resolve #656 
