### PR TITLE
feat(bump): `version_files` now support glob patterns (fix #1067)

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 from collections import OrderedDict
+from glob import iglob
 from string import Template
 from typing import cast
 
@@ -53,23 +54,20 @@ def update_version_in_files(
     *,
     check_consistency: bool = False,
     encoding: str = encoding,
-) -> None:
+) -> list[str]:
     """Change old version to the new one in every file given.
 
     Note that this version is not the tag formatted one.
     So for example, your tag could look like `v1.0.0` while your version in
     the package like `1.0.0`.
+
+    Returns the list of updated files.
     """
     # TODO: separate check step and write step
-    for location in files:
-        drive, tail = os.path.splitdrive(location)
-        path, _, regex = tail.partition(":")
-        filepath = drive + path
-        if not regex:
-            regex = _version_to_regex(current_version)
-
+    updated = []
+    for path, regex in files_and_regexs(files, current_version):
         current_version_found, version_file = _bump_with_regex(
-            filepath,
+            path,
             current_version,
             new_version,
             regex,
@@ -78,14 +76,33 @@ def update_version_in_files(
 
         if check_consistency and not current_version_found:
             raise CurrentVersionNotFoundError(
-                f"Current version {current_version} is not found in {location}.\n"
+                f"Current version {current_version} is not found in {path}.\n"
                 "The version defined in commitizen configuration and the ones in "
                 "version_files are possibly inconsistent."
             )
 
         # Write the file out again
-        with smart_open(filepath, "w", encoding=encoding) as file:
+        with smart_open(path, "w", encoding=encoding) as file:
             file.write(version_file)
+        updated.append(path)
+    return updated
+
+
+def files_and_regexs(patterns: list[str], version: str) -> list[tuple[str, str]]:
+    """
+    Resolve all distinct files with their regexp from a list of glob patterns with optional regexp
+    """
+    out = []
+    for pattern in patterns:
+        drive, tail = os.path.splitdrive(pattern)
+        path, _, regex = tail.partition(":")
+        filepath = drive + path
+        if not regex:
+            regex = _version_to_regex(version)
+
+        for path in iglob(filepath):
+            out.append((path, regex))
+    return sorted(list(set(out)))
 
 
 def _bump_with_regex(

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -4,7 +4,7 @@ import os.path
 from difflib import SequenceMatcher
 from operator import itemgetter
 from pathlib import Path
-from typing import Callable
+from typing import Callable, cast
 
 from commitizen import bump, changelog, defaults, factory, git, out
 
@@ -38,8 +38,8 @@ class Changelog:
         self.start_rev = args.get("start_rev") or self.config.settings.get(
             "changelog_start_rev"
         )
-        self.file_name = args.get("file_name") or self.config.settings.get(
-            "changelog_file"
+        self.file_name = args.get("file_name") or cast(
+            str, self.config.settings.get("changelog_file")
         )
         if not isinstance(self.file_name, str):
             raise NotAllowed(

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -98,8 +98,8 @@ def tag(
     return c
 
 
-def add(args: str = "") -> cmd.Command:
-    c = cmd.run(f"git add {args}")
+def add(*args: str) -> cmd.Command:
+    c = cmd.run(f"git add {' '.join(args)}")
     return c
 
 

--- a/docs/bump.md
+++ b/docs/bump.md
@@ -474,6 +474,10 @@ In the example above, we can see the reference `"setup.py:version"`.
 This means that it will find a file `setup.py` and will only make a change
 in a line containing the `version` substring.
 
+!!! note
+    Files can be specified using relative (to the execution) paths, absolute paths
+    or glob patterns.
+
 ---
 
 ### `bump_message`

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -812,6 +812,16 @@ __version__ = "0.1.0"
 """,
             id="version in __init__.py with regex",
         ),
+        pytest.param(
+            "pyproject.toml",
+            "*.toml:^version",
+            """
+[tool.poetry]
+name = "my_package"
+version = "0.1.0"
+""",
+            id="version in pyproject.toml with glob and regex",
+        ),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/test_bump_update_version_in_files.py
+++ b/tests/test_bump_update_version_in_files.py
@@ -207,3 +207,21 @@ def test_multiplt_versions_to_bump(
     bump.update_version_in_files(old_version, new_version, [location], encoding="utf-8")
     with open(multiple_versions_to_update_poetry_lock, encoding="utf-8") as f:
         file_regression.check(f.read(), extension=".toml")
+
+
+def test_update_version_in_globbed_files(commitizen_config_file, file_regression):
+    old_version = "1.2.3"
+    new_version = "2.0.0"
+    other = commitizen_config_file.dirpath("other.toml")
+    print(commitizen_config_file, other)
+    copyfile(commitizen_config_file, other)
+
+    # Prepend full ppath as test assume absolute paths or cwd-relative
+    version_files = [commitizen_config_file.dirpath("*.toml")]
+
+    bump.update_version_in_files(
+        old_version, new_version, version_files, encoding="utf-8"
+    )
+
+    for file in commitizen_config_file, other:
+        file_regression.check(file.read_text("utf-8"), extension=".toml")

--- a/tests/test_bump_update_version_in_files/test_update_version_in_globbed_files.toml
+++ b/tests/test_bump_update_version_in_files/test_update_version_in_globbed_files.toml
@@ -1,0 +1,3 @@
+[tool.poetry]
+name = "commitizen"
+version = "2.0.0"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
This PR adds support for glob patterns in version files.

Bump changelog generation has been simplified a bit in the process.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
`version_files` accept glob patterns instead of raw file names, and all the matching files should be properly bumped and added to the commit when bumping.


## Steps to Test This Pull Request
1. Defined one or many glob patterns in `version_files`, with an optional line regex
2. Bump a release
3. Check that all expected files have been updated with the new version, and committed (if using git)


## Additional context
Implements and fixes #1067
