### PR TITLE
Turn on isort for ruff

### DIFF
--- a/commitizen/changelog_formats/__init__.py
+++ b/commitizen/changelog_formats/__init__.py
@@ -5,9 +5,8 @@ from typing import ClassVar, Protocol
 import importlib_metadata as metadata
 
 from commitizen.changelog import Metadata
-from commitizen.exceptions import ChangelogFormatUnknown
 from commitizen.config.base_config import BaseConfig
-
+from commitizen.exceptions import ChangelogFormatUnknown
 
 CHANGELOG_FORMAT_ENTRYPOINT = "commitizen.changelog_format"
 TEMPLATE_EXTENSION = "j2"

--- a/commitizen/changelog_formats/restructuredtext.py
+++ b/commitizen/changelog_formats/restructuredtext.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import sys
 from itertools import zip_longest
-from typing import IO, TYPE_CHECKING, Any, Union, Tuple
+from typing import IO, TYPE_CHECKING, Any, Tuple, Union
 
 from commitizen.changelog import Metadata
 

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -6,6 +6,7 @@ from logging import getLogger
 import questionary
 
 from commitizen import bump, factory, git, hooks, out
+from commitizen.changelog_formats import get_changelog_format
 from commitizen.commands.changelog import Changelog
 from commitizen.config import BaseConfig
 from commitizen.exceptions import (
@@ -21,13 +22,12 @@ from commitizen.exceptions import (
     NotAllowed,
     NoVersionSpecifiedError,
 )
-from commitizen.changelog_formats import get_changelog_format
 from commitizen.providers import get_provider
 from commitizen.version_schemes import (
-    get_version_scheme,
     Increment,
     InvalidVersion,
     Prerelease,
+    get_version_scheme,
 )
 
 logger = getLogger("commitizen")

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -7,9 +7,10 @@ from pathlib import Path
 from typing import Callable, cast
 
 from commitizen import bump, changelog, defaults, factory, git, out
-
+from commitizen.changelog_formats import get_changelog_format
 from commitizen.config import BaseConfig
-from commitizen.cz.base import MessageBuilderHook, ChangelogReleaseHook
+from commitizen.cz.base import ChangelogReleaseHook, MessageBuilderHook
+from commitizen.cz.utils import strip_local_version
 from commitizen.exceptions import (
     DryRunExit,
     NoCommitsFoundError,
@@ -18,10 +19,8 @@ from commitizen.exceptions import (
     NotAGitProjectError,
     NotAllowed,
 )
-from commitizen.changelog_formats import get_changelog_format
 from commitizen.git import GitTag, smart_open
 from commitizen.version_schemes import get_version_scheme
-from commitizen.cz.utils import strip_local_version
 
 
 class Changelog:

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import os
 
-
 import questionary
 
 from commitizen import factory, git, out

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import questionary
 import yaml
+
 from commitizen import cmd, factory, out
 from commitizen.__version__ import __version__
 from commitizen.config import BaseConfig, JsonConfig, TomlConfig, YAMLConfig

--- a/commitizen/config/__init__.py
+++ b/commitizen/config/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from commitizen import defaults, git
-from commitizen.exceptions import ConfigFileNotFound, ConfigFileIsEmpty
+from commitizen.exceptions import ConfigFileIsEmpty, ConfigFileNotFound
 
 from .base_config import BaseConfig
 from .json_config import JsonConfig

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from commitizen.exceptions import InvalidConfigurationError
 
+from commitizen.exceptions import InvalidConfigurationError
 from commitizen.git import smart_open
 
 from .base_config import BaseConfig

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from tomlkit import exceptions, parse, table
 
 from commitizen.exceptions import InvalidConfigurationError
+
 from .base_config import BaseConfig
 
 

--- a/commitizen/config/yaml_config.py
+++ b/commitizen/config/yaml_config.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 import yaml
 
-from commitizen.git import smart_open
 from commitizen.exceptions import InvalidConfigurationError
+from commitizen.git import smart_open
 
 from .base_config import BaseConfig
 

--- a/commitizen/cz/utils.py
+++ b/commitizen/cz/utils.py
@@ -1,9 +1,9 @@
-import re
 import os
+import re
 import tempfile
 
-from commitizen.cz import exceptions
 from commitizen import git
+from commitizen.cz import exceptions
 
 
 def required_validator(answer, msg=None):

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import pathlib
 from collections import OrderedDict
-from typing import Any, Iterable, MutableMapping
-
-from typing import TypedDict
+from typing import Any, Iterable, MutableMapping, TypedDict
 
 # Type
 Questions = Iterable[MutableMapping[str, Any]]

--- a/commitizen/providers/__init__.py
+++ b/commitizen/providers/__init__.py
@@ -6,7 +6,6 @@ import importlib_metadata as metadata
 
 from commitizen.config.base_config import BaseConfig
 from commitizen.exceptions import VersionProviderUnknown
-
 from commitizen.providers.base_provider import VersionProvider
 from commitizen.providers.cargo_provider import CargoProvider
 from commitizen.providers.commitizen_provider import CommitizenProvider

--- a/commitizen/providers/cargo_provider.py
+++ b/commitizen/providers/cargo_provider.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import tomlkit
 
-
 from commitizen.providers.base_provider import TomlProvider
 
 

--- a/commitizen/providers/commitizen_provider.py
+++ b/commitizen/providers/commitizen_provider.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 from commitizen.providers.base_provider import VersionProvider
 
 

--- a/commitizen/providers/composer_provider.py
+++ b/commitizen/providers/composer_provider.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 from commitizen.providers.base_provider import JsonProvider
 
 

--- a/commitizen/providers/npm_provider.py
+++ b/commitizen/providers/npm_provider.py
@@ -4,7 +4,6 @@ import json
 from pathlib import Path
 from typing import Any, ClassVar
 
-
 from commitizen.providers.base_provider import VersionProvider
 
 

--- a/commitizen/providers/pep621_provider.py
+++ b/commitizen/providers/pep621_provider.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 from commitizen.providers.base_provider import TomlProvider
 
 

--- a/commitizen/providers/poetry_provider.py
+++ b/commitizen/providers/poetry_provider.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import tomlkit
 
-
 from commitizen.providers.base_provider import TomlProvider
 
 

--- a/commitizen/providers/scm_provider.py
+++ b/commitizen/providers/scm_provider.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 import re
 from typing import Callable
 
-
 from commitizen.git import get_tags
+from commitizen.providers.base_provider import VersionProvider
 from commitizen.version_schemes import (
-    get_version_scheme,
     InvalidVersion,
     Version,
     VersionProtocol,
+    get_version_scheme,
 )
-
-from commitizen.providers.base_provider import VersionProvider
 
 
 class ScmProvider(VersionProvider):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,16 @@ addopts = "--strict-markers"
 line-length = 88
 
 [tool.ruff.lint]
-select = ["E", "F", "UP"]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # isort
+    "I",
+]
 ignore = [
     "E501",
     "D1",

--- a/scripts/format
+++ b/scripts/format
@@ -5,5 +5,7 @@ export PREFIX="poetry run python -m "
 
 set -x
 
+# This is needed for running import sorting
+${PREFIX}ruff check --fix commitizen tests
 ${PREFIX}ruff format commitizen tests
 ${PREFIX}black commitizen tests

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -12,6 +12,7 @@ from pytest_mock import MockFixture
 
 import commitizen.commands.bump as bump
 from commitizen import cli, cmd, git, hooks
+from commitizen.changelog_formats import ChangelogFormat
 from commitizen.cz.base import BaseCommitizen
 from commitizen.exceptions import (
     BumpTagFailedError,
@@ -28,7 +29,6 @@ from commitizen.exceptions import (
     NotAllowed,
     NoVersionSpecifiedError,
 )
-from commitizen.changelog_formats import ChangelogFormat
 from tests.utils import create_file_and_commit, create_tag
 
 

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -11,6 +11,7 @@ from pytest_mock import MockFixture
 
 from commitizen import __file__ as commitizen_init
 from commitizen import cli, git
+from commitizen.changelog_formats import ChangelogFormat
 from commitizen.commands.changelog import Changelog
 from commitizen.config.base_config import BaseConfig
 from commitizen.cz.base import BaseCommitizen
@@ -22,7 +23,6 @@ from commitizen.exceptions import (
     NotAGitProjectError,
     NotAllowed,
 )
-from commitizen.changelog_formats import ChangelogFormat
 from tests.utils import (
     create_branch,
     create_file_and_commit,

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -1,8 +1,8 @@
 import os
+from unittest.mock import ANY
 
 import pytest
 from pytest_mock import MockFixture
-from unittest.mock import ANY
 
 from commitizen import cmd, commands
 from commitizen.cz.exceptions import CzException

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,13 +10,13 @@ import pytest
 from pytest_mock import MockerFixture
 
 from commitizen import cmd, defaults
-from commitizen.config import BaseConfig
-from commitizen.cz import registry
-from commitizen.cz.base import BaseCommitizen
 from commitizen.changelog_formats import (
     ChangelogFormat,
     get_changelog_format,
 )
+from commitizen.config import BaseConfig
+from commitizen.cz import registry
+from commitizen.cz.base import BaseCommitizen
 from tests.utils import create_file_and_commit
 
 SIGNER = "GitHub Action"

--- a/tests/providers/test_base_provider.py
+++ b/tests/providers/test_base_provider.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 import pytest
 
 from commitizen.config.base_config import BaseConfig

--- a/tests/providers/test_cargo_provider.py
+++ b/tests/providers/test_cargo_provider.py
@@ -9,7 +9,6 @@ from commitizen.config.base_config import BaseConfig
 from commitizen.providers import get_provider
 from commitizen.providers.cargo_provider import CargoProvider
 
-
 CARGO_TOML = """\
 [package]
 name = "whatever"

--- a/tests/providers/test_commitizen_provider.py
+++ b/tests/providers/test_commitizen_provider.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-
 from commitizen.config.base_config import BaseConfig
 from commitizen.providers.commitizen_provider import CommitizenProvider
-
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture

--- a/tests/providers/test_composer_provider.py
+++ b/tests/providers/test_composer_provider.py
@@ -9,7 +9,6 @@ from commitizen.config.base_config import BaseConfig
 from commitizen.providers import get_provider
 from commitizen.providers.composer_provider import ComposerProvider
 
-
 COMPOSER_JSON = """\
 {
     "name": "whatever",

--- a/tests/providers/test_npm_provider.py
+++ b/tests/providers/test_npm_provider.py
@@ -9,7 +9,6 @@ from commitizen.config.base_config import BaseConfig
 from commitizen.providers import get_provider
 from commitizen.providers.npm_provider import NpmProvider
 
-
 NPM_PACKAGE_JSON = """\
 {
   "name": "whatever",

--- a/tests/providers/test_pep621_provider.py
+++ b/tests/providers/test_pep621_provider.py
@@ -9,7 +9,6 @@ from commitizen.config.base_config import BaseConfig
 from commitizen.providers import get_provider
 from commitizen.providers.pep621_provider import Pep621Provider
 
-
 PEP621_TOML = """\
 [project]
 version = "0.1.0"

--- a/tests/providers/test_poetry_provider.py
+++ b/tests/providers/test_poetry_provider.py
@@ -9,7 +9,6 @@ from commitizen.config.base_config import BaseConfig
 from commitizen.providers import get_provider
 from commitizen.providers.poetry_provider import PoetryProvider
 
-
 POETRY_TOML = """\
 [tool.poetry]
 version = "0.1.0"

--- a/tests/providers/test_scm_provider.py
+++ b/tests/providers/test_scm_provider.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 import pytest
 
 from commitizen.config.base_config import BaseConfig

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,5 +1,4 @@
 import re
-
 from pathlib import Path
 from typing import Optional
 
@@ -7,11 +6,11 @@ import pytest
 from jinja2 import FileSystemLoader
 
 from commitizen import changelog, git
+from commitizen.changelog_formats import ChangelogFormat
 from commitizen.cz.conventional_commits.conventional_commits import (
     ConventionalCommitsCz,
 )
 from commitizen.exceptions import InvalidConfigurationError
-from commitizen.changelog_formats import ChangelogFormat
 
 COMMITS_DATA = [
     {

--- a/tests/test_changelog_format_asciidoc.py
+++ b/tests/test_changelog_format_asciidoc.py
@@ -5,9 +5,8 @@ from pathlib import Path
 import pytest
 
 from commitizen.changelog import Metadata
-from commitizen.config.base_config import BaseConfig
 from commitizen.changelog_formats.asciidoc import AsciiDoc
-
+from commitizen.config.base_config import BaseConfig
 
 CHANGELOG_A = """
 = Changelog

--- a/tests/test_changelog_format_markdown.py
+++ b/tests/test_changelog_format_markdown.py
@@ -5,9 +5,8 @@ from pathlib import Path
 import pytest
 
 from commitizen.changelog import Metadata
-from commitizen.config.base_config import BaseConfig
 from commitizen.changelog_formats.markdown import Markdown
-
+from commitizen.config.base_config import BaseConfig
 
 CHANGELOG_A = """
 # Changelog

--- a/tests/test_changelog_format_restructuredtext.py
+++ b/tests/test_changelog_format_restructuredtext.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 import pytest
 
 from commitizen.changelog import Metadata
-from commitizen.config.base_config import BaseConfig
 from commitizen.changelog_formats.restructuredtext import RestructuredText
+from commitizen.config.base_config import BaseConfig
 
 if TYPE_CHECKING:
     from _pytest.mark.structures import ParameterSet

--- a/tests/test_changelog_format_textile.py
+++ b/tests/test_changelog_format_textile.py
@@ -5,9 +5,8 @@ from pathlib import Path
 import pytest
 
 from commitizen.changelog import Metadata
-from commitizen.config.base_config import BaseConfig
 from commitizen.changelog_formats.textile import Textile
-
+from commitizen.config.base_config import BaseConfig
 
 CHANGELOG_A = """
 h1. Changelog

--- a/tests/test_changelog_formats.py
+++ b/tests/test_changelog_formats.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import pytest
+
 from commitizen import defaults
-from commitizen.config.base_config import BaseConfig
 from commitizen.changelog_formats import (
     KNOWN_CHANGELOG_FORMATS,
     ChangelogFormat,
     get_changelog_format,
     guess_changelog_format,
 )
+from commitizen.config.base_config import BaseConfig
 from commitizen.exceptions import ChangelogFormatUnknown
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,11 +8,11 @@ from pytest_mock import MockFixture
 
 from commitizen import cli
 from commitizen.exceptions import (
+    ConfigFileNotFound,
     ExpectedExit,
+    InvalidCommandArgumentError,
     NoCommandFoundError,
     NotAGitProjectError,
-    InvalidCommandArgumentError,
-    ConfigFileNotFound,
 )
 
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 
 from commitizen import config, defaults, git
-from commitizen.exceptions import InvalidConfigurationError, ConfigFileIsEmpty
+from commitizen.exceptions import ConfigFileIsEmpty, InvalidConfigurationError
 
 PYPROJECT = """
 [tool.commitizen]

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -6,14 +6,14 @@ import platform
 import shutil
 
 import pytest
-from commitizen import cmd, exceptions, git
 from pytest_mock import MockFixture
 
+from commitizen import cmd, exceptions, git
 from tests.utils import (
     FakeCommand,
+    create_branch,
     create_file_and_commit,
     create_tag,
-    create_branch,
     switch_branch,
 )
 

--- a/tests/test_version_schemes.py
+++ b/tests/test_version_schemes.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import importlib_metadata as metadata
 import pytest
 from pytest_mock import MockerFixture
-import importlib_metadata as metadata
 
 from commitizen.config.base_config import BaseConfig
 from commitizen.exceptions import VersionSchemeUnknown

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 import uuid
 from pathlib import Path
+
 from deprecated import deprecated
 
 from commitizen import cmd, exceptions, git


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
* style: sort import
* [build(script): add "ruff check --fix" to format script to enable import sorting](build: add I into ruff lint and add "ruff check --fix" to format script to enable import sorting)

According to ruff doc, we'll need these additional setups for sorting imports, and we've missed it for some time
https://docs.astral.sh/ruff/formatter/#sorting-imports
<img width="1117" alt="image" src="https://github.com/commitizen-tools/commitizen/assets/5144808/a53d1a43-7bf3-4d72-aaac-97316a608fd1">


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
the import should be sorted by ruff


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

./script/format


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
