### PR TITLE
ci(github-actions): update env var used in doc publish actions

### DIFF
--- a/.github/workflows/docspublish.yml
+++ b/.github/workflows/docspublish.yml
@@ -31,8 +31,10 @@ jobs:
         token: ${{ secrets.PERSONAL_ACCESS_TOKEN_FOR_ORG }}
         file: 'docs/README.md'
     - name: Push doc to Github Page
-      uses: peaceiris/actions-gh-pages@v2
+      uses: peaceiris/actions-gh-pages@v4
       env:
-        PERSONAL_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./site
+        personal_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: ./site
+        user_name: "github-actions[bot]"
+        user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

The doc publish action is broken due to https://github.com/commitizen-tools/commitizen/pull/1057. The root cause is that the env var used has been changed since peaceiris/actions-gh-pages@3

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
