### PR TITLE
feat(config_files): add suport for "cz.toml" config file

### DIFF
--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -67,6 +67,7 @@ config_files: list[str] = [
     "cz.json",
     ".cz.yaml",
     "cz.yaml",
+    "cz.toml",
 ]
 encoding: str = "utf-8"
 

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -408,7 +408,7 @@ regarding if the file is present or not in `version_files`.
 
 Some examples
 
-`pyproject.toml` or `.cz.toml`
+`pyproject.toml`, `.cz.toml` or `cz.toml`
 
 ```toml
 [tool.commitizen]
@@ -441,7 +441,7 @@ defaults to: `bump: version $current_version → $new_version`
 
 Some examples
 
-`pyproject.toml` or `.cz.toml`
+`pyproject.toml`, `.cz.toml` or `cz.toml`
 
 ```toml
 [tool.commitizen]

--- a/docs/config.md
+++ b/docs/config.md
@@ -227,11 +227,11 @@ Provide extra variables to the changelog template. [Read more][template-customiz
 
 ## Configuration file
 
-### pyproject.toml or .cz.toml
+### pyproject.toml, .cz.toml or cz.toml
 
 Default and recommended configuration format for a project.
 For a **python** project, we recommend adding an entry to your `pyproject.toml`.
-You can also create a `.cz.toml` file at the root of your project folder.
+You can also create a `.cz.toml` or `cz.toml` file at the root of your project folder.
 
 Example configuration:
 
@@ -339,7 +339,7 @@ Commitizen provides some version providers for some well known formats:
 !!! note
 The `scm` provider is meant to be used with `setuptools-scm` or any packager `*-scm` plugin.
 
-An example in your `.cz.toml` would look like this:
+An example in your `.cz.toml` or `cz.toml` would look like this:
 
 ```toml
 [tool.commitizen]

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -57,7 +57,7 @@ They differ a bit in design, not sure if cz-js does any of this, but these are s
 - create custom rules, version bumps and changelog generation, by default we use the popular conventional commits (I think cz-js allows this).
 - single package, install one thing and it will work (cz-js is a monorepo, but you have to install different dependencies AFAIK)
 - pre-commit integration
-- works on any language project, as long as you create the `.cz.toml` file.
+- works on any language project, as long as you create the `.cz.toml` or `cz.toml` file.
 
 Where do they cross paths?
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,7 +8,7 @@ The assistant utility will help you set up everything
 cz init
 ```
 
-Alternatively, create a file `.cz.toml` in your project's directory.
+Alternatively, create a file `.cz.toml` or `cz.toml` in your project's directory.
 
 ```toml
 [tool.commitizen]

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -214,19 +214,30 @@ class TestReadCfg:
                 config.read_cfg(filepath="./not_in_root/pyproject.toml")
 
 
+@pytest.mark.parametrize(
+    "config_file, exception_string",
+    [
+        (".cz.toml", r"\.cz\.toml"),
+        ("cz.toml", r"cz\.toml"),
+        ("pyproject.toml", r"pyproject\.toml"),
+    ],
+    ids=[".cz.toml", "cz.toml", "pyproject.toml"],
+)
 class TestTomlConfig:
-    def test_init_empty_config_content(self, tmpdir):
-        path = tmpdir.mkdir("commitizen").join(".cz.toml")
+    def test_init_empty_config_content(self, tmpdir, config_file, exception_string):
+        path = tmpdir.mkdir("commitizen").join(config_file)
         toml_config = config.TomlConfig(data="", path=path)
         toml_config.init_empty_config_content()
 
         with open(path, encoding="utf-8") as toml_file:
             assert toml_file.read() == "[tool.commitizen]\n"
 
-    def test_init_empty_config_content_with_existing_content(self, tmpdir):
+    def test_init_empty_config_content_with_existing_content(
+        self, tmpdir, config_file, exception_string
+    ):
         existing_content = "[tool.black]\n" "line-length = 88\n"
 
-        path = tmpdir.mkdir("commitizen").join(".cz.toml")
+        path = tmpdir.mkdir("commitizen").join(config_file)
         path.write(existing_content)
         toml_config = config.TomlConfig(data="", path=path)
         toml_config.init_empty_config_content()
@@ -234,11 +245,13 @@ class TestTomlConfig:
         with open(path, encoding="utf-8") as toml_file:
             assert toml_file.read() == existing_content + "\n[tool.commitizen]\n"
 
-    def test_init_with_invalid_config_content(self, tmpdir):
+    def test_init_with_invalid_config_content(
+        self, tmpdir, config_file, exception_string
+    ):
         existing_content = "invalid toml content"
-        path = tmpdir.mkdir("commitizen").join(".cz.toml")
+        path = tmpdir.mkdir("commitizen").join(config_file)
 
-        with pytest.raises(InvalidConfigurationError, match=r"\.cz\.toml"):
+        with pytest.raises(InvalidConfigurationError, match=exception_string):
             config.TomlConfig(data=existing_content, path=path)
 
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -255,35 +255,53 @@ class TestTomlConfig:
             config.TomlConfig(data=existing_content, path=path)
 
 
+@pytest.mark.parametrize(
+    "config_file, exception_string",
+    [
+        (".cz.json", r"\.cz\.json"),
+        ("cz.json", r"cz\.json"),
+    ],
+    ids=[".cz.json", "cz.json"],
+)
 class TestJsonConfig:
-    def test_init_empty_config_content(self, tmpdir):
-        path = tmpdir.mkdir("commitizen").join(".cz.json")
+    def test_init_empty_config_content(self, tmpdir, config_file, exception_string):
+        path = tmpdir.mkdir("commitizen").join(config_file)
         json_config = config.JsonConfig(data="{}", path=path)
         json_config.init_empty_config_content()
 
         with open(path, encoding="utf-8") as json_file:
             assert json.load(json_file) == {"commitizen": {}}
 
-    def test_init_with_invalid_config_content(self, tmpdir):
+    def test_init_with_invalid_config_content(
+        self, tmpdir, config_file, exception_string
+    ):
         existing_content = "invalid json content"
-        path = tmpdir.mkdir("commitizen").join(".cz.json")
+        path = tmpdir.mkdir("commitizen").join(config_file)
 
-        with pytest.raises(InvalidConfigurationError, match=r"\.cz\.json"):
+        with pytest.raises(InvalidConfigurationError, match=exception_string):
             config.JsonConfig(data=existing_content, path=path)
 
 
+@pytest.mark.parametrize(
+    "config_file, exception_string",
+    [
+        (".cz.yaml", r"\.cz\.yaml"),
+        ("cz.yaml", r"cz\.yaml"),
+    ],
+    ids=[".cz.yaml", "cz.yaml"],
+)
 class TestYamlConfig:
-    def test_init_empty_config_content(self, tmpdir):
-        path = tmpdir.mkdir("commitizen").join(".cz.yaml")
+    def test_init_empty_config_content(self, tmpdir, config_file, exception_string):
+        path = tmpdir.mkdir("commitizen").join(config_file)
         yaml_config = config.YAMLConfig(data="{}", path=path)
         yaml_config.init_empty_config_content()
 
         with open(path) as yaml_file:
             assert yaml.safe_load(yaml_file) == {"commitizen": {}}
 
-    def test_init_with_invalid_content(self, tmpdir):
+    def test_init_with_invalid_content(self, tmpdir, config_file, exception_string):
         existing_content = "invalid: .cz.yaml: content: maybe?"
-        path = tmpdir.mkdir("commitizen").join(".cz.yaml")
+        path = tmpdir.mkdir("commitizen").join(config_file)
 
-        with pytest.raises(InvalidConfigurationError, match=r"\.cz\.yaml"):
+        with pytest.raises(InvalidConfigurationError, match=exception_string):
             config.YAMLConfig(data=existing_content, path=path)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Add support to configure commitizen through `cz.toml` file.


## Checklist

- [x] Add test cases to all the changes you introduce **(see details below!)**
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
Be able to initialize and configure commitizen through `cz.toml`

## Screenshots
<details>
<summary>Test the new config file</summary>
<br/>

1. Rename the pyproject.toml to whatever
2. Run `cz init` and you will see the new possible config file

![image](https://github.com/commitizen-tools/commitizen/assets/48416792/2a0ac79b-0f35-41b3-861d-a3070d46d2e9)

Successfully created the `cz.toml`:

![image](https://github.com/commitizen-tools/commitizen/assets/48416792/48e2e4f7-4589-4b95-b135-678cac6c67de)
</details>

<details>
<summary>About this feature be already covered by current tests</summary>
<br/>
Since its just an new filename, not extension nor format, its already fully covered by tests.

`tests/test_conf.py::TestReadCfg` already cover the tests on `.toml` extension:

![image](https://github.com/commitizen-tools/commitizen/assets/48416792/3828beee-5e39-4295-ba05-db596d1917ca)

And also pass all other tests:

![image](https://github.com/commitizen-tools/commitizen/assets/48416792/a0277a0a-1538-4ab6-be4b-7c46e101bc5e)


</details>

Closes: #1111 