### PR TITLE
cli(script): gen screenshot for cli helps

### DIFF
--- a/docs/images/cli_help/cz___help.svg
+++ b/docs/images/cli_help/cz___help.svg
@@ -1,0 +1,198 @@
+<svg class="rich-terminal" viewBox="0 0 994 904.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-911685263-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-911685263-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-911685263-r1 { fill: #c5c8c6 }
+.terminal-911685263-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-911685263-r3 { fill: #d0b344 }
+.terminal-911685263-r4 { fill: #1984e9;text-decoration: underline; }
+.terminal-911685263-r5 { fill: #68a0b3;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-911685263-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="853.0" />
+    </clipPath>
+    <clipPath id="terminal-911685263-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-23">
+    <rect x="0" y="562.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-24">
+    <rect x="0" y="587.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-25">
+    <rect x="0" y="611.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-26">
+    <rect x="0" y="635.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-27">
+    <rect x="0" y="660.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-28">
+    <rect x="0" y="684.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-29">
+    <rect x="0" y="709.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-30">
+    <rect x="0" y="733.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-31">
+    <rect x="0" y="757.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-32">
+    <rect x="0" y="782.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-911685263-line-33">
+    <rect x="0" y="806.7" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="902" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-911685263-clip-terminal)">
+
+    <g class="terminal-911685263-matrix">
+    <text class="terminal-911685263-r1" x="0" y="20" textLength="134.2" clip-path="url(#terminal-911685263-line-0)">$&#160;cz&#160;--help</text><text class="terminal-911685263-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-911685263-line-0)">
+</text><text class="terminal-911685263-r1" x="0" y="44.4" textLength="122" clip-path="url(#terminal-911685263-line-1)">usage:&#160;cz&#160;</text><text class="terminal-911685263-r2" x="122" y="44.4" textLength="12.2" clip-path="url(#terminal-911685263-line-1)">[</text><text class="terminal-911685263-r1" x="134.2" y="44.4" textLength="24.4" clip-path="url(#terminal-911685263-line-1)">-h</text><text class="terminal-911685263-r2" x="158.6" y="44.4" textLength="12.2" clip-path="url(#terminal-911685263-line-1)">]</text><text class="terminal-911685263-r2" x="183" y="44.4" textLength="12.2" clip-path="url(#terminal-911685263-line-1)">[</text><text class="terminal-911685263-r1" x="195.2" y="44.4" textLength="85.4" clip-path="url(#terminal-911685263-line-1)">--debug</text><text class="terminal-911685263-r2" x="280.6" y="44.4" textLength="12.2" clip-path="url(#terminal-911685263-line-1)">]</text><text class="terminal-911685263-r2" x="305" y="44.4" textLength="12.2" clip-path="url(#terminal-911685263-line-1)">[</text><text class="terminal-911685263-r1" x="317.2" y="44.4" textLength="85.4" clip-path="url(#terminal-911685263-line-1)">-n&#160;NAME</text><text class="terminal-911685263-r2" x="402.6" y="44.4" textLength="12.2" clip-path="url(#terminal-911685263-line-1)">]</text><text class="terminal-911685263-r2" x="427" y="44.4" textLength="12.2" clip-path="url(#terminal-911685263-line-1)">[</text><text class="terminal-911685263-r1" x="439.2" y="44.4" textLength="146.4" clip-path="url(#terminal-911685263-line-1)">-nr&#160;NO_RAISE</text><text class="terminal-911685263-r2" x="585.6" y="44.4" textLength="12.2" clip-path="url(#terminal-911685263-line-1)">]</text><text class="terminal-911685263-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-911685263-line-1)">
+</text><text class="terminal-911685263-r2" x="122" y="68.8" textLength="12.2" clip-path="url(#terminal-911685263-line-2)">{</text><text class="terminal-911685263-r1" x="134.2" y="68.8" textLength="829.6" clip-path="url(#terminal-911685263-line-2)">init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version</text><text class="terminal-911685263-r2" x="963.8" y="68.8" textLength="12.2" clip-path="url(#terminal-911685263-line-2)">}</text><text class="terminal-911685263-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-911685263-line-2)">
+</text><text class="terminal-911685263-r3" x="122" y="93.2" textLength="36.6" clip-path="url(#terminal-911685263-line-3)">...</text><text class="terminal-911685263-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-911685263-line-3)">
+</text><text class="terminal-911685263-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-911685263-line-4)">
+</text><text class="terminal-911685263-r1" x="0" y="142" textLength="707.6" clip-path="url(#terminal-911685263-line-5)">Commitizen&#160;is&#160;a&#160;cli&#160;tool&#160;to&#160;generate&#160;conventional&#160;commits.</text><text class="terminal-911685263-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-911685263-line-5)">
+</text><text class="terminal-911685263-r1" x="0" y="166.4" textLength="524.6" clip-path="url(#terminal-911685263-line-6)">For&#160;more&#160;information&#160;about&#160;the&#160;topic&#160;go&#160;to&#160;</text><text class="terminal-911685263-r4" x="524.6" y="166.4" textLength="390.4" clip-path="url(#terminal-911685263-line-6)">https://conventionalcommits.org/</text><text class="terminal-911685263-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-911685263-line-6)">
+</text><text class="terminal-911685263-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-911685263-line-7)">
+</text><text class="terminal-911685263-r1" x="0" y="215.2" textLength="97.6" clip-path="url(#terminal-911685263-line-8)">options:</text><text class="terminal-911685263-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-911685263-line-8)">
+</text><text class="terminal-911685263-r1" x="0" y="239.6" textLength="671" clip-path="url(#terminal-911685263-line-9)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-911685263-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-911685263-line-9)">
+</text><text class="terminal-911685263-r1" x="0" y="264" textLength="463.6" clip-path="url(#terminal-911685263-line-10)">&#160;&#160;--debug&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;use&#160;debug&#160;mode</text><text class="terminal-911685263-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-911685263-line-10)">
+</text><text class="terminal-911685263-r1" x="0" y="288.4" textLength="597.8" clip-path="url(#terminal-911685263-line-11)">&#160;&#160;-n&#160;NAME,&#160;--name&#160;NAME&#160;&#160;use&#160;the&#160;given&#160;commitizen&#160;</text><text class="terminal-911685263-r2" x="597.8" y="288.4" textLength="12.2" clip-path="url(#terminal-911685263-line-11)">(</text><text class="terminal-911685263-r1" x="610" y="288.4" textLength="97.6" clip-path="url(#terminal-911685263-line-11)">default:</text><text class="terminal-911685263-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-911685263-line-11)">
+</text><text class="terminal-911685263-r1" x="0" y="312.8" textLength="573.4" clip-path="url(#terminal-911685263-line-12)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;cz_conventional_commits</text><text class="terminal-911685263-r2" x="573.4" y="312.8" textLength="12.2" clip-path="url(#terminal-911685263-line-12)">)</text><text class="terminal-911685263-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-911685263-line-12)">
+</text><text class="terminal-911685263-r1" x="0" y="337.2" textLength="427" clip-path="url(#terminal-911685263-line-13)">&#160;&#160;-nr&#160;NO_RAISE,&#160;--no-raise&#160;NO_RAISE</text><text class="terminal-911685263-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-911685263-line-13)">
+</text><text class="terminal-911685263-r1" x="0" y="361.6" textLength="902.8" clip-path="url(#terminal-911685263-line-14)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;comma&#160;separated&#160;error&#160;codes&#160;that&#160;won&#x27;t&#160;rise&#160;error,</text><text class="terminal-911685263-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-911685263-line-14)">
+</text><text class="terminal-911685263-r1" x="0" y="386" textLength="439.2" clip-path="url(#terminal-911685263-line-15)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;e.g:&#160;cz&#160;-nr&#160;</text><text class="terminal-911685263-r5" x="439.2" y="386" textLength="12.2" clip-path="url(#terminal-911685263-line-15)">1</text><text class="terminal-911685263-r1" x="451.4" y="386" textLength="12.2" clip-path="url(#terminal-911685263-line-15)">,</text><text class="terminal-911685263-r5" x="463.6" y="386" textLength="12.2" clip-path="url(#terminal-911685263-line-15)">2</text><text class="terminal-911685263-r1" x="475.8" y="386" textLength="12.2" clip-path="url(#terminal-911685263-line-15)">,</text><text class="terminal-911685263-r5" x="488" y="386" textLength="12.2" clip-path="url(#terminal-911685263-line-15)">3</text><text class="terminal-911685263-r1" x="500.2" y="386" textLength="231.8" clip-path="url(#terminal-911685263-line-15)">&#160;bump.&#160;See&#160;codes&#160;at</text><text class="terminal-911685263-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-911685263-line-15)">
+</text><text class="terminal-911685263-r4" x="292.8" y="410.4" textLength="231.8" clip-path="url(#terminal-911685263-line-16)">https://commitizen-</text><text class="terminal-911685263-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-911685263-line-16)">
+</text><text class="terminal-911685263-r1" x="0" y="434.8" textLength="756.4" clip-path="url(#terminal-911685263-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;tools.github.io/commitizen/exit_codes/</text><text class="terminal-911685263-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-911685263-line-17)">
+</text><text class="terminal-911685263-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-911685263-line-18)">
+</text><text class="terminal-911685263-r1" x="0" y="483.6" textLength="109.8" clip-path="url(#terminal-911685263-line-19)">commands:</text><text class="terminal-911685263-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-911685263-line-19)">
+</text><text class="terminal-911685263-r2" x="24.4" y="508" textLength="12.2" clip-path="url(#terminal-911685263-line-20)">{</text><text class="terminal-911685263-r1" x="36.6" y="508" textLength="829.6" clip-path="url(#terminal-911685263-line-20)">init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version</text><text class="terminal-911685263-r2" x="866.2" y="508" textLength="12.2" clip-path="url(#terminal-911685263-line-20)">}</text><text class="terminal-911685263-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-911685263-line-20)">
+</text><text class="terminal-911685263-r1" x="0" y="532.4" textLength="646.6" clip-path="url(#terminal-911685263-line-21)">&#160;&#160;&#160;&#160;init&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;init&#160;commitizen&#160;configuration</text><text class="terminal-911685263-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-911685263-line-21)">
+</text><text class="terminal-911685263-r1" x="0" y="556.8" textLength="134.2" clip-path="url(#terminal-911685263-line-22)">&#160;&#160;&#160;&#160;commit&#160;</text><text class="terminal-911685263-r2" x="134.2" y="556.8" textLength="12.2" clip-path="url(#terminal-911685263-line-22)">(</text><text class="terminal-911685263-r1" x="146.4" y="556.8" textLength="12.2" clip-path="url(#terminal-911685263-line-22)">c</text><text class="terminal-911685263-r2" x="158.6" y="556.8" textLength="12.2" clip-path="url(#terminal-911685263-line-22)">)</text><text class="terminal-911685263-r1" x="170.8" y="556.8" textLength="329.4" clip-path="url(#terminal-911685263-line-22)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;create&#160;new&#160;commit</text><text class="terminal-911685263-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-911685263-line-22)">
+</text><text class="terminal-911685263-r1" x="0" y="581.2" textLength="610" clip-path="url(#terminal-911685263-line-23)">&#160;&#160;&#160;&#160;ls&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;available&#160;commitizens</text><text class="terminal-911685263-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-911685263-line-23)">
+</text><text class="terminal-911685263-r1" x="0" y="605.6" textLength="524.6" clip-path="url(#terminal-911685263-line-24)">&#160;&#160;&#160;&#160;example&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;commit&#160;example</text><text class="terminal-911685263-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-911685263-line-24)">
+</text><text class="terminal-911685263-r1" x="0" y="630" textLength="646.6" clip-path="url(#terminal-911685263-line-25)">&#160;&#160;&#160;&#160;info&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;information&#160;about&#160;the&#160;cz</text><text class="terminal-911685263-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-911685263-line-25)">
+</text><text class="terminal-911685263-r1" x="0" y="654.4" textLength="512.4" clip-path="url(#terminal-911685263-line-26)">&#160;&#160;&#160;&#160;schema&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;commit&#160;schema</text><text class="terminal-911685263-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-911685263-line-26)">
+</text><text class="terminal-911685263-r1" x="0" y="678.8" textLength="805.2" clip-path="url(#terminal-911685263-line-27)">&#160;&#160;&#160;&#160;bump&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;semantic&#160;version&#160;based&#160;on&#160;the&#160;git&#160;log</text><text class="terminal-911685263-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-911685263-line-27)">
+</text><text class="terminal-911685263-r1" x="0" y="703.2" textLength="170.8" clip-path="url(#terminal-911685263-line-28)">&#160;&#160;&#160;&#160;changelog&#160;</text><text class="terminal-911685263-r2" x="170.8" y="703.2" textLength="12.2" clip-path="url(#terminal-911685263-line-28)">(</text><text class="terminal-911685263-r1" x="183" y="703.2" textLength="24.4" clip-path="url(#terminal-911685263-line-28)">ch</text><text class="terminal-911685263-r2" x="207.4" y="703.2" textLength="12.2" clip-path="url(#terminal-911685263-line-28)">)</text><text class="terminal-911685263-r1" x="219.6" y="703.2" textLength="305" clip-path="url(#terminal-911685263-line-28)">&#160;&#160;&#160;&#160;&#160;&#160;generate&#160;changelog&#160;</text><text class="terminal-911685263-r2" x="524.6" y="703.2" textLength="12.2" clip-path="url(#terminal-911685263-line-28)">(</text><text class="terminal-911685263-r1" x="536.8" y="703.2" textLength="329.4" clip-path="url(#terminal-911685263-line-28)">note&#160;that&#160;it&#160;will&#160;overwrite</text><text class="terminal-911685263-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-911685263-line-28)">
+</text><text class="terminal-911685263-r1" x="0" y="727.6" textLength="451.4" clip-path="url(#terminal-911685263-line-29)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;existing&#160;file</text><text class="terminal-911685263-r2" x="451.4" y="727.6" textLength="12.2" clip-path="url(#terminal-911685263-line-29)">)</text><text class="terminal-911685263-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-911685263-line-29)">
+</text><text class="terminal-911685263-r1" x="0" y="752" textLength="951.6" clip-path="url(#terminal-911685263-line-30)">&#160;&#160;&#160;&#160;check&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;validates&#160;that&#160;a&#160;commit&#160;message&#160;matches&#160;the&#160;commitizen</text><text class="terminal-911685263-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-911685263-line-30)">
+</text><text class="terminal-911685263-r1" x="0" y="776.4" textLength="366" clip-path="url(#terminal-911685263-line-31)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;schema</text><text class="terminal-911685263-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-911685263-line-31)">
+</text><text class="terminal-911685263-r1" x="0" y="800.8" textLength="902.8" clip-path="url(#terminal-911685263-line-32)">&#160;&#160;&#160;&#160;version&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;get&#160;the&#160;version&#160;of&#160;the&#160;installed&#160;commitizen&#160;or&#160;the</text><text class="terminal-911685263-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-911685263-line-32)">
+</text><text class="terminal-911685263-r1" x="0" y="825.2" textLength="488" clip-path="url(#terminal-911685263-line-33)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;current&#160;project&#160;</text><text class="terminal-911685263-r2" x="488" y="825.2" textLength="12.2" clip-path="url(#terminal-911685263-line-33)">(</text><text class="terminal-911685263-r1" x="500.2" y="825.2" textLength="353.8" clip-path="url(#terminal-911685263-line-33)">default:&#160;installed&#160;commitizen</text><text class="terminal-911685263-r2" x="854" y="825.2" textLength="12.2" clip-path="url(#terminal-911685263-line-33)">)</text><text class="terminal-911685263-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-911685263-line-33)">
+</text><text class="terminal-911685263-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-911685263-line-34)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/cli_help/cz_bump___help.svg
+++ b/docs/images/cli_help/cz_bump___help.svg
@@ -1,0 +1,373 @@
+<svg class="rich-terminal" viewBox="0 0 994 1977.6" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2106414123-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2106414123-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2106414123-r1 { fill: #c5c8c6 }
+.terminal-2106414123-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-2106414123-r3 { fill: #68a0b3;font-weight: bold }
+.terminal-2106414123-r4 { fill: #98a84b }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2106414123-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="1926.6" />
+    </clipPath>
+    <clipPath id="terminal-2106414123-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-23">
+    <rect x="0" y="562.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-24">
+    <rect x="0" y="587.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-25">
+    <rect x="0" y="611.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-26">
+    <rect x="0" y="635.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-27">
+    <rect x="0" y="660.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-28">
+    <rect x="0" y="684.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-29">
+    <rect x="0" y="709.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-30">
+    <rect x="0" y="733.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-31">
+    <rect x="0" y="757.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-32">
+    <rect x="0" y="782.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-33">
+    <rect x="0" y="806.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-34">
+    <rect x="0" y="831.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-35">
+    <rect x="0" y="855.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-36">
+    <rect x="0" y="879.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-37">
+    <rect x="0" y="904.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-38">
+    <rect x="0" y="928.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-39">
+    <rect x="0" y="953.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-40">
+    <rect x="0" y="977.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-41">
+    <rect x="0" y="1001.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-42">
+    <rect x="0" y="1026.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-43">
+    <rect x="0" y="1050.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-44">
+    <rect x="0" y="1075.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-45">
+    <rect x="0" y="1099.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-46">
+    <rect x="0" y="1123.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-47">
+    <rect x="0" y="1148.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-48">
+    <rect x="0" y="1172.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-49">
+    <rect x="0" y="1197.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-50">
+    <rect x="0" y="1221.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-51">
+    <rect x="0" y="1245.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-52">
+    <rect x="0" y="1270.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-53">
+    <rect x="0" y="1294.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-54">
+    <rect x="0" y="1319.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-55">
+    <rect x="0" y="1343.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-56">
+    <rect x="0" y="1367.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-57">
+    <rect x="0" y="1392.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-58">
+    <rect x="0" y="1416.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-59">
+    <rect x="0" y="1441.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-60">
+    <rect x="0" y="1465.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-61">
+    <rect x="0" y="1489.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-62">
+    <rect x="0" y="1514.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-63">
+    <rect x="0" y="1538.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-64">
+    <rect x="0" y="1563.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-65">
+    <rect x="0" y="1587.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-66">
+    <rect x="0" y="1611.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-67">
+    <rect x="0" y="1636.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-68">
+    <rect x="0" y="1660.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-69">
+    <rect x="0" y="1685.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-70">
+    <rect x="0" y="1709.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-71">
+    <rect x="0" y="1733.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-72">
+    <rect x="0" y="1758.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-73">
+    <rect x="0" y="1782.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-74">
+    <rect x="0" y="1807.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-75">
+    <rect x="0" y="1831.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-76">
+    <rect x="0" y="1855.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2106414123-line-77">
+    <rect x="0" y="1880.3" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="1975.6" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2106414123-clip-terminal)">
+
+    <g class="terminal-2106414123-matrix">
+    <text class="terminal-2106414123-r1" x="0" y="20" textLength="195.2" clip-path="url(#terminal-2106414123-line-0)">$&#160;cz&#160;bump&#160;--help</text><text class="terminal-2106414123-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2106414123-line-0)">
+</text><text class="terminal-2106414123-r1" x="0" y="44.4" textLength="183" clip-path="url(#terminal-2106414123-line-1)">usage:&#160;cz&#160;bump&#160;</text><text class="terminal-2106414123-r2" x="183" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">[</text><text class="terminal-2106414123-r1" x="195.2" y="44.4" textLength="24.4" clip-path="url(#terminal-2106414123-line-1)">-h</text><text class="terminal-2106414123-r2" x="219.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">]</text><text class="terminal-2106414123-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">[</text><text class="terminal-2106414123-r1" x="256.2" y="44.4" textLength="109.8" clip-path="url(#terminal-2106414123-line-1)">--dry-run</text><text class="terminal-2106414123-r2" x="366" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">]</text><text class="terminal-2106414123-r2" x="390.4" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">[</text><text class="terminal-2106414123-r1" x="402.6" y="44.4" textLength="146.4" clip-path="url(#terminal-2106414123-line-1)">--files-only</text><text class="terminal-2106414123-r2" x="549" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">]</text><text class="terminal-2106414123-r2" x="573.4" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">[</text><text class="terminal-2106414123-r1" x="585.6" y="44.4" textLength="183" clip-path="url(#terminal-2106414123-line-1)">--local-version</text><text class="terminal-2106414123-r2" x="768.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">]</text><text class="terminal-2106414123-r2" x="793" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">[</text><text class="terminal-2106414123-r1" x="805.2" y="44.4" textLength="134.2" clip-path="url(#terminal-2106414123-line-1)">--changelog</text><text class="terminal-2106414123-r2" x="939.4" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">]</text><text class="terminal-2106414123-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-1)">
+</text><text class="terminal-2106414123-r2" x="183" y="68.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-2)">[</text><text class="terminal-2106414123-r1" x="195.2" y="68.8" textLength="134.2" clip-path="url(#terminal-2106414123-line-2)">--no-verify</text><text class="terminal-2106414123-r2" x="329.4" y="68.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-2)">]</text><text class="terminal-2106414123-r2" x="353.8" y="68.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-2)">[</text><text class="terminal-2106414123-r1" x="366" y="68.8" textLength="61" clip-path="url(#terminal-2106414123-line-2)">--yes</text><text class="terminal-2106414123-r2" x="427" y="68.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-2)">]</text><text class="terminal-2106414123-r2" x="451.4" y="68.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-2)">[</text><text class="terminal-2106414123-r1" x="463.6" y="68.8" textLength="280.6" clip-path="url(#terminal-2106414123-line-2)">--tag-format&#160;TAG_FORMAT</text><text class="terminal-2106414123-r2" x="744.2" y="68.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-2)">]</text><text class="terminal-2106414123-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-2)">
+</text><text class="terminal-2106414123-r2" x="183" y="93.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-3)">[</text><text class="terminal-2106414123-r1" x="195.2" y="93.2" textLength="329.4" clip-path="url(#terminal-2106414123-line-3)">--bump-message&#160;BUMP_MESSAGE</text><text class="terminal-2106414123-r2" x="524.6" y="93.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-3)">]</text><text class="terminal-2106414123-r2" x="549" y="93.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-3)">[</text><text class="terminal-2106414123-r1" x="561.2" y="93.2" textLength="158.6" clip-path="url(#terminal-2106414123-line-3)">--prerelease&#160;</text><text class="terminal-2106414123-r2" x="719.8" y="93.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-3)">{</text><text class="terminal-2106414123-r1" x="732" y="93.2" textLength="158.6" clip-path="url(#terminal-2106414123-line-3)">alpha,beta,rc</text><text class="terminal-2106414123-r2" x="890.6" y="93.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-3)">}</text><text class="terminal-2106414123-r2" x="902.8" y="93.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-3)">]</text><text class="terminal-2106414123-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-3)">
+</text><text class="terminal-2106414123-r2" x="183" y="117.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-4)">[</text><text class="terminal-2106414123-r1" x="195.2" y="117.6" textLength="280.6" clip-path="url(#terminal-2106414123-line-4)">--devrelease&#160;DEVRELEASE</text><text class="terminal-2106414123-r2" x="475.8" y="117.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-4)">]</text><text class="terminal-2106414123-r2" x="500.2" y="117.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-4)">[</text><text class="terminal-2106414123-r1" x="512.4" y="117.6" textLength="146.4" clip-path="url(#terminal-2106414123-line-4)">--increment&#160;</text><text class="terminal-2106414123-r2" x="658.8" y="117.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-4)">{</text><text class="terminal-2106414123-r1" x="671" y="117.6" textLength="207.4" clip-path="url(#terminal-2106414123-line-4)">MAJOR,MINOR,PATCH</text><text class="terminal-2106414123-r2" x="878.4" y="117.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-4)">}</text><text class="terminal-2106414123-r2" x="890.6" y="117.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-4)">]</text><text class="terminal-2106414123-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-4)">
+</text><text class="terminal-2106414123-r2" x="183" y="142" textLength="12.2" clip-path="url(#terminal-2106414123-line-5)">[</text><text class="terminal-2106414123-r1" x="195.2" y="142" textLength="207.4" clip-path="url(#terminal-2106414123-line-5)">--increment-mode&#160;</text><text class="terminal-2106414123-r2" x="402.6" y="142" textLength="12.2" clip-path="url(#terminal-2106414123-line-5)">{</text><text class="terminal-2106414123-r1" x="414.8" y="142" textLength="146.4" clip-path="url(#terminal-2106414123-line-5)">linear,exact</text><text class="terminal-2106414123-r2" x="561.2" y="142" textLength="12.2" clip-path="url(#terminal-2106414123-line-5)">}</text><text class="terminal-2106414123-r2" x="573.4" y="142" textLength="12.2" clip-path="url(#terminal-2106414123-line-5)">]</text><text class="terminal-2106414123-r2" x="597.8" y="142" textLength="12.2" clip-path="url(#terminal-2106414123-line-5)">[</text><text class="terminal-2106414123-r1" x="610" y="142" textLength="231.8" clip-path="url(#terminal-2106414123-line-5)">--check-consistency</text><text class="terminal-2106414123-r2" x="841.8" y="142" textLength="12.2" clip-path="url(#terminal-2106414123-line-5)">]</text><text class="terminal-2106414123-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2106414123-line-5)">
+</text><text class="terminal-2106414123-r2" x="183" y="166.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-6)">[</text><text class="terminal-2106414123-r1" x="195.2" y="166.4" textLength="183" clip-path="url(#terminal-2106414123-line-6)">--annotated-tag</text><text class="terminal-2106414123-r2" x="378.2" y="166.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-6)">]</text><text class="terminal-2106414123-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-6)">
+</text><text class="terminal-2106414123-r2" x="183" y="190.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-7)">[</text><text class="terminal-2106414123-r1" x="195.2" y="190.8" textLength="549" clip-path="url(#terminal-2106414123-line-7)">--annotated-tag-message&#160;ANNOTATED_TAG_MESSAGE</text><text class="terminal-2106414123-r2" x="744.2" y="190.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-7)">]</text><text class="terminal-2106414123-r2" x="768.6" y="190.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-7)">[</text><text class="terminal-2106414123-r1" x="780.8" y="190.8" textLength="122" clip-path="url(#terminal-2106414123-line-7)">--gpg-sign</text><text class="terminal-2106414123-r2" x="902.8" y="190.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-7)">]</text><text class="terminal-2106414123-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-7)">
+</text><text class="terminal-2106414123-r2" x="183" y="215.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-8)">[</text><text class="terminal-2106414123-r1" x="195.2" y="215.2" textLength="256.2" clip-path="url(#terminal-2106414123-line-8)">--changelog-to-stdout</text><text class="terminal-2106414123-r2" x="451.4" y="215.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-8)">]</text><text class="terminal-2106414123-r2" x="475.8" y="215.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-8)">[</text><text class="terminal-2106414123-r1" x="488" y="215.2" textLength="268.4" clip-path="url(#terminal-2106414123-line-8)">--git-output-to-stderr</text><text class="terminal-2106414123-r2" x="756.4" y="215.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-8)">]</text><text class="terminal-2106414123-r2" x="780.8" y="215.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-8)">[</text><text class="terminal-2106414123-r1" x="793" y="215.2" textLength="85.4" clip-path="url(#terminal-2106414123-line-8)">--retry</text><text class="terminal-2106414123-r2" x="878.4" y="215.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-8)">]</text><text class="terminal-2106414123-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-8)">
+</text><text class="terminal-2106414123-r2" x="183" y="239.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-9)">[</text><text class="terminal-2106414123-r1" x="195.2" y="239.6" textLength="244" clip-path="url(#terminal-2106414123-line-9)">--major-version-zero</text><text class="terminal-2106414123-r2" x="439.2" y="239.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-9)">]</text><text class="terminal-2106414123-r2" x="463.6" y="239.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-9)">[</text><text class="terminal-2106414123-r1" x="475.8" y="239.6" textLength="231.8" clip-path="url(#terminal-2106414123-line-9)">--template&#160;TEMPLATE</text><text class="terminal-2106414123-r2" x="707.6" y="239.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-9)">]</text><text class="terminal-2106414123-r2" x="732" y="239.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-9)">[</text><text class="terminal-2106414123-r1" x="744.2" y="239.6" textLength="158.6" clip-path="url(#terminal-2106414123-line-9)">--extra&#160;EXTRA</text><text class="terminal-2106414123-r2" x="902.8" y="239.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-9)">]</text><text class="terminal-2106414123-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-9)">
+</text><text class="terminal-2106414123-r2" x="183" y="264" textLength="12.2" clip-path="url(#terminal-2106414123-line-10)">[</text><text class="terminal-2106414123-r1" x="195.2" y="264" textLength="256.2" clip-path="url(#terminal-2106414123-line-10)">--file-name&#160;FILE_NAME</text><text class="terminal-2106414123-r2" x="451.4" y="264" textLength="12.2" clip-path="url(#terminal-2106414123-line-10)">]</text><text class="terminal-2106414123-r2" x="475.8" y="264" textLength="12.2" clip-path="url(#terminal-2106414123-line-10)">[</text><text class="terminal-2106414123-r1" x="488" y="264" textLength="451.4" clip-path="url(#terminal-2106414123-line-10)">--prerelease-offset&#160;PRERELEASE_OFFSET</text><text class="terminal-2106414123-r2" x="939.4" y="264" textLength="12.2" clip-path="url(#terminal-2106414123-line-10)">]</text><text class="terminal-2106414123-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-2106414123-line-10)">
+</text><text class="terminal-2106414123-r2" x="183" y="288.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-11)">[</text><text class="terminal-2106414123-r1" x="195.2" y="288.4" textLength="207.4" clip-path="url(#terminal-2106414123-line-11)">--version-scheme&#160;</text><text class="terminal-2106414123-r2" x="402.6" y="288.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-11)">{</text><text class="terminal-2106414123-r1" x="414.8" y="288.4" textLength="158.6" clip-path="url(#terminal-2106414123-line-11)">semver,pep440</text><text class="terminal-2106414123-r2" x="573.4" y="288.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-11)">}</text><text class="terminal-2106414123-r2" x="585.6" y="288.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-11)">]</text><text class="terminal-2106414123-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-11)">
+</text><text class="terminal-2106414123-r2" x="183" y="312.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-12)">[</text><text class="terminal-2106414123-r1" x="195.2" y="312.8" textLength="183" clip-path="url(#terminal-2106414123-line-12)">--version-type&#160;</text><text class="terminal-2106414123-r2" x="378.2" y="312.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-12)">{</text><text class="terminal-2106414123-r1" x="390.4" y="312.8" textLength="158.6" clip-path="url(#terminal-2106414123-line-12)">semver,pep440</text><text class="terminal-2106414123-r2" x="549" y="312.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-12)">}</text><text class="terminal-2106414123-r2" x="561.2" y="312.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-12)">]</text><text class="terminal-2106414123-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-12)">
+</text><text class="terminal-2106414123-r2" x="183" y="337.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-13)">[</text><text class="terminal-2106414123-r1" x="195.2" y="337.2" textLength="378.2" clip-path="url(#terminal-2106414123-line-13)">--build-metadata&#160;BUILD_METADATA</text><text class="terminal-2106414123-r2" x="573.4" y="337.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-13)">]</text><text class="terminal-2106414123-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-13)">
+</text><text class="terminal-2106414123-r2" x="183" y="361.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-14)">[</text><text class="terminal-2106414123-r1" x="195.2" y="361.6" textLength="170.8" clip-path="url(#terminal-2106414123-line-14)">MANUAL_VERSION</text><text class="terminal-2106414123-r2" x="366" y="361.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-14)">]</text><text class="terminal-2106414123-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-14)">
+</text><text class="terminal-2106414123-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-2106414123-line-15)">
+</text><text class="terminal-2106414123-r1" x="0" y="410.4" textLength="256.2" clip-path="url(#terminal-2106414123-line-16)">positional&#160;arguments:</text><text class="terminal-2106414123-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-16)">
+</text><text class="terminal-2106414123-r1" x="0" y="434.8" textLength="610" clip-path="url(#terminal-2106414123-line-17)">&#160;&#160;MANUAL_VERSION&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;to&#160;the&#160;given&#160;version&#160;</text><text class="terminal-2106414123-r2" x="610" y="434.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-17)">(</text><text class="terminal-2106414123-r1" x="622.2" y="434.8" textLength="61" clip-path="url(#terminal-2106414123-line-17)">e.g:&#160;</text><text class="terminal-2106414123-r3" x="683.2" y="434.8" textLength="36.6" clip-path="url(#terminal-2106414123-line-17)">1.5</text><text class="terminal-2106414123-r1" x="719.8" y="434.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-17)">.</text><text class="terminal-2106414123-r3" x="732" y="434.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-17)">3</text><text class="terminal-2106414123-r2" x="744.2" y="434.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-17)">)</text><text class="terminal-2106414123-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-17)">
+</text><text class="terminal-2106414123-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-18)">
+</text><text class="terminal-2106414123-r1" x="0" y="483.6" textLength="97.6" clip-path="url(#terminal-2106414123-line-19)">options:</text><text class="terminal-2106414123-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-19)">
+</text><text class="terminal-2106414123-r1" x="0" y="508" textLength="671" clip-path="url(#terminal-2106414123-line-20)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-2106414123-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-2106414123-line-20)">
+</text><text class="terminal-2106414123-r1" x="0" y="532.4" textLength="915" clip-path="url(#terminal-2106414123-line-21)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;output&#160;to&#160;stdout,&#160;no&#160;commit,&#160;no&#160;modified&#160;files</text><text class="terminal-2106414123-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-21)">
+</text><text class="terminal-2106414123-r1" x="0" y="556.8" textLength="793" clip-path="url(#terminal-2106414123-line-22)">&#160;&#160;--files-only&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;version&#160;in&#160;the&#160;files&#160;from&#160;the&#160;config</text><text class="terminal-2106414123-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-22)">
+</text><text class="terminal-2106414123-r1" x="0" y="581.2" textLength="719.8" clip-path="url(#terminal-2106414123-line-23)">&#160;&#160;--local-version&#160;&#160;&#160;&#160;&#160;&#160;&#160;bump&#160;only&#160;the&#160;local&#160;version&#160;portion</text><text class="terminal-2106414123-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-23)">
+</text><text class="terminal-2106414123-r1" x="0" y="605.6" textLength="841.8" clip-path="url(#terminal-2106414123-line-24)">&#160;&#160;--changelog,&#160;-ch&#160;&#160;&#160;&#160;&#160;&#160;generate&#160;the&#160;changelog&#160;for&#160;the&#160;newest&#160;version</text><text class="terminal-2106414123-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-24)">
+</text><text class="terminal-2106414123-r1" x="0" y="630" textLength="902.8" clip-path="url(#terminal-2106414123-line-25)">&#160;&#160;--no-verify&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;this&#160;option&#160;bypasses&#160;the&#160;pre-commit&#160;and&#160;commit-msg</text><text class="terminal-2106414123-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-2106414123-line-25)">
+</text><text class="terminal-2106414123-r1" x="0" y="654.4" textLength="353.8" clip-path="url(#terminal-2106414123-line-26)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;hooks</text><text class="terminal-2106414123-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-26)">
+</text><text class="terminal-2106414123-r1" x="0" y="678.8" textLength="719.8" clip-path="url(#terminal-2106414123-line-27)">&#160;&#160;--yes&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;accept&#160;automatically&#160;questions&#160;done</text><text class="terminal-2106414123-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-27)">
+</text><text class="terminal-2106414123-r1" x="0" y="703.2" textLength="305" clip-path="url(#terminal-2106414123-line-28)">&#160;&#160;--tag-format&#160;TAG_FORMAT</text><text class="terminal-2106414123-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-28)">
+</text><text class="terminal-2106414123-r1" x="0" y="727.6" textLength="939.4" clip-path="url(#terminal-2106414123-line-29)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;format&#160;used&#160;to&#160;tag&#160;the&#160;commit&#160;and&#160;read&#160;it,&#160;use&#160;it</text><text class="terminal-2106414123-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-29)">
+</text><text class="terminal-2106414123-r1" x="0" y="752" textLength="866.2" clip-path="url(#terminal-2106414123-line-30)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;in&#160;existing&#160;projects,&#160;wrap&#160;around&#160;simple&#160;quotes</text><text class="terminal-2106414123-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-2106414123-line-30)">
+</text><text class="terminal-2106414123-r1" x="0" y="776.4" textLength="353.8" clip-path="url(#terminal-2106414123-line-31)">&#160;&#160;--bump-message&#160;BUMP_MESSAGE</text><text class="terminal-2106414123-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-31)">
+</text><text class="terminal-2106414123-r1" x="0" y="800.8" textLength="902.8" clip-path="url(#terminal-2106414123-line-32)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;template&#160;used&#160;to&#160;create&#160;the&#160;release&#160;commit,&#160;useful</text><text class="terminal-2106414123-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-32)">
+</text><text class="terminal-2106414123-r1" x="0" y="825.2" textLength="536.8" clip-path="url(#terminal-2106414123-line-33)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;when&#160;working&#160;with&#160;CI</text><text class="terminal-2106414123-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-33)">
+</text><text class="terminal-2106414123-r1" x="0" y="849.6" textLength="183" clip-path="url(#terminal-2106414123-line-34)">&#160;&#160;--prerelease&#160;</text><text class="terminal-2106414123-r2" x="183" y="849.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-34)">{</text><text class="terminal-2106414123-r1" x="195.2" y="849.6" textLength="158.6" clip-path="url(#terminal-2106414123-line-34)">alpha,beta,rc</text><text class="terminal-2106414123-r2" x="353.8" y="849.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-34)">}</text><text class="terminal-2106414123-r1" x="366" y="849.6" textLength="73.2" clip-path="url(#terminal-2106414123-line-34)">,&#160;-pr&#160;</text><text class="terminal-2106414123-r2" x="439.2" y="849.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-34)">{</text><text class="terminal-2106414123-r1" x="451.4" y="849.6" textLength="158.6" clip-path="url(#terminal-2106414123-line-34)">alpha,beta,rc</text><text class="terminal-2106414123-r2" x="610" y="849.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-34)">}</text><text class="terminal-2106414123-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-34)">
+</text><text class="terminal-2106414123-r1" x="0" y="874" textLength="597.8" clip-path="url(#terminal-2106414123-line-35)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;choose&#160;type&#160;of&#160;prerelease</text><text class="terminal-2106414123-r1" x="976" y="874" textLength="12.2" clip-path="url(#terminal-2106414123-line-35)">
+</text><text class="terminal-2106414123-r1" x="0" y="898.4" textLength="488" clip-path="url(#terminal-2106414123-line-36)">&#160;&#160;--devrelease&#160;DEVRELEASE,&#160;-d&#160;DEVRELEASE</text><text class="terminal-2106414123-r1" x="976" y="898.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-36)">
+</text><text class="terminal-2106414123-r1" x="0" y="922.8" textLength="841.8" clip-path="url(#terminal-2106414123-line-37)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;specify&#160;non-negative&#160;integer&#160;for&#160;dev.&#160;release</text><text class="terminal-2106414123-r1" x="976" y="922.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-37)">
+</text><text class="terminal-2106414123-r1" x="0" y="947.2" textLength="170.8" clip-path="url(#terminal-2106414123-line-38)">&#160;&#160;--increment&#160;</text><text class="terminal-2106414123-r2" x="170.8" y="947.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-38)">{</text><text class="terminal-2106414123-r1" x="183" y="947.2" textLength="207.4" clip-path="url(#terminal-2106414123-line-38)">MAJOR,MINOR,PATCH</text><text class="terminal-2106414123-r2" x="390.4" y="947.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-38)">}</text><text class="terminal-2106414123-r1" x="976" y="947.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-38)">
+</text><text class="terminal-2106414123-r1" x="0" y="971.6" textLength="756.4" clip-path="url(#terminal-2106414123-line-39)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;manually&#160;specify&#160;the&#160;desired&#160;increment</text><text class="terminal-2106414123-r1" x="976" y="971.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-39)">
+</text><text class="terminal-2106414123-r1" x="0" y="996" textLength="231.8" clip-path="url(#terminal-2106414123-line-40)">&#160;&#160;--increment-mode&#160;</text><text class="terminal-2106414123-r2" x="231.8" y="996" textLength="12.2" clip-path="url(#terminal-2106414123-line-40)">{</text><text class="terminal-2106414123-r1" x="244" y="996" textLength="146.4" clip-path="url(#terminal-2106414123-line-40)">linear,exact</text><text class="terminal-2106414123-r2" x="390.4" y="996" textLength="12.2" clip-path="url(#terminal-2106414123-line-40)">}</text><text class="terminal-2106414123-r1" x="976" y="996" textLength="12.2" clip-path="url(#terminal-2106414123-line-40)">
+</text><text class="terminal-2106414123-r1" x="0" y="1020.4" textLength="902.8" clip-path="url(#terminal-2106414123-line-41)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;set&#160;the&#160;method&#160;by&#160;which&#160;the&#160;new&#160;version&#160;is&#160;chosen.</text><text class="terminal-2106414123-r1" x="976" y="1020.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-41)">
+</text><text class="terminal-2106414123-r4" x="292.8" y="1044.8" textLength="97.6" clip-path="url(#terminal-2106414123-line-42)">&#x27;linear&#x27;</text><text class="terminal-2106414123-r2" x="402.6" y="1044.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-42)">(</text><text class="terminal-2106414123-r1" x="414.8" y="1044.8" textLength="85.4" clip-path="url(#terminal-2106414123-line-42)">default</text><text class="terminal-2106414123-r2" x="500.2" y="1044.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-42)">)</text><text class="terminal-2106414123-r1" x="512.4" y="1044.8" textLength="414.8" clip-path="url(#terminal-2106414123-line-42)">&#160;guesses&#160;the&#160;next&#160;version&#160;based&#160;on</text><text class="terminal-2106414123-r1" x="976" y="1044.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-42)">
+</text><text class="terminal-2106414123-r1" x="0" y="1069.2" textLength="939.4" clip-path="url(#terminal-2106414123-line-43)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;typical&#160;linear&#160;version&#160;progression,&#160;such&#160;that&#160;bumping</text><text class="terminal-2106414123-r1" x="976" y="1069.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-43)">
+</text><text class="terminal-2106414123-r1" x="0" y="1093.6" textLength="866.2" clip-path="url(#terminal-2106414123-line-44)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;of&#160;a&#160;pre-release&#160;with&#160;lower&#160;precedence&#160;than&#160;the</text><text class="terminal-2106414123-r1" x="976" y="1093.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-44)">
+</text><text class="terminal-2106414123-r1" x="0" y="1118" textLength="939.4" clip-path="url(#terminal-2106414123-line-45)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;current&#160;pre-release&#160;phase&#160;maintains&#160;the&#160;current&#160;phase</text><text class="terminal-2106414123-r1" x="976" y="1118" textLength="12.2" clip-path="url(#terminal-2106414123-line-45)">
+</text><text class="terminal-2106414123-r1" x="0" y="1142.4" textLength="561.2" clip-path="url(#terminal-2106414123-line-46)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;of&#160;higher&#160;precedence.&#160;</text><text class="terminal-2106414123-r4" x="561.2" y="1142.4" textLength="85.4" clip-path="url(#terminal-2106414123-line-46)">&#x27;exact&#x27;</text><text class="terminal-2106414123-r1" x="646.6" y="1142.4" textLength="305" clip-path="url(#terminal-2106414123-line-46)">&#160;applies&#160;the&#160;changes&#160;that</text><text class="terminal-2106414123-r1" x="976" y="1142.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-46)">
+</text><text class="terminal-2106414123-r1" x="0" y="1166.8" textLength="536.8" clip-path="url(#terminal-2106414123-line-47)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;have&#160;been&#160;specified&#160;</text><text class="terminal-2106414123-r2" x="536.8" y="1166.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-47)">(</text><text class="terminal-2106414123-r1" x="549" y="1166.8" textLength="353.8" clip-path="url(#terminal-2106414123-line-47)">or&#160;determined&#160;from&#160;the&#160;commit</text><text class="terminal-2106414123-r1" x="976" y="1166.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-47)">
+</text><text class="terminal-2106414123-r1" x="0" y="1191.2" textLength="329.4" clip-path="url(#terminal-2106414123-line-48)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;log</text><text class="terminal-2106414123-r2" x="329.4" y="1191.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-48)">)</text><text class="terminal-2106414123-r1" x="341.6" y="1191.2" textLength="585.6" clip-path="url(#terminal-2106414123-line-48)">&#160;without&#160;interpretation,&#160;such&#160;that&#160;the&#160;increment</text><text class="terminal-2106414123-r1" x="976" y="1191.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-48)">
+</text><text class="terminal-2106414123-r1" x="0" y="1215.6" textLength="707.6" clip-path="url(#terminal-2106414123-line-49)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;and&#160;pre-release&#160;are&#160;always&#160;honored</text><text class="terminal-2106414123-r1" x="976" y="1215.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-49)">
+</text><text class="terminal-2106414123-r1" x="0" y="1240" textLength="317.2" clip-path="url(#terminal-2106414123-line-50)">&#160;&#160;--check-consistency,&#160;-cc</text><text class="terminal-2106414123-r1" x="976" y="1240" textLength="12.2" clip-path="url(#terminal-2106414123-line-50)">
+</text><text class="terminal-2106414123-r1" x="0" y="1264.4" textLength="951.6" clip-path="url(#terminal-2106414123-line-51)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;check&#160;consistency&#160;among&#160;versions&#160;defined&#160;in&#160;commitizen</text><text class="terminal-2106414123-r1" x="976" y="1264.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-51)">
+</text><text class="terminal-2106414123-r1" x="0" y="1288.8" textLength="671" clip-path="url(#terminal-2106414123-line-52)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;configuration&#160;and&#160;version_files</text><text class="terminal-2106414123-r1" x="976" y="1288.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-52)">
+</text><text class="terminal-2106414123-r1" x="0" y="1313.2" textLength="866.2" clip-path="url(#terminal-2106414123-line-53)">&#160;&#160;--annotated-tag,&#160;-at&#160;&#160;create&#160;annotated&#160;tag&#160;instead&#160;of&#160;lightweight&#160;one</text><text class="terminal-2106414123-r1" x="976" y="1313.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-53)">
+</text><text class="terminal-2106414123-r1" x="0" y="1337.6" textLength="915" clip-path="url(#terminal-2106414123-line-54)">&#160;&#160;--annotated-tag-message&#160;ANNOTATED_TAG_MESSAGE,&#160;-atm&#160;ANNOTATED_TAG_MESSAGE</text><text class="terminal-2106414123-r1" x="976" y="1337.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-54)">
+</text><text class="terminal-2106414123-r1" x="0" y="1362" textLength="634.4" clip-path="url(#terminal-2106414123-line-55)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;create&#160;annotated&#160;tag&#160;message</text><text class="terminal-2106414123-r1" x="976" y="1362" textLength="12.2" clip-path="url(#terminal-2106414123-line-55)">
+</text><text class="terminal-2106414123-r1" x="0" y="1386.4" textLength="719.8" clip-path="url(#terminal-2106414123-line-56)">&#160;&#160;--gpg-sign,&#160;-s&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sign&#160;tag&#160;instead&#160;of&#160;lightweight&#160;one</text><text class="terminal-2106414123-r1" x="976" y="1386.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-56)">
+</text><text class="terminal-2106414123-r1" x="0" y="1410.8" textLength="280.6" clip-path="url(#terminal-2106414123-line-57)">&#160;&#160;--changelog-to-stdout</text><text class="terminal-2106414123-r1" x="976" y="1410.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-57)">
+</text><text class="terminal-2106414123-r1" x="0" y="1435.2" textLength="658.8" clip-path="url(#terminal-2106414123-line-58)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Output&#160;changelog&#160;to&#160;the&#160;stdout</text><text class="terminal-2106414123-r1" x="976" y="1435.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-58)">
+</text><text class="terminal-2106414123-r1" x="0" y="1459.6" textLength="292.8" clip-path="url(#terminal-2106414123-line-59)">&#160;&#160;--git-output-to-stderr</text><text class="terminal-2106414123-r1" x="976" y="1459.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-59)">
+</text><text class="terminal-2106414123-r1" x="0" y="1484" textLength="646.6" clip-path="url(#terminal-2106414123-line-60)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Redirect&#160;git&#160;output&#160;to&#160;stderr</text><text class="terminal-2106414123-r1" x="976" y="1484" textLength="12.2" clip-path="url(#terminal-2106414123-line-60)">
+</text><text class="terminal-2106414123-r1" x="0" y="1508.4" textLength="744.2" clip-path="url(#terminal-2106414123-line-61)">&#160;&#160;--retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;retry&#160;commit&#160;if&#160;it&#160;fails&#160;the&#160;1st&#160;time</text><text class="terminal-2106414123-r1" x="976" y="1508.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-61)">
+</text><text class="terminal-2106414123-r1" x="0" y="1532.8" textLength="939.4" clip-path="url(#terminal-2106414123-line-62)">&#160;&#160;--major-version-zero&#160;&#160;keep&#160;major&#160;version&#160;at&#160;zero,&#160;even&#160;for&#160;breaking&#160;changes</text><text class="terminal-2106414123-r1" x="976" y="1532.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-62)">
+</text><text class="terminal-2106414123-r1" x="0" y="1557.2" textLength="414.8" clip-path="url(#terminal-2106414123-line-63)">&#160;&#160;--template&#160;TEMPLATE,&#160;-t&#160;TEMPLATE</text><text class="terminal-2106414123-r1" x="976" y="1557.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-63)">
+</text><text class="terminal-2106414123-r1" x="0" y="1581.6" textLength="646.6" clip-path="url(#terminal-2106414123-line-64)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;changelog&#160;template&#160;file&#160;name&#160;</text><text class="terminal-2106414123-r2" x="646.6" y="1581.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-64)">(</text><text class="terminal-2106414123-r1" x="658.8" y="1581.6" textLength="280.6" clip-path="url(#terminal-2106414123-line-64)">relative&#160;to&#160;the&#160;current</text><text class="terminal-2106414123-r1" x="976" y="1581.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-64)">
+</text><text class="terminal-2106414123-r1" x="0" y="1606" textLength="500.2" clip-path="url(#terminal-2106414123-line-65)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;working&#160;directory</text><text class="terminal-2106414123-r2" x="500.2" y="1606" textLength="12.2" clip-path="url(#terminal-2106414123-line-65)">)</text><text class="terminal-2106414123-r1" x="976" y="1606" textLength="12.2" clip-path="url(#terminal-2106414123-line-65)">
+</text><text class="terminal-2106414123-r1" x="0" y="1630.4" textLength="305" clip-path="url(#terminal-2106414123-line-66)">&#160;&#160;--extra&#160;EXTRA,&#160;-e&#160;EXTRA</text><text class="terminal-2106414123-r1" x="976" y="1630.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-66)">
+</text><text class="terminal-2106414123-r1" x="0" y="1654.8" textLength="622.2" clip-path="url(#terminal-2106414123-line-67)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;a&#160;changelog&#160;extra&#160;variable&#160;</text><text class="terminal-2106414123-r2" x="622.2" y="1654.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-67)">(</text><text class="terminal-2106414123-r1" x="634.4" y="1654.8" textLength="146.4" clip-path="url(#terminal-2106414123-line-67)">in&#160;the&#160;form&#160;</text><text class="terminal-2106414123-r4" x="780.8" y="1654.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-67)">&#x27;</text><text class="terminal-2106414123-r4" x="793" y="1654.8" textLength="36.6" clip-path="url(#terminal-2106414123-line-67)">key</text><text class="terminal-2106414123-r4" x="829.6" y="1654.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-67)">=</text><text class="terminal-2106414123-r4" x="841.8" y="1654.8" textLength="61" clip-path="url(#terminal-2106414123-line-67)">value</text><text class="terminal-2106414123-r4" x="902.8" y="1654.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-67)">&#x27;</text><text class="terminal-2106414123-r2" x="915" y="1654.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-67)">)</text><text class="terminal-2106414123-r1" x="976" y="1654.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-67)">
+</text><text class="terminal-2106414123-r1" x="0" y="1679.2" textLength="280.6" clip-path="url(#terminal-2106414123-line-68)">&#160;&#160;--file-name&#160;FILE_NAME</text><text class="terminal-2106414123-r1" x="976" y="1679.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-68)">
+</text><text class="terminal-2106414123-r1" x="0" y="1703.6" textLength="573.4" clip-path="url(#terminal-2106414123-line-69)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;file&#160;name&#160;of&#160;changelog&#160;</text><text class="terminal-2106414123-r2" x="573.4" y="1703.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-69)">(</text><text class="terminal-2106414123-r1" x="585.6" y="1703.6" textLength="109.8" clip-path="url(#terminal-2106414123-line-69)">default:&#160;</text><text class="terminal-2106414123-r4" x="695.4" y="1703.6" textLength="170.8" clip-path="url(#terminal-2106414123-line-69)">&#x27;CHANGELOG.md&#x27;</text><text class="terminal-2106414123-r2" x="866.2" y="1703.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-69)">)</text><text class="terminal-2106414123-r1" x="976" y="1703.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-69)">
+</text><text class="terminal-2106414123-r1" x="0" y="1728" textLength="475.8" clip-path="url(#terminal-2106414123-line-70)">&#160;&#160;--prerelease-offset&#160;PRERELEASE_OFFSET</text><text class="terminal-2106414123-r1" x="976" y="1728" textLength="12.2" clip-path="url(#terminal-2106414123-line-70)">
+</text><text class="terminal-2106414123-r1" x="0" y="1752.4" textLength="719.8" clip-path="url(#terminal-2106414123-line-71)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;start&#160;pre-releases&#160;with&#160;this&#160;offset</text><text class="terminal-2106414123-r1" x="976" y="1752.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-71)">
+</text><text class="terminal-2106414123-r1" x="0" y="1776.8" textLength="231.8" clip-path="url(#terminal-2106414123-line-72)">&#160;&#160;--version-scheme&#160;</text><text class="terminal-2106414123-r2" x="231.8" y="1776.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-72)">{</text><text class="terminal-2106414123-r1" x="244" y="1776.8" textLength="158.6" clip-path="url(#terminal-2106414123-line-72)">semver,pep440</text><text class="terminal-2106414123-r2" x="402.6" y="1776.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-72)">}</text><text class="terminal-2106414123-r1" x="976" y="1776.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-72)">
+</text><text class="terminal-2106414123-r1" x="0" y="1801.2" textLength="549" clip-path="url(#terminal-2106414123-line-73)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;choose&#160;version&#160;scheme</text><text class="terminal-2106414123-r1" x="976" y="1801.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-73)">
+</text><text class="terminal-2106414123-r1" x="0" y="1825.6" textLength="207.4" clip-path="url(#terminal-2106414123-line-74)">&#160;&#160;--version-type&#160;</text><text class="terminal-2106414123-r2" x="207.4" y="1825.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-74)">{</text><text class="terminal-2106414123-r1" x="219.6" y="1825.6" textLength="158.6" clip-path="url(#terminal-2106414123-line-74)">semver,pep440</text><text class="terminal-2106414123-r2" x="378.2" y="1825.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-74)">}</text><text class="terminal-2106414123-r1" x="976" y="1825.6" textLength="12.2" clip-path="url(#terminal-2106414123-line-74)">
+</text><text class="terminal-2106414123-r1" x="0" y="1850" textLength="683.2" clip-path="url(#terminal-2106414123-line-75)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Deprecated,&#160;use&#160;--version-scheme</text><text class="terminal-2106414123-r1" x="976" y="1850" textLength="12.2" clip-path="url(#terminal-2106414123-line-75)">
+</text><text class="terminal-2106414123-r1" x="0" y="1874.4" textLength="402.6" clip-path="url(#terminal-2106414123-line-76)">&#160;&#160;--build-metadata&#160;BUILD_METADATA</text><text class="terminal-2106414123-r1" x="976" y="1874.4" textLength="12.2" clip-path="url(#terminal-2106414123-line-76)">
+</text><text class="terminal-2106414123-r1" x="0" y="1898.8" textLength="915" clip-path="url(#terminal-2106414123-line-77)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Add&#160;additional&#160;build-metadata&#160;to&#160;the&#160;version-number</text><text class="terminal-2106414123-r1" x="976" y="1898.8" textLength="12.2" clip-path="url(#terminal-2106414123-line-77)">
+</text><text class="terminal-2106414123-r1" x="976" y="1923.2" textLength="12.2" clip-path="url(#terminal-2106414123-line-78)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/cli_help/cz_changelog___help.svg
+++ b/docs/images/cli_help/cz_changelog___help.svg
@@ -1,0 +1,217 @@
+<svg class="rich-terminal" viewBox="0 0 994 1026.0" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-3815852825-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-3815852825-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-3815852825-r1 { fill: #c5c8c6 }
+.terminal-3815852825-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-3815852825-r3 { fill: #68a0b3;font-weight: bold }
+.terminal-3815852825-r4 { fill: #98a84b }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-3815852825-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="975.0" />
+    </clipPath>
+    <clipPath id="terminal-3815852825-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-22">
+    <rect x="0" y="538.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-23">
+    <rect x="0" y="562.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-24">
+    <rect x="0" y="587.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-25">
+    <rect x="0" y="611.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-26">
+    <rect x="0" y="635.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-27">
+    <rect x="0" y="660.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-28">
+    <rect x="0" y="684.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-29">
+    <rect x="0" y="709.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-30">
+    <rect x="0" y="733.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-31">
+    <rect x="0" y="757.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-32">
+    <rect x="0" y="782.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-33">
+    <rect x="0" y="806.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-34">
+    <rect x="0" y="831.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-35">
+    <rect x="0" y="855.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-36">
+    <rect x="0" y="879.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-37">
+    <rect x="0" y="904.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3815852825-line-38">
+    <rect x="0" y="928.7" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="1024" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3815852825-clip-terminal)">
+
+    <g class="terminal-3815852825-matrix">
+    <text class="terminal-3815852825-r1" x="0" y="20" textLength="256.2" clip-path="url(#terminal-3815852825-line-0)">$&#160;cz&#160;changelog&#160;--help</text><text class="terminal-3815852825-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3815852825-line-0)">
+</text><text class="terminal-3815852825-r1" x="0" y="44.4" textLength="244" clip-path="url(#terminal-3815852825-line-1)">usage:&#160;cz&#160;changelog&#160;</text><text class="terminal-3815852825-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-1)">[</text><text class="terminal-3815852825-r1" x="256.2" y="44.4" textLength="24.4" clip-path="url(#terminal-3815852825-line-1)">-h</text><text class="terminal-3815852825-r2" x="280.6" y="44.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-1)">]</text><text class="terminal-3815852825-r2" x="305" y="44.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-1)">[</text><text class="terminal-3815852825-r1" x="317.2" y="44.4" textLength="109.8" clip-path="url(#terminal-3815852825-line-1)">--dry-run</text><text class="terminal-3815852825-r2" x="427" y="44.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-1)">]</text><text class="terminal-3815852825-r2" x="451.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-1)">[</text><text class="terminal-3815852825-r1" x="463.6" y="44.4" textLength="256.2" clip-path="url(#terminal-3815852825-line-1)">--file-name&#160;FILE_NAME</text><text class="terminal-3815852825-r2" x="719.8" y="44.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-1)">]</text><text class="terminal-3815852825-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-1)">
+</text><text class="terminal-3815852825-r2" x="244" y="68.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-2)">[</text><text class="terminal-3815852825-r1" x="256.2" y="68.8" textLength="475.8" clip-path="url(#terminal-3815852825-line-2)">--unreleased-version&#160;UNRELEASED_VERSION</text><text class="terminal-3815852825-r2" x="732" y="68.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-2)">]</text><text class="terminal-3815852825-r2" x="756.4" y="68.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-2)">[</text><text class="terminal-3815852825-r1" x="768.6" y="68.8" textLength="158.6" clip-path="url(#terminal-3815852825-line-2)">--incremental</text><text class="terminal-3815852825-r2" x="927.2" y="68.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-2)">]</text><text class="terminal-3815852825-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-2)">
+</text><text class="terminal-3815852825-r2" x="244" y="93.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-3)">[</text><text class="terminal-3815852825-r1" x="256.2" y="93.2" textLength="256.2" clip-path="url(#terminal-3815852825-line-3)">--start-rev&#160;START_REV</text><text class="terminal-3815852825-r2" x="512.4" y="93.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-3)">]</text><text class="terminal-3815852825-r2" x="536.8" y="93.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-3)">[</text><text class="terminal-3815852825-r1" x="549" y="93.2" textLength="219.6" clip-path="url(#terminal-3815852825-line-3)">--merge-prerelease</text><text class="terminal-3815852825-r2" x="768.6" y="93.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-3)">]</text><text class="terminal-3815852825-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-3)">
+</text><text class="terminal-3815852825-r2" x="244" y="117.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-4)">[</text><text class="terminal-3815852825-r1" x="256.2" y="117.6" textLength="207.4" clip-path="url(#terminal-3815852825-line-4)">--version-scheme&#160;</text><text class="terminal-3815852825-r2" x="463.6" y="117.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-4)">{</text><text class="terminal-3815852825-r1" x="475.8" y="117.6" textLength="158.6" clip-path="url(#terminal-3815852825-line-4)">pep440,semver</text><text class="terminal-3815852825-r2" x="634.4" y="117.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-4)">}</text><text class="terminal-3815852825-r2" x="646.6" y="117.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-4)">]</text><text class="terminal-3815852825-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-4)">
+</text><text class="terminal-3815852825-r2" x="244" y="142" textLength="12.2" clip-path="url(#terminal-3815852825-line-5)">[</text><text class="terminal-3815852825-r1" x="256.2" y="142" textLength="402.6" clip-path="url(#terminal-3815852825-line-5)">--export-template&#160;EXPORT_TEMPLATE</text><text class="terminal-3815852825-r2" x="658.8" y="142" textLength="12.2" clip-path="url(#terminal-3815852825-line-5)">]</text><text class="terminal-3815852825-r2" x="683.2" y="142" textLength="12.2" clip-path="url(#terminal-3815852825-line-5)">[</text><text class="terminal-3815852825-r1" x="695.4" y="142" textLength="231.8" clip-path="url(#terminal-3815852825-line-5)">--template&#160;TEMPLATE</text><text class="terminal-3815852825-r2" x="927.2" y="142" textLength="12.2" clip-path="url(#terminal-3815852825-line-5)">]</text><text class="terminal-3815852825-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3815852825-line-5)">
+</text><text class="terminal-3815852825-r2" x="244" y="166.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-6)">[</text><text class="terminal-3815852825-r1" x="256.2" y="166.4" textLength="158.6" clip-path="url(#terminal-3815852825-line-6)">--extra&#160;EXTRA</text><text class="terminal-3815852825-r2" x="414.8" y="166.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-6)">]</text><text class="terminal-3815852825-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-6)">
+</text><text class="terminal-3815852825-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-7)">
+</text><text class="terminal-3815852825-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-8)">
+</text><text class="terminal-3815852825-r1" x="0" y="239.6" textLength="256.2" clip-path="url(#terminal-3815852825-line-9)">positional&#160;arguments:</text><text class="terminal-3815852825-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-9)">
+</text><text class="terminal-3815852825-r1" x="0" y="264" textLength="805.2" clip-path="url(#terminal-3815852825-line-10)">&#160;&#160;rev_range&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;generates&#160;changelog&#160;for&#160;the&#160;given&#160;version&#160;</text><text class="terminal-3815852825-r2" x="805.2" y="264" textLength="12.2" clip-path="url(#terminal-3815852825-line-10)">(</text><text class="terminal-3815852825-r1" x="817.4" y="264" textLength="61" clip-path="url(#terminal-3815852825-line-10)">e.g:&#160;</text><text class="terminal-3815852825-r3" x="878.4" y="264" textLength="36.6" clip-path="url(#terminal-3815852825-line-10)">1.5</text><text class="terminal-3815852825-r1" x="915" y="264" textLength="12.2" clip-path="url(#terminal-3815852825-line-10)">.</text><text class="terminal-3815852825-r3" x="927.2" y="264" textLength="12.2" clip-path="url(#terminal-3815852825-line-10)">3</text><text class="terminal-3815852825-r2" x="939.4" y="264" textLength="12.2" clip-path="url(#terminal-3815852825-line-10)">)</text><text class="terminal-3815852825-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3815852825-line-10)">
+</text><text class="terminal-3815852825-r1" x="0" y="288.4" textLength="500.2" clip-path="url(#terminal-3815852825-line-11)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;or&#160;version&#160;range&#160;</text><text class="terminal-3815852825-r2" x="500.2" y="288.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-11)">(</text><text class="terminal-3815852825-r1" x="512.4" y="288.4" textLength="61" clip-path="url(#terminal-3815852825-line-11)">e.g:&#160;</text><text class="terminal-3815852825-r3" x="573.4" y="288.4" textLength="36.6" clip-path="url(#terminal-3815852825-line-11)">1.5</text><text class="terminal-3815852825-r1" x="610" y="288.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-11)">.</text><text class="terminal-3815852825-r3" x="622.2" y="288.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-11)">3</text><text class="terminal-3815852825-r1" x="634.4" y="288.4" textLength="24.4" clip-path="url(#terminal-3815852825-line-11)">..</text><text class="terminal-3815852825-r3" x="658.8" y="288.4" textLength="36.6" clip-path="url(#terminal-3815852825-line-11)">1.7</text><text class="terminal-3815852825-r1" x="695.4" y="288.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-11)">.</text><text class="terminal-3815852825-r3" x="707.6" y="288.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-11)">9</text><text class="terminal-3815852825-r2" x="719.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-11)">)</text><text class="terminal-3815852825-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-11)">
+</text><text class="terminal-3815852825-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-12)">
+</text><text class="terminal-3815852825-r1" x="0" y="337.2" textLength="97.6" clip-path="url(#terminal-3815852825-line-13)">options:</text><text class="terminal-3815852825-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-13)">
+</text><text class="terminal-3815852825-r1" x="0" y="361.6" textLength="671" clip-path="url(#terminal-3815852825-line-14)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-3815852825-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-14)">
+</text><text class="terminal-3815852825-r1" x="0" y="386" textLength="585.6" clip-path="url(#terminal-3815852825-line-15)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;changelog&#160;to&#160;stdout</text><text class="terminal-3815852825-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3815852825-line-15)">
+</text><text class="terminal-3815852825-r1" x="0" y="410.4" textLength="280.6" clip-path="url(#terminal-3815852825-line-16)">&#160;&#160;--file-name&#160;FILE_NAME</text><text class="terminal-3815852825-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-16)">
+</text><text class="terminal-3815852825-r1" x="0" y="434.8" textLength="573.4" clip-path="url(#terminal-3815852825-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;file&#160;name&#160;of&#160;changelog&#160;</text><text class="terminal-3815852825-r2" x="573.4" y="434.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-17)">(</text><text class="terminal-3815852825-r1" x="585.6" y="434.8" textLength="109.8" clip-path="url(#terminal-3815852825-line-17)">default:&#160;</text><text class="terminal-3815852825-r4" x="695.4" y="434.8" textLength="170.8" clip-path="url(#terminal-3815852825-line-17)">&#x27;CHANGELOG.md&#x27;</text><text class="terminal-3815852825-r2" x="866.2" y="434.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-17)">)</text><text class="terminal-3815852825-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-17)">
+</text><text class="terminal-3815852825-r1" x="0" y="459.2" textLength="500.2" clip-path="url(#terminal-3815852825-line-18)">&#160;&#160;--unreleased-version&#160;UNRELEASED_VERSION</text><text class="terminal-3815852825-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-18)">
+</text><text class="terminal-3815852825-r1" x="0" y="483.6" textLength="707.6" clip-path="url(#terminal-3815852825-line-19)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;set&#160;the&#160;value&#160;for&#160;the&#160;new&#160;version&#160;</text><text class="terminal-3815852825-r2" x="707.6" y="483.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-19)">(</text><text class="terminal-3815852825-r1" x="719.8" y="483.6" textLength="207.4" clip-path="url(#terminal-3815852825-line-19)">use&#160;the&#160;tag&#160;value</text><text class="terminal-3815852825-r2" x="927.2" y="483.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-19)">)</text><text class="terminal-3815852825-r1" x="939.4" y="483.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-19)">,</text><text class="terminal-3815852825-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-19)">
+</text><text class="terminal-3815852825-r1" x="0" y="508" textLength="622.2" clip-path="url(#terminal-3815852825-line-20)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;instead&#160;of&#160;using&#160;unreleased</text><text class="terminal-3815852825-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3815852825-line-20)">
+</text><text class="terminal-3815852825-r1" x="0" y="532.4" textLength="939.4" clip-path="url(#terminal-3815852825-line-21)">&#160;&#160;--incremental&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;generates&#160;changelog&#160;from&#160;last&#160;created&#160;version,&#160;useful</text><text class="terminal-3815852825-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-21)">
+</text><text class="terminal-3815852825-r1" x="0" y="556.8" textLength="817.4" clip-path="url(#terminal-3815852825-line-22)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;if&#160;the&#160;changelog&#160;has&#160;been&#160;manually&#160;modified</text><text class="terminal-3815852825-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-22)">
+</text><text class="terminal-3815852825-r1" x="0" y="581.2" textLength="280.6" clip-path="url(#terminal-3815852825-line-23)">&#160;&#160;--start-rev&#160;START_REV</text><text class="terminal-3815852825-r1" x="976" y="581.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-23)">
+</text><text class="terminal-3815852825-r1" x="0" y="605.6" textLength="866.2" clip-path="url(#terminal-3815852825-line-24)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;start&#160;rev&#160;of&#160;the&#160;changelog.&#160;If&#160;not&#160;set,&#160;it&#160;will</text><text class="terminal-3815852825-r1" x="976" y="605.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-24)">
+</text><text class="terminal-3815852825-r1" x="0" y="630" textLength="695.4" clip-path="url(#terminal-3815852825-line-25)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;generate&#160;changelog&#160;from&#160;the&#160;start</text><text class="terminal-3815852825-r1" x="976" y="630" textLength="12.2" clip-path="url(#terminal-3815852825-line-25)">
+</text><text class="terminal-3815852825-r1" x="0" y="654.4" textLength="915" clip-path="url(#terminal-3815852825-line-26)">&#160;&#160;--merge-prerelease&#160;&#160;&#160;&#160;collect&#160;all&#160;changes&#160;from&#160;prereleases&#160;into&#160;next&#160;non-</text><text class="terminal-3815852825-r1" x="976" y="654.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-26)">
+</text><text class="terminal-3815852825-r1" x="0" y="678.8" textLength="951.6" clip-path="url(#terminal-3815852825-line-27)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;prerelease.&#160;If&#160;not&#160;set,&#160;it&#160;will&#160;include&#160;prereleases&#160;in</text><text class="terminal-3815852825-r1" x="976" y="678.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-27)">
+</text><text class="terminal-3815852825-r1" x="0" y="703.2" textLength="451.4" clip-path="url(#terminal-3815852825-line-28)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;changelog</text><text class="terminal-3815852825-r1" x="976" y="703.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-28)">
+</text><text class="terminal-3815852825-r1" x="0" y="727.6" textLength="231.8" clip-path="url(#terminal-3815852825-line-29)">&#160;&#160;--version-scheme&#160;</text><text class="terminal-3815852825-r2" x="231.8" y="727.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-29)">{</text><text class="terminal-3815852825-r1" x="244" y="727.6" textLength="158.6" clip-path="url(#terminal-3815852825-line-29)">pep440,semver</text><text class="terminal-3815852825-r2" x="402.6" y="727.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-29)">}</text><text class="terminal-3815852825-r1" x="976" y="727.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-29)">
+</text><text class="terminal-3815852825-r1" x="0" y="752" textLength="549" clip-path="url(#terminal-3815852825-line-30)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;choose&#160;version&#160;scheme</text><text class="terminal-3815852825-r1" x="976" y="752" textLength="12.2" clip-path="url(#terminal-3815852825-line-30)">
+</text><text class="terminal-3815852825-r1" x="0" y="776.4" textLength="427" clip-path="url(#terminal-3815852825-line-31)">&#160;&#160;--export-template&#160;EXPORT_TEMPLATE</text><text class="terminal-3815852825-r1" x="976" y="776.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-31)">
+</text><text class="terminal-3815852825-r1" x="0" y="800.8" textLength="927.2" clip-path="url(#terminal-3815852825-line-32)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Export&#160;the&#160;changelog&#160;template&#160;into&#160;this&#160;file&#160;instead</text><text class="terminal-3815852825-r1" x="976" y="800.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-32)">
+</text><text class="terminal-3815852825-r1" x="0" y="825.2" textLength="475.8" clip-path="url(#terminal-3815852825-line-33)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;of&#160;rendering&#160;it</text><text class="terminal-3815852825-r1" x="976" y="825.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-33)">
+</text><text class="terminal-3815852825-r1" x="0" y="849.6" textLength="414.8" clip-path="url(#terminal-3815852825-line-34)">&#160;&#160;--template&#160;TEMPLATE,&#160;-t&#160;TEMPLATE</text><text class="terminal-3815852825-r1" x="976" y="849.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-34)">
+</text><text class="terminal-3815852825-r1" x="0" y="874" textLength="646.6" clip-path="url(#terminal-3815852825-line-35)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;changelog&#160;template&#160;file&#160;name&#160;</text><text class="terminal-3815852825-r2" x="646.6" y="874" textLength="12.2" clip-path="url(#terminal-3815852825-line-35)">(</text><text class="terminal-3815852825-r1" x="658.8" y="874" textLength="280.6" clip-path="url(#terminal-3815852825-line-35)">relative&#160;to&#160;the&#160;current</text><text class="terminal-3815852825-r1" x="976" y="874" textLength="12.2" clip-path="url(#terminal-3815852825-line-35)">
+</text><text class="terminal-3815852825-r1" x="0" y="898.4" textLength="500.2" clip-path="url(#terminal-3815852825-line-36)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;working&#160;directory</text><text class="terminal-3815852825-r2" x="500.2" y="898.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-36)">)</text><text class="terminal-3815852825-r1" x="976" y="898.4" textLength="12.2" clip-path="url(#terminal-3815852825-line-36)">
+</text><text class="terminal-3815852825-r1" x="0" y="922.8" textLength="305" clip-path="url(#terminal-3815852825-line-37)">&#160;&#160;--extra&#160;EXTRA,&#160;-e&#160;EXTRA</text><text class="terminal-3815852825-r1" x="976" y="922.8" textLength="12.2" clip-path="url(#terminal-3815852825-line-37)">
+</text><text class="terminal-3815852825-r1" x="0" y="947.2" textLength="622.2" clip-path="url(#terminal-3815852825-line-38)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;a&#160;changelog&#160;extra&#160;variable&#160;</text><text class="terminal-3815852825-r2" x="622.2" y="947.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-38)">(</text><text class="terminal-3815852825-r1" x="634.4" y="947.2" textLength="146.4" clip-path="url(#terminal-3815852825-line-38)">in&#160;the&#160;form&#160;</text><text class="terminal-3815852825-r4" x="780.8" y="947.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-38)">&#x27;</text><text class="terminal-3815852825-r4" x="793" y="947.2" textLength="36.6" clip-path="url(#terminal-3815852825-line-38)">key</text><text class="terminal-3815852825-r4" x="829.6" y="947.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-38)">=</text><text class="terminal-3815852825-r4" x="841.8" y="947.2" textLength="61" clip-path="url(#terminal-3815852825-line-38)">value</text><text class="terminal-3815852825-r4" x="902.8" y="947.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-38)">&#x27;</text><text class="terminal-3815852825-r2" x="915" y="947.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-38)">)</text><text class="terminal-3815852825-r1" x="976" y="947.2" textLength="12.2" clip-path="url(#terminal-3815852825-line-38)">
+</text><text class="terminal-3815852825-r1" x="976" y="971.6" textLength="12.2" clip-path="url(#terminal-3815852825-line-39)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/cli_help/cz_check___help.svg
+++ b/docs/images/cli_help/cz_check___help.svg
@@ -1,0 +1,149 @@
+<svg class="rich-terminal" viewBox="0 0 994 611.1999999999999" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-3217887475-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-3217887475-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-3217887475-r1 { fill: #c5c8c6 }
+.terminal-3217887475-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-3217887475-r3 { fill: #d0b344 }
+.terminal-3217887475-r4 { fill: #68a0b3;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-3217887475-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="560.1999999999999" />
+    </clipPath>
+    <clipPath id="terminal-3217887475-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-17">
+    <rect x="0" y="416.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-18">
+    <rect x="0" y="440.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-19">
+    <rect x="0" y="465.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-20">
+    <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3217887475-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="609.2" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3217887475-clip-terminal)">
+
+    <g class="terminal-3217887475-matrix">
+    <text class="terminal-3217887475-r1" x="0" y="20" textLength="207.4" clip-path="url(#terminal-3217887475-line-0)">$&#160;cz&#160;check&#160;--help</text><text class="terminal-3217887475-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3217887475-line-0)">
+</text><text class="terminal-3217887475-r1" x="0" y="44.4" textLength="195.2" clip-path="url(#terminal-3217887475-line-1)">usage:&#160;cz&#160;check&#160;</text><text class="terminal-3217887475-r2" x="195.2" y="44.4" textLength="12.2" clip-path="url(#terminal-3217887475-line-1)">[</text><text class="terminal-3217887475-r1" x="207.4" y="44.4" textLength="24.4" clip-path="url(#terminal-3217887475-line-1)">-h</text><text class="terminal-3217887475-r2" x="231.8" y="44.4" textLength="12.2" clip-path="url(#terminal-3217887475-line-1)">]</text><text class="terminal-3217887475-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3217887475-line-1)">
+</text><text class="terminal-3217887475-r2" x="195.2" y="68.8" textLength="12.2" clip-path="url(#terminal-3217887475-line-2)">[</text><text class="terminal-3217887475-r1" x="207.4" y="68.8" textLength="768.6" clip-path="url(#terminal-3217887475-line-2)">--commit-msg-file&#160;COMMIT_MSG_FILE&#160;|&#160;--rev-range&#160;REV_RANGE&#160;|&#160;-m&#160;</text><text class="terminal-3217887475-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3217887475-line-2)">
+</text><text class="terminal-3217887475-r1" x="0" y="93.2" textLength="85.4" clip-path="url(#terminal-3217887475-line-3)">MESSAGE</text><text class="terminal-3217887475-r2" x="85.4" y="93.2" textLength="12.2" clip-path="url(#terminal-3217887475-line-3)">]</text><text class="terminal-3217887475-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3217887475-line-3)">
+</text><text class="terminal-3217887475-r2" x="195.2" y="117.6" textLength="12.2" clip-path="url(#terminal-3217887475-line-4)">[</text><text class="terminal-3217887475-r1" x="207.4" y="117.6" textLength="158.6" clip-path="url(#terminal-3217887475-line-4)">--allow-abort</text><text class="terminal-3217887475-r2" x="366" y="117.6" textLength="12.2" clip-path="url(#terminal-3217887475-line-4)">]</text><text class="terminal-3217887475-r2" x="390.4" y="117.6" textLength="12.2" clip-path="url(#terminal-3217887475-line-4)">[</text><text class="terminal-3217887475-r1" x="402.6" y="117.6" textLength="231.8" clip-path="url(#terminal-3217887475-line-4)">--allowed-prefixes&#160;</text><text class="terminal-3217887475-r2" x="634.4" y="117.6" textLength="12.2" clip-path="url(#terminal-3217887475-line-4)">[</text><text class="terminal-3217887475-r1" x="646.6" y="117.6" textLength="207.4" clip-path="url(#terminal-3217887475-line-4)">ALLOWED_PREFIXES&#160;</text><text class="terminal-3217887475-r3" x="854" y="117.6" textLength="36.6" clip-path="url(#terminal-3217887475-line-4)">...</text><text class="terminal-3217887475-r2" x="890.6" y="117.6" textLength="12.2" clip-path="url(#terminal-3217887475-line-4)">]</text><text class="terminal-3217887475-r2" x="902.8" y="117.6" textLength="12.2" clip-path="url(#terminal-3217887475-line-4)">]</text><text class="terminal-3217887475-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3217887475-line-4)">
+</text><text class="terminal-3217887475-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3217887475-line-5)">
+</text><text class="terminal-3217887475-r1" x="0" y="166.4" textLength="97.6" clip-path="url(#terminal-3217887475-line-6)">options:</text><text class="terminal-3217887475-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3217887475-line-6)">
+</text><text class="terminal-3217887475-r1" x="0" y="190.8" textLength="671" clip-path="url(#terminal-3217887475-line-7)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-3217887475-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3217887475-line-7)">
+</text><text class="terminal-3217887475-r1" x="0" y="215.2" textLength="427" clip-path="url(#terminal-3217887475-line-8)">&#160;&#160;--commit-msg-file&#160;COMMIT_MSG_FILE</text><text class="terminal-3217887475-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3217887475-line-8)">
+</text><text class="terminal-3217887475-r1" x="0" y="239.6" textLength="915" clip-path="url(#terminal-3217887475-line-9)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;ask&#160;for&#160;the&#160;name&#160;of&#160;the&#160;temporal&#160;file&#160;that&#160;contains</text><text class="terminal-3217887475-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3217887475-line-9)">
+</text><text class="terminal-3217887475-r1" x="0" y="264" textLength="902.8" clip-path="url(#terminal-3217887475-line-10)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;the&#160;commit&#160;message.&#160;Using&#160;it&#160;in&#160;a&#160;git&#160;hook&#160;script:</text><text class="terminal-3217887475-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3217887475-line-10)">
+</text><text class="terminal-3217887475-r3" x="292.8" y="288.4" textLength="97.6" clip-path="url(#terminal-3217887475-line-11)">MSG_FILE</text><text class="terminal-3217887475-r1" x="390.4" y="288.4" textLength="24.4" clip-path="url(#terminal-3217887475-line-11)">=$</text><text class="terminal-3217887475-r4" x="414.8" y="288.4" textLength="12.2" clip-path="url(#terminal-3217887475-line-11)">1</text><text class="terminal-3217887475-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3217887475-line-11)">
+</text><text class="terminal-3217887475-r1" x="0" y="312.8" textLength="280.6" clip-path="url(#terminal-3217887475-line-12)">&#160;&#160;--rev-range&#160;REV_RANGE</text><text class="terminal-3217887475-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3217887475-line-12)">
+</text><text class="terminal-3217887475-r1" x="0" y="337.2" textLength="854" clip-path="url(#terminal-3217887475-line-13)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;a&#160;range&#160;of&#160;git&#160;rev&#160;to&#160;check.&#160;e.g,&#160;master..HEAD</text><text class="terminal-3217887475-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3217887475-line-13)">
+</text><text class="terminal-3217887475-r1" x="0" y="361.6" textLength="378.2" clip-path="url(#terminal-3217887475-line-14)">&#160;&#160;-m&#160;MESSAGE,&#160;--message&#160;MESSAGE</text><text class="terminal-3217887475-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3217887475-line-14)">
+</text><text class="terminal-3217887475-r1" x="0" y="386" textLength="768.6" clip-path="url(#terminal-3217887475-line-15)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;commit&#160;message&#160;that&#160;needs&#160;to&#160;be&#160;checked</text><text class="terminal-3217887475-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3217887475-line-15)">
+</text><text class="terminal-3217887475-r1" x="0" y="410.4" textLength="927.2" clip-path="url(#terminal-3217887475-line-16)">&#160;&#160;--allow-abort&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;allow&#160;empty&#160;commit&#160;messages,&#160;which&#160;typically&#160;abort&#160;a</text><text class="terminal-3217887475-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3217887475-line-16)">
+</text><text class="terminal-3217887475-r1" x="0" y="434.8" textLength="366" clip-path="url(#terminal-3217887475-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;commit</text><text class="terminal-3217887475-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3217887475-line-17)">
+</text><text class="terminal-3217887475-r1" x="0" y="459.2" textLength="256.2" clip-path="url(#terminal-3217887475-line-18)">&#160;&#160;--allowed-prefixes&#160;</text><text class="terminal-3217887475-r2" x="256.2" y="459.2" textLength="12.2" clip-path="url(#terminal-3217887475-line-18)">[</text><text class="terminal-3217887475-r1" x="268.4" y="459.2" textLength="207.4" clip-path="url(#terminal-3217887475-line-18)">ALLOWED_PREFIXES&#160;</text><text class="terminal-3217887475-r3" x="475.8" y="459.2" textLength="36.6" clip-path="url(#terminal-3217887475-line-18)">...</text><text class="terminal-3217887475-r2" x="512.4" y="459.2" textLength="12.2" clip-path="url(#terminal-3217887475-line-18)">]</text><text class="terminal-3217887475-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3217887475-line-18)">
+</text><text class="terminal-3217887475-r1" x="0" y="483.6" textLength="951.6" clip-path="url(#terminal-3217887475-line-19)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;allowed&#160;commit&#160;message&#160;prefixes.&#160;If&#160;the&#160;message&#160;starts</text><text class="terminal-3217887475-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3217887475-line-19)">
+</text><text class="terminal-3217887475-r1" x="0" y="508" textLength="951.6" clip-path="url(#terminal-3217887475-line-20)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;by&#160;one&#160;of&#160;these&#160;prefixes,&#160;the&#160;message&#160;won&#x27;t&#160;be&#160;checked</text><text class="terminal-3217887475-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3217887475-line-20)">
+</text><text class="terminal-3217887475-r1" x="0" y="532.4" textLength="500.2" clip-path="url(#terminal-3217887475-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;against&#160;the&#160;regex</text><text class="terminal-3217887475-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3217887475-line-21)">
+</text><text class="terminal-3217887475-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-3217887475-line-22)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/cli_help/cz_commit___help.svg
+++ b/docs/images/cli_help/cz_commit___help.svg
@@ -1,0 +1,123 @@
+<svg class="rich-terminal" viewBox="0 0 994 464.79999999999995" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-3369302934-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-3369302934-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-3369302934-r1 { fill: #c5c8c6 }
+.terminal-3369302934-r2 { fill: #c5c8c6;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-3369302934-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="413.79999999999995" />
+    </clipPath>
+    <clipPath id="terminal-3369302934-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-3369302934-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="462.8" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-3369302934-clip-terminal)">
+
+    <g class="terminal-3369302934-matrix">
+    <text class="terminal-3369302934-r1" x="0" y="20" textLength="219.6" clip-path="url(#terminal-3369302934-line-0)">$&#160;cz&#160;commit&#160;--help</text><text class="terminal-3369302934-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3369302934-line-0)">
+</text><text class="terminal-3369302934-r1" x="0" y="44.4" textLength="207.4" clip-path="url(#terminal-3369302934-line-1)">usage:&#160;cz&#160;commit&#160;</text><text class="terminal-3369302934-r2" x="207.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-1)">[</text><text class="terminal-3369302934-r1" x="219.6" y="44.4" textLength="24.4" clip-path="url(#terminal-3369302934-line-1)">-h</text><text class="terminal-3369302934-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-1)">]</text><text class="terminal-3369302934-r2" x="268.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-1)">[</text><text class="terminal-3369302934-r1" x="280.6" y="44.4" textLength="85.4" clip-path="url(#terminal-3369302934-line-1)">--retry</text><text class="terminal-3369302934-r2" x="366" y="44.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-1)">]</text><text class="terminal-3369302934-r2" x="390.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-1)">[</text><text class="terminal-3369302934-r1" x="402.6" y="44.4" textLength="122" clip-path="url(#terminal-3369302934-line-1)">--no-retry</text><text class="terminal-3369302934-r2" x="524.6" y="44.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-1)">]</text><text class="terminal-3369302934-r2" x="549" y="44.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-1)">[</text><text class="terminal-3369302934-r1" x="561.2" y="44.4" textLength="109.8" clip-path="url(#terminal-3369302934-line-1)">--dry-run</text><text class="terminal-3369302934-r2" x="671" y="44.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-1)">]</text><text class="terminal-3369302934-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-1)">
+</text><text class="terminal-3369302934-r2" x="207.4" y="68.8" textLength="12.2" clip-path="url(#terminal-3369302934-line-2)">[</text><text class="terminal-3369302934-r1" x="219.6" y="68.8" textLength="402.6" clip-path="url(#terminal-3369302934-line-2)">--write-message-to-file&#160;FILE_PATH</text><text class="terminal-3369302934-r2" x="622.2" y="68.8" textLength="12.2" clip-path="url(#terminal-3369302934-line-2)">]</text><text class="terminal-3369302934-r2" x="646.6" y="68.8" textLength="12.2" clip-path="url(#terminal-3369302934-line-2)">[</text><text class="terminal-3369302934-r1" x="658.8" y="68.8" textLength="24.4" clip-path="url(#terminal-3369302934-line-2)">-s</text><text class="terminal-3369302934-r2" x="683.2" y="68.8" textLength="12.2" clip-path="url(#terminal-3369302934-line-2)">]</text><text class="terminal-3369302934-r2" x="707.6" y="68.8" textLength="12.2" clip-path="url(#terminal-3369302934-line-2)">[</text><text class="terminal-3369302934-r1" x="719.8" y="68.8" textLength="24.4" clip-path="url(#terminal-3369302934-line-2)">-a</text><text class="terminal-3369302934-r2" x="744.2" y="68.8" textLength="12.2" clip-path="url(#terminal-3369302934-line-2)">]</text><text class="terminal-3369302934-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3369302934-line-2)">
+</text><text class="terminal-3369302934-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3369302934-line-3)">
+</text><text class="terminal-3369302934-r1" x="0" y="117.6" textLength="97.6" clip-path="url(#terminal-3369302934-line-4)">options:</text><text class="terminal-3369302934-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3369302934-line-4)">
+</text><text class="terminal-3369302934-r1" x="0" y="142" textLength="671" clip-path="url(#terminal-3369302934-line-5)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-3369302934-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3369302934-line-5)">
+</text><text class="terminal-3369302934-r1" x="0" y="166.4" textLength="500.2" clip-path="url(#terminal-3369302934-line-6)">&#160;&#160;--retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;retry&#160;last&#160;commit</text><text class="terminal-3369302934-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-6)">
+</text><text class="terminal-3369302934-r1" x="0" y="190.8" textLength="878.4" clip-path="url(#terminal-3369302934-line-7)">&#160;&#160;--no-retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;skip&#160;retry&#160;if&#160;retry_after_failure&#160;is&#160;set&#160;to&#160;true</text><text class="terminal-3369302934-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3369302934-line-7)">
+</text><text class="terminal-3369302934-r1" x="0" y="215.2" textLength="915" clip-path="url(#terminal-3369302934-line-8)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;output&#160;to&#160;stdout,&#160;no&#160;commit,&#160;no&#160;modified&#160;files</text><text class="terminal-3369302934-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3369302934-line-8)">
+</text><text class="terminal-3369302934-r1" x="0" y="239.6" textLength="427" clip-path="url(#terminal-3369302934-line-9)">&#160;&#160;--write-message-to-file&#160;FILE_PATH</text><text class="terminal-3369302934-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3369302934-line-9)">
+</text><text class="terminal-3369302934-r1" x="0" y="264" textLength="780.8" clip-path="url(#terminal-3369302934-line-10)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;write&#160;message&#160;to&#160;file&#160;before&#160;committing&#160;</text><text class="terminal-3369302934-r2" x="780.8" y="264" textLength="12.2" clip-path="url(#terminal-3369302934-line-10)">(</text><text class="terminal-3369302934-r1" x="793" y="264" textLength="73.2" clip-path="url(#terminal-3369302934-line-10)">can&#160;be</text><text class="terminal-3369302934-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3369302934-line-10)">
+</text><text class="terminal-3369302934-r1" x="0" y="288.4" textLength="573.4" clip-path="url(#terminal-3369302934-line-11)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;combined&#160;with&#160;--dry-run</text><text class="terminal-3369302934-r2" x="573.4" y="288.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-11)">)</text><text class="terminal-3369302934-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-11)">
+</text><text class="terminal-3369302934-r1" x="0" y="312.8" textLength="524.6" clip-path="url(#terminal-3369302934-line-12)">&#160;&#160;-s,&#160;--signoff&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sign&#160;off&#160;the&#160;commit</text><text class="terminal-3369302934-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3369302934-line-12)">
+</text><text class="terminal-3369302934-r1" x="0" y="337.2" textLength="902.8" clip-path="url(#terminal-3369302934-line-13)">&#160;&#160;-a,&#160;--all&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Tell&#160;the&#160;command&#160;to&#160;automatically&#160;stage&#160;files&#160;that</text><text class="terminal-3369302934-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3369302934-line-13)">
+</text><text class="terminal-3369302934-r1" x="0" y="361.6" textLength="951.6" clip-path="url(#terminal-3369302934-line-14)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;have&#160;been&#160;modified&#160;and&#160;deleted,&#160;but&#160;new&#160;files&#160;you&#160;have</text><text class="terminal-3369302934-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3369302934-line-14)">
+</text><text class="terminal-3369302934-r1" x="0" y="386" textLength="732" clip-path="url(#terminal-3369302934-line-15)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;not&#160;told&#160;Git&#160;about&#160;are&#160;not&#160;affected.</text><text class="terminal-3369302934-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3369302934-line-15)">
+</text><text class="terminal-3369302934-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3369302934-line-16)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/cli_help/cz_example___help.svg
+++ b/docs/images/cli_help/cz_example___help.svg
@@ -1,0 +1,79 @@
+<svg class="rich-terminal" viewBox="0 0 994 196.39999999999998" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2958388120-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2958388120-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2958388120-r1 { fill: #c5c8c6 }
+.terminal-2958388120-r2 { fill: #c5c8c6;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2958388120-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="145.39999999999998" />
+    </clipPath>
+    <clipPath id="terminal-2958388120-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2958388120-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2958388120-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2958388120-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2958388120-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="194.4" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2958388120-clip-terminal)">
+
+    <g class="terminal-2958388120-matrix">
+    <text class="terminal-2958388120-r1" x="0" y="20" textLength="231.8" clip-path="url(#terminal-2958388120-line-0)">$&#160;cz&#160;example&#160;--help</text><text class="terminal-2958388120-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2958388120-line-0)">
+</text><text class="terminal-2958388120-r1" x="0" y="44.4" textLength="219.6" clip-path="url(#terminal-2958388120-line-1)">usage:&#160;cz&#160;example&#160;</text><text class="terminal-2958388120-r2" x="219.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2958388120-line-1)">[</text><text class="terminal-2958388120-r1" x="231.8" y="44.4" textLength="24.4" clip-path="url(#terminal-2958388120-line-1)">-h</text><text class="terminal-2958388120-r2" x="256.2" y="44.4" textLength="12.2" clip-path="url(#terminal-2958388120-line-1)">]</text><text class="terminal-2958388120-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2958388120-line-1)">
+</text><text class="terminal-2958388120-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2958388120-line-2)">
+</text><text class="terminal-2958388120-r1" x="0" y="93.2" textLength="97.6" clip-path="url(#terminal-2958388120-line-3)">options:</text><text class="terminal-2958388120-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2958388120-line-3)">
+</text><text class="terminal-2958388120-r1" x="0" y="117.6" textLength="549" clip-path="url(#terminal-2958388120-line-4)">&#160;&#160;-h,&#160;--help&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-2958388120-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2958388120-line-4)">
+</text><text class="terminal-2958388120-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2958388120-line-5)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/cli_help/cz_info___help.svg
+++ b/docs/images/cli_help/cz_info___help.svg
@@ -1,0 +1,79 @@
+<svg class="rich-terminal" viewBox="0 0 994 196.39999999999998" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2494261528-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2494261528-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2494261528-r1 { fill: #c5c8c6 }
+.terminal-2494261528-r2 { fill: #c5c8c6;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2494261528-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="145.39999999999998" />
+    </clipPath>
+    <clipPath id="terminal-2494261528-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2494261528-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2494261528-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2494261528-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2494261528-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="194.4" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2494261528-clip-terminal)">
+
+    <g class="terminal-2494261528-matrix">
+    <text class="terminal-2494261528-r1" x="0" y="20" textLength="195.2" clip-path="url(#terminal-2494261528-line-0)">$&#160;cz&#160;info&#160;--help</text><text class="terminal-2494261528-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2494261528-line-0)">
+</text><text class="terminal-2494261528-r1" x="0" y="44.4" textLength="183" clip-path="url(#terminal-2494261528-line-1)">usage:&#160;cz&#160;info&#160;</text><text class="terminal-2494261528-r2" x="183" y="44.4" textLength="12.2" clip-path="url(#terminal-2494261528-line-1)">[</text><text class="terminal-2494261528-r1" x="195.2" y="44.4" textLength="24.4" clip-path="url(#terminal-2494261528-line-1)">-h</text><text class="terminal-2494261528-r2" x="219.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2494261528-line-1)">]</text><text class="terminal-2494261528-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2494261528-line-1)">
+</text><text class="terminal-2494261528-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2494261528-line-2)">
+</text><text class="terminal-2494261528-r1" x="0" y="93.2" textLength="97.6" clip-path="url(#terminal-2494261528-line-3)">options:</text><text class="terminal-2494261528-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2494261528-line-3)">
+</text><text class="terminal-2494261528-r1" x="0" y="117.6" textLength="549" clip-path="url(#terminal-2494261528-line-4)">&#160;&#160;-h,&#160;--help&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-2494261528-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2494261528-line-4)">
+</text><text class="terminal-2494261528-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2494261528-line-5)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/cli_help/cz_init___help.svg
+++ b/docs/images/cli_help/cz_init___help.svg
@@ -1,0 +1,79 @@
+<svg class="rich-terminal" viewBox="0 0 994 196.39999999999998" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2788256040-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2788256040-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2788256040-r1 { fill: #c5c8c6 }
+.terminal-2788256040-r2 { fill: #c5c8c6;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2788256040-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="145.39999999999998" />
+    </clipPath>
+    <clipPath id="terminal-2788256040-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2788256040-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2788256040-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2788256040-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2788256040-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="194.4" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2788256040-clip-terminal)">
+
+    <g class="terminal-2788256040-matrix">
+    <text class="terminal-2788256040-r1" x="0" y="20" textLength="195.2" clip-path="url(#terminal-2788256040-line-0)">$&#160;cz&#160;init&#160;--help</text><text class="terminal-2788256040-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2788256040-line-0)">
+</text><text class="terminal-2788256040-r1" x="0" y="44.4" textLength="183" clip-path="url(#terminal-2788256040-line-1)">usage:&#160;cz&#160;init&#160;</text><text class="terminal-2788256040-r2" x="183" y="44.4" textLength="12.2" clip-path="url(#terminal-2788256040-line-1)">[</text><text class="terminal-2788256040-r1" x="195.2" y="44.4" textLength="24.4" clip-path="url(#terminal-2788256040-line-1)">-h</text><text class="terminal-2788256040-r2" x="219.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2788256040-line-1)">]</text><text class="terminal-2788256040-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2788256040-line-1)">
+</text><text class="terminal-2788256040-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2788256040-line-2)">
+</text><text class="terminal-2788256040-r1" x="0" y="93.2" textLength="97.6" clip-path="url(#terminal-2788256040-line-3)">options:</text><text class="terminal-2788256040-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2788256040-line-3)">
+</text><text class="terminal-2788256040-r1" x="0" y="117.6" textLength="549" clip-path="url(#terminal-2788256040-line-4)">&#160;&#160;-h,&#160;--help&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-2788256040-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2788256040-line-4)">
+</text><text class="terminal-2788256040-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2788256040-line-5)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/cli_help/cz_ls___help.svg
+++ b/docs/images/cli_help/cz_ls___help.svg
@@ -1,0 +1,79 @@
+<svg class="rich-terminal" viewBox="0 0 994 196.39999999999998" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2631362430-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2631362430-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2631362430-r1 { fill: #c5c8c6 }
+.terminal-2631362430-r2 { fill: #c5c8c6;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2631362430-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="145.39999999999998" />
+    </clipPath>
+    <clipPath id="terminal-2631362430-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2631362430-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2631362430-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2631362430-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2631362430-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="194.4" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2631362430-clip-terminal)">
+
+    <g class="terminal-2631362430-matrix">
+    <text class="terminal-2631362430-r1" x="0" y="20" textLength="170.8" clip-path="url(#terminal-2631362430-line-0)">$&#160;cz&#160;ls&#160;--help</text><text class="terminal-2631362430-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2631362430-line-0)">
+</text><text class="terminal-2631362430-r1" x="0" y="44.4" textLength="158.6" clip-path="url(#terminal-2631362430-line-1)">usage:&#160;cz&#160;ls&#160;</text><text class="terminal-2631362430-r2" x="158.6" y="44.4" textLength="12.2" clip-path="url(#terminal-2631362430-line-1)">[</text><text class="terminal-2631362430-r1" x="170.8" y="44.4" textLength="24.4" clip-path="url(#terminal-2631362430-line-1)">-h</text><text class="terminal-2631362430-r2" x="195.2" y="44.4" textLength="12.2" clip-path="url(#terminal-2631362430-line-1)">]</text><text class="terminal-2631362430-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2631362430-line-1)">
+</text><text class="terminal-2631362430-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2631362430-line-2)">
+</text><text class="terminal-2631362430-r1" x="0" y="93.2" textLength="97.6" clip-path="url(#terminal-2631362430-line-3)">options:</text><text class="terminal-2631362430-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2631362430-line-3)">
+</text><text class="terminal-2631362430-r1" x="0" y="117.6" textLength="549" clip-path="url(#terminal-2631362430-line-4)">&#160;&#160;-h,&#160;--help&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-2631362430-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2631362430-line-4)">
+</text><text class="terminal-2631362430-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2631362430-line-5)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/cli_help/cz_schema___help.svg
+++ b/docs/images/cli_help/cz_schema___help.svg
@@ -1,0 +1,79 @@
+<svg class="rich-terminal" viewBox="0 0 994 196.39999999999998" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-2172349090-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-2172349090-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-2172349090-r1 { fill: #c5c8c6 }
+.terminal-2172349090-r2 { fill: #c5c8c6;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-2172349090-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="145.39999999999998" />
+    </clipPath>
+    <clipPath id="terminal-2172349090-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2172349090-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2172349090-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2172349090-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-2172349090-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="194.4" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-2172349090-clip-terminal)">
+
+    <g class="terminal-2172349090-matrix">
+    <text class="terminal-2172349090-r1" x="0" y="20" textLength="219.6" clip-path="url(#terminal-2172349090-line-0)">$&#160;cz&#160;schema&#160;--help</text><text class="terminal-2172349090-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-2172349090-line-0)">
+</text><text class="terminal-2172349090-r1" x="0" y="44.4" textLength="207.4" clip-path="url(#terminal-2172349090-line-1)">usage:&#160;cz&#160;schema&#160;</text><text class="terminal-2172349090-r2" x="207.4" y="44.4" textLength="12.2" clip-path="url(#terminal-2172349090-line-1)">[</text><text class="terminal-2172349090-r1" x="219.6" y="44.4" textLength="24.4" clip-path="url(#terminal-2172349090-line-1)">-h</text><text class="terminal-2172349090-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-2172349090-line-1)">]</text><text class="terminal-2172349090-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-2172349090-line-1)">
+</text><text class="terminal-2172349090-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-2172349090-line-2)">
+</text><text class="terminal-2172349090-r1" x="0" y="93.2" textLength="97.6" clip-path="url(#terminal-2172349090-line-3)">options:</text><text class="terminal-2172349090-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-2172349090-line-3)">
+</text><text class="terminal-2172349090-r1" x="0" y="117.6" textLength="549" clip-path="url(#terminal-2172349090-line-4)">&#160;&#160;-h,&#160;--help&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-2172349090-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-2172349090-line-4)">
+</text><text class="terminal-2172349090-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-2172349090-line-5)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/docs/images/cli_help/cz_version___help.svg
+++ b/docs/images/cli_help/cz_version___help.svg
@@ -1,0 +1,99 @@
+<svg class="rich-terminal" viewBox="0 0 994 318.4" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1533814420-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1533814420-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1533814420-r1 { fill: #c5c8c6 }
+.terminal-1533814420-r2 { fill: #c5c8c6;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1533814420-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="267.4" />
+    </clipPath>
+    <clipPath id="terminal-1533814420-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1533814420-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1533814420-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1533814420-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1533814420-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1533814420-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1533814420-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1533814420-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1533814420-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1533814420-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="316.4" rx="8"/>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1533814420-clip-terminal)">
+
+    <g class="terminal-1533814420-matrix">
+    <text class="terminal-1533814420-r1" x="0" y="20" textLength="231.8" clip-path="url(#terminal-1533814420-line-0)">$&#160;cz&#160;version&#160;--help</text><text class="terminal-1533814420-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-1533814420-line-0)">
+</text><text class="terminal-1533814420-r1" x="0" y="44.4" textLength="219.6" clip-path="url(#terminal-1533814420-line-1)">usage:&#160;cz&#160;version&#160;</text><text class="terminal-1533814420-r2" x="219.6" y="44.4" textLength="12.2" clip-path="url(#terminal-1533814420-line-1)">[</text><text class="terminal-1533814420-r1" x="231.8" y="44.4" textLength="24.4" clip-path="url(#terminal-1533814420-line-1)">-h</text><text class="terminal-1533814420-r2" x="256.2" y="44.4" textLength="12.2" clip-path="url(#terminal-1533814420-line-1)">]</text><text class="terminal-1533814420-r2" x="280.6" y="44.4" textLength="12.2" clip-path="url(#terminal-1533814420-line-1)">[</text><text class="terminal-1533814420-r1" x="292.8" y="44.4" textLength="207.4" clip-path="url(#terminal-1533814420-line-1)">-r&#160;|&#160;-p&#160;|&#160;-c&#160;|&#160;-v</text><text class="terminal-1533814420-r2" x="500.2" y="44.4" textLength="12.2" clip-path="url(#terminal-1533814420-line-1)">]</text><text class="terminal-1533814420-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-1533814420-line-1)">
+</text><text class="terminal-1533814420-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-1533814420-line-2)">
+</text><text class="terminal-1533814420-r1" x="0" y="93.2" textLength="97.6" clip-path="url(#terminal-1533814420-line-3)">options:</text><text class="terminal-1533814420-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-1533814420-line-3)">
+</text><text class="terminal-1533814420-r1" x="0" y="117.6" textLength="622.2" clip-path="url(#terminal-1533814420-line-4)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-1533814420-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-1533814420-line-4)">
+</text><text class="terminal-1533814420-r1" x="0" y="142" textLength="744.2" clip-path="url(#terminal-1533814420-line-5)">&#160;&#160;-r,&#160;--report&#160;&#160;&#160;&#160;&#160;&#160;get&#160;system&#160;information&#160;for&#160;reporting&#160;bugs</text><text class="terminal-1533814420-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-1533814420-line-5)">
+</text><text class="terminal-1533814420-r1" x="0" y="166.4" textLength="707.6" clip-path="url(#terminal-1533814420-line-6)">&#160;&#160;-p,&#160;--project&#160;&#160;&#160;&#160;&#160;get&#160;the&#160;version&#160;of&#160;the&#160;current&#160;project</text><text class="terminal-1533814420-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-1533814420-line-6)">
+</text><text class="terminal-1533814420-r1" x="0" y="190.8" textLength="768.6" clip-path="url(#terminal-1533814420-line-7)">&#160;&#160;-c,&#160;--commitizen&#160;&#160;get&#160;the&#160;version&#160;of&#160;the&#160;installed&#160;commitizen</text><text class="terminal-1533814420-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-1533814420-line-7)">
+</text><text class="terminal-1533814420-r1" x="0" y="215.2" textLength="927.2" clip-path="url(#terminal-1533814420-line-8)">&#160;&#160;-v,&#160;--verbose&#160;&#160;&#160;&#160;&#160;get&#160;the&#160;version&#160;of&#160;both&#160;the&#160;installed&#160;commitizen&#160;and&#160;the</text><text class="terminal-1533814420-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-1533814420-line-8)">
+</text><text class="terminal-1533814420-r1" x="0" y="239.6" textLength="427" clip-path="url(#terminal-1533814420-line-9)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;current&#160;project</text><text class="terminal-1533814420-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-1533814420-line-9)">
+</text><text class="terminal-1533814420-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-1533814420-line-10)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/poetry.lock
+++ b/poetry.lock
@@ -618,6 +618,30 @@ docs = ["mdx-gh-links (>=0.2)", "mkdocs (>=1.5)", "mkdocs-gen-files", "mkdocs-li
 testing = ["coverage", "pyyaml"]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"},
+    {file = "markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+code-style = ["pre-commit (>=3.0,<4.0)"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "mistletoe (>=1.0,<2.0)", "mistune (>=2.0,<3.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins"]
+profiling = ["gprof2dot"]
+rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "sphinx-copybutton", "sphinx-design", "sphinx_book_theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.3"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -699,6 +723,17 @@ files = [
 
 [package.dependencies]
 traitlets = "*"
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
 
 [[package]]
 name = "mergedeep"
@@ -1406,6 +1441,25 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "rich"
+version = "13.7.1"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "rich-13.7.1-py3-none-any.whl", hash = "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222"},
+    {file = "rich-13.7.1.tar.gz", hash = "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "ruff"
 version = "0.3.4"
 description = "An extremely fast Python linter and code formatter, written in Rust."
@@ -1766,4 +1820,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "614f9b1db867d5b7f954c318309b0e7b18951ed7be6d8016af79a08b8c2c7a89"
+content-hash = "5cd809db4e9dc8005ab2295ca7d182435021752953a7b1552bb81912b54df791"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ mkdocs-material = "^9.1.6"
 deprecated = "^1.2.13"
 types-deprecated = "^1.2.9.2"
 types-python-dateutil = "^2.8.19.13"
+rich = "^13.7.1"
 
 
 [tool.poetry.scripts]

--- a/scripts/gen_cli_help_screenshots.py
+++ b/scripts/gen_cli_help_screenshots.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+from pathlib import Path
+
+from rich.console import Console
+
+from commitizen.cli import data
+
+project_root = Path(__file__).parent.parent.absolute()
+images_root = project_root / Path("docs") / Path("images") / Path("cli_help")
+
+
+def gen_cli_help_screenshots() -> None:
+    """Generate the screenshot for help message on each cli command and save them as svg files."""
+    if not os.path.exists(images_root):
+        os.makedirs(images_root)
+        print(f"Created {images_root}")
+
+    help_cmds = _list_help_cmds()
+    for cmd in help_cmds:
+        file_name = f"{cmd.replace(' ', '_').replace('-', '_')}.svg"
+        _export_cmd_as_svg(cmd, f"{images_root}/{file_name}")
+
+
+def _list_help_cmds() -> list[str]:
+    cmds = [f"{data['prog']} --help"] + [
+        f"{data['prog']} {sub_c['name'] if isinstance(sub_c['name'], str) else sub_c['name'][0]} --help"
+        for sub_c in data["subcommands"]["commands"]
+    ]
+
+    return cmds
+
+
+def _export_cmd_as_svg(cmd: str, file_name: str) -> None:
+    stdout = subprocess.run(cmd, shell=True, capture_output=True).stdout.decode("utf-8")
+    console = Console(record=True, width=80)
+    console.print(f"$ {cmd}\n{stdout}")
+    console.save_svg(file_name, title="")
+
+
+if __name__ == "__main__":
+    gen_cli_help_screenshots()


### PR DESCRIPTION
## Description
<!-- Describe what the change is -->
Add a script to generate screenshot of all cli help contents. 

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes


## Expected behavior

Execute `scripts/gen_cli_help_screenshots.py` will generate screenshots of cli help instructions

## Steps to Test This Pull Request

1. Execute `scripts/gen_cli_help_screenshots.py`
2. Check each of content insides `commitizen.cli`'s `data` is match its screenshot in `docs/images/cli_help/` folder.


## Additional context

Considering the purpose of the file is more closed to a script, put it into scripts folder.
Should add test and update the documentation accordinately after the change is accepted. 
