### PR TITLE
docs: fix a few typos in CHANGELOG.md and .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: commitizen
   name: commitizen check
   description: >
-    Check whether the current commit message follows commiting rules. Allow
+    Check whether the current commit message follows committing rules. Allow
     empty commit messages by default, because they typically indicate to Git
     that the commit should be aborted.
   entry: cz check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -773,7 +773,7 @@
 
 ### Fix
 
-- **check**: filter out comment messege when checking
+- **check**: filter out comment message when checking
 
 ## v2.20.2 (2021-12-14)
 
@@ -1024,7 +1024,7 @@
 
 ### Fix
 
-- prevent prerelase from creating a bump when there are no commits
+- prevent prerelease from creating a bump when there are no commits
 
 ## v2.8.0 (2020-11-15)
 
@@ -1511,7 +1511,7 @@
 
 - new config system where each config type has its own class
 - **config**: add type annotation to config property
-- **config**: fix wrongly type annoated functions
+- **config**: fix wrongly type annotated functions
 - **config/ini_config**: move deprecation warning into class initialization
 - **config**: use add_path instead of directly assigning _path
 - **all**: replace all the _settings invoke with settings.update


### PR DESCRIPTION
I saw that there were typo fixes in CHANGELOG.md in the past (e.g. 90e2fd84b918153facf7a41d6ff40e2c75839c53) so decided to do again.

Ran `codespell -w` while on top of 

- #1136 

so to have proper config available.

Note that when I did `pre-commit run codespell --all` I think it ignored  CHANGELOG.md 

```
❯ pre-commit run codespell --all
Run codespell to check for common misspellings in files.......................Failed
- hook id: codespell
- files were modified by this hook

FIXED: .pre-commit-hooks.yaml

pre-commit run codespell --all  5.87s user 0.62s system 969% cpu 0.669 total
```

