### PR TITLE
Shows deprecated warning before prompt questions

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -149,7 +149,7 @@ data = {
                     {
                         "name": ["-s", "--signoff"],
                         "action": "store_true",
-                        "help": "sign off the commit",
+                        "help": "sign off the commit (deprecated: use `cz commit -- -s` instead)",
                     },
                     {
                         "name": ["-a", "--all"],

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -287,6 +287,50 @@ def test_commit_command_with_always_signoff_enabled(config, mocker: MockFixture)
     success_mock.assert_called_once()
 
 
+@pytest.mark.usefixtures("staging_is_clean")
+def test_commit_command_with_signoff_option_prints_deprecated_warning(
+    config, mocker: MockFixture, capsys, file_regression
+):
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "",
+        "footer": "",
+    }
+
+    commit_mock = mocker.patch("commitizen.git.commit")
+    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
+    commands.Commit(config, {"signoff": True})()
+
+    _, err = capsys.readouterr()
+    file_regression.check(err, extension=".txt")
+
+
+@pytest.mark.usefixtures("staging_is_clean")
+def test_commit_command_without_signoff_option_dont_prints_deprecated_warning(
+    config, mocker: MockFixture, capsys, file_regression
+):
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "",
+        "footer": "",
+    }
+
+    commit_mock = mocker.patch("commitizen.git.commit")
+    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
+    commands.Commit(config, {"signoff": False})()
+
+    _, err = capsys.readouterr()
+    file_regression.check(err, extension=".txt")
+
+
 @pytest.mark.usefixtures("tmp_git_project")
 def test_commit_when_nothing_to_commit(config, mocker: MockFixture):
     is_staging_clean_mock = mocker.patch("commitizen.git.is_staging_clean")

--- a/tests/commands/test_commit_command/test_commit_command_shows_description_when_use_help_option.txt
+++ b/tests/commands/test_commit_command/test_commit_command_shows_description_when_use_help_option.txt
@@ -12,7 +12,8 @@ options:
   --write-message-to-file FILE_PATH
                         write message to file before committing (can be
                         combined with --dry-run)
-  -s, --signoff         sign off the commit
+  -s, --signoff         sign off the commit (deprecated: use `cz commit -- -s`
+                        instead)
   -a, --all             Tell the command to automatically stage files that
                         have been modified and deleted, but new files you have
                         not told Git about are not affected.

--- a/tests/commands/test_commit_command/test_commit_command_with_signoff_option_prints_deprecated_warning.txt
+++ b/tests/commands/test_commit_command/test_commit_command_with_signoff_option_prints_deprecated_warning.txt
@@ -1,0 +1,2 @@
+signoff mechanic is deprecated, please use `cz commit -- -s` instead.
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Shows deprecated warning before prompt questions to dev, for an better experience.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes **_(deprecated warning already in docs)_**

## Screenshots
### Shows deprecated warning before prompt questions
![image](https://github.com/commitizen-tools/commitizen/assets/48416792/64bff408-2efd-42e4-b994-b01d2f88eb22)

### Shows deprecated warning on command help text
![image](https://github.com/commitizen-tools/commitizen/assets/48416792/8886286a-7657-4454-8966-abeb9ba64f61)

### Dont' shows deprecated warning if uses `--signoff` option the right way
![image](https://github.com/commitizen-tools/commitizen/assets/48416792/b26639bd-2947-4272-b348-802e79789eab)

