### PR TITLE
ci: skip 'update-cli-screenshots' if no changes

### DIFF
--- a/.github/workflows/docspublish.yml
+++ b/.github/workflows/docspublish.yml
@@ -30,8 +30,13 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add docs/images/cli_help
-          git commit -m "docs(cli/screenshots): update CLI screenshots" -m "[skip ci]"
-          git push
+
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git commit -m "docs(cli/screenshots): update CLI screenshots" -m "[skip ci]"
+            git push
+          else
+            echo "No changes to commit. Skipping."
+          fi
 
   publish-documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Job `update-cli-screenshots` was failling when no changes detected on `docs/images/cli_help` and blocking other jobs to run.

Closes: #1138

## Checklist

- [ ] Add test cases to all the changes you introduce **_(not applicable)_**
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes **_(not applicable)_**

## Expected behavior
Job `update-cli-screenshots` must be skipped if no changes detected on `docs/images/cli_help`

## Screenshots

### Overview

![image](https://github.com/commitizen-tools/commitizen/assets/48416792/968f945f-969c-4716-8ba4-1c9f22483399)

### Explanation

I made two commits:

1. Commit with no changes related to CLI, so theres no changes detected from `update-cli-screenshots` (**114383c**).
2. Commit with changes on CLI (changed description of commands) (**b585baf**).

Note that commit with no changes exits with status 0 and don't creates the commit "docs(cli/screenshots): update CLI screenshots"

## More screenshots

### Workflow run for commit with no changes

![image](https://github.com/commitizen-tools/commitizen/assets/48416792/9a940595-655c-4f57-846c-61abb0d2f97f)

### Workflow run for commit with changes

![image](https://github.com/commitizen-tools/commitizen/assets/48416792/0c3a3788-2f16-4019-ad28-ff23f302499e)

