### PR TITLE
feat(ci/cd): automates the generation of CLI screenshots

### DIFF
--- a/.github/workflows/generate_cli_screenshots.yml
+++ b/.github/workflows/generate_cli_screenshots.yml
@@ -1,0 +1,39 @@
+name: Generate CLI screenshots
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  generate_cli_screenshots:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip poetry
+          poetry --version
+          poetry install
+
+      - name: Generate CLI screenshots
+        run: |
+          poetry run python scripts/gen_cli_help_screenshots.py
+
+      - name: Commit and push CLI screenshots
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/images/cli_help
+          git commit -m "docs(cli/screenshots) update CLI screenshots"
+          git push


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [ ] Add test cases to all the changes you introduce **_(not applicable)_**
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test **_(not applicable)_**
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes **_(not applicable)_**

## Expected behavior
After any pull requested merged, this Github Action Workflow will be triggered and will updated the CLI screenshots.


## Steps to Test This Pull Request
I tested manually using an clone of **commitizen** repo.

General view:

![image](https://github.com/commitizen-tools/commitizen/assets/48416792/a8c9a85c-4b9a-4e68-aa8d-3ed6ff10194f)

Generate CLI screenshots using the **scripts/gen_cli_help_screenshots.py**:

![image](https://github.com/commitizen-tools/commitizen/assets/48416792/511b4403-d0df-43d4-97f2-a8cb5fe56c89)

Push updated images to repository:

![image](https://github.com/commitizen-tools/commitizen/assets/48416792/6810c25f-218e-485d-8198-50a8c907d81b)



