### PR TITLE
fix(base.py): add encoding when open changlelog_file

### DIFF
--- a/commitizen/changelog_formats/base.py
+++ b/commitizen/changelog_formats/base.py
@@ -24,6 +24,7 @@ class BaseFormat(ChangelogFormat, metaclass=ABCMeta):
         # Constructor needs to be redefined because `Protocol` prevent instantiation by default
         # See: https://bugs.python.org/issue44807
         self.config = config
+        self.encoding = self.config.settings["encoding"]
 
     @property
     def version_parser(self) -> Pattern:
@@ -33,7 +34,7 @@ class BaseFormat(ChangelogFormat, metaclass=ABCMeta):
         if not os.path.isfile(filepath):
             return Metadata()
 
-        with open(filepath) as changelog_file:
+        with open(filepath, encoding=self.encoding) as changelog_file:
             return self.get_metadata_from_file(changelog_file)
 
     def get_metadata_from_file(self, file: IO[Any]) -> Metadata:


### PR DESCRIPTION
#1110

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

add encoding when open changlelog_file

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes
