### PR TITLE
fix: set shell to False if running subprocess on Windows

### DIFF
--- a/commitizen/cmd.py
+++ b/commitizen/cmd.py
@@ -33,7 +33,7 @@ def run(cmd: str, env=None) -> Command:
         env = {**os.environ, **env}
     process = subprocess.Popen(
         cmd,
-        shell=True,
+        shell=False if os.name == 'nt' else True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         stdin=subprocess.PIPE,


### PR DESCRIPTION
## Description

When running a subprocess through `run` in `cmd.py`, if the OS is Windows set `shell=False`.

Closes https://github.com/commitizen-tools/commitizen/issues/1118


## Checklist

- [ ] Add test cases to all the changes you introduce
- [X] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [X] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
Running `rye run cz bump` on a Windows machine in a rye-managed project now works.
