### PR TITLE
style: move codespell configuration to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,10 @@ repos:
     hooks:
       - id: codespell
         name: Run codespell to check for common misspellings in files
+        # config section is within pyproject.toml
         language: python
         types: [ text ]
-        args: [ "--write-changes", "--ignore-words-list", "asend" ]
-        exclude: "poetry.lock"
+        args: [ "--write-changes" ]
 
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v3.26.2 # automatically updated by Commitizen

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,8 @@ repos:
         language: python
         types: [ text ]
         args: [ "--write-changes" ]
+        additional_dependencies:
+          - tomli
 
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v3.26.2 # automatically updated by Commitizen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,3 +174,9 @@ warn_unused_configs = true
 [[tool.mypy.overrides]]
 module = "py.*"  # Legacy pytest dependencies
 ignore_missing_imports = true
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.svg,*.lock'
+check-hidden = true
+ignore-words-list = 'asend'


### PR DESCRIPTION
## Description

So people could just run "codespell" without pre-commit and have centralized configuration for tools (the others are already in pyproject.toml)

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->


## Checklist

- [N/A] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test

I did ;) 
```shell
❯ ./scripts/format
+ poetry run python -m ruff format commitizen tests
/home/yoh/venvs/dev3.11/bin/python: No module named ruff
❯ ./scripts/test
ImportError while loading conftest '/home/yoh/proj/misc/commitizen/tests/conftest.py'.
tests/conftest.py:10: in <module>
    from pytest_mock import MockerFixture
E   ModuleNotFoundError: No module named 'pytest_mock'
```

- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes
