### PR TITLE
master

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -44,7 +44,7 @@ def find_increment(
                 if increment == MAJOR:
                     break
 
-    return cast(Increment, increment)
+    return None if increment is None else Increment[increment]
 
 
 def update_version_in_files(

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -244,7 +244,7 @@ data = {
                     {
                         "name": ["--prerelease", "-pr"],
                         "help": "choose type of prerelease",
-                        "choices": ["alpha", "beta", "rc"],
+                        "choices": ["alpha", "beta", "rc", "none"],
                     },
                     {
                         "name": ["--devrelease", "-d"],

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -152,7 +152,7 @@ class Bump:
         dry_run: bool = self.arguments["dry_run"]
         is_yes: bool = self.arguments["yes"]
         increment: Increment | None = self.arguments["increment"]
-        prerelease: Prerelease | None = self.arguments["prerelease"]
+        prerelease: Prerelease | None = None if self.arguments["prerelease"] == "none" else self.arguments["prerelease"]
         devrelease: int | None = self.arguments["devrelease"]
         is_files_only: bool | None = self.arguments["files_only"]
         is_local_version: bool = self.arguments["local_version"]

--- a/commitizen/version_schemes.py
+++ b/commitizen/version_schemes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import re
 import sys
 import warnings
@@ -37,9 +38,21 @@ if TYPE_CHECKING:
         from typing import Self
 
 
-Increment: TypeAlias = Literal["MAJOR", "MINOR", "PATCH"]
-Prerelease: TypeAlias = Literal["alpha", "beta", "rc"]
 DEFAULT_VERSION_PARSER = r"v?(?P<version>([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?(\w+)?)"
+
+
+class Increment(enum.StrEnum):
+    MAJOR = "MAJOR"
+    MINOR = "MINOR"
+    PATCH = "PATCH"
+
+
+class Prerelease(enum.StrEnum):
+    alpha = "alpha"
+    beta = "beta"
+    rc = "rc"
+    none = "none"
+
 
 
 @runtime_checkable


### PR DESCRIPTION
- docs(github_actions.md): fix typo crendetial -> credential
- build(deps-dev): bump ruff from 0.1.13 to 0.1.14
- build(deps): bump argcomplete from 3.2.1 to 3.2.2
- build(deps-dev): bump mkdocs-material from 9.5.4 to 9.5.5
- docs: add cz-conventional-gitmoji to the third party docs
- build(deps-dev): bump mkdocs-material from 9.5.5 to 9.5.6
- build(deps-dev): bump pytest from 7.4.4 to 8.0.0
- build(deps-dev): bump ruff from 0.1.14 to 0.1.15
- ci(deps): bump codecov/codecov-action from 3 to 4
- chore: Declare support for Python 3.12 in PyPI classifiers
- feat: properly bump versions between prereleases (#799)
- bump: version 3.13.0 → 3.14.0
- build(deps-dev): bump ruff from 0.1.15 to 0.2.0
- build(deps-dev): bump black from 23.12.1 to 24.1.1
- style: format the code with the latest black and ruff
- style: update ruff config with the latest config format
- fix(scm): only search tags that are reachable by the current commit
- test(version_schemes): add tests for version sortability
- fix(bump): remove unused method
- bump: version 3.14.0 → 3.14.1
- build(deps-dev): bump mkdocs-material from 9.5.6 to 9.5.7
- build(deps-dev): bump ruff from 0.2.0 to 0.2.1
- build(deps-dev): bump mkdocs-material from 9.5.7 to 9.5.8
- build(deps-dev): bump mkdocs-material from 9.5.8 to 9.5.9
- build(deps-dev): bump black from 24.1.1 to 24.2.0
- feat(bump): functionality to add build-metadata to version string
- bump: version 3.14.1 → 3.15.0
- build(deps-dev): bump ruff from 0.2.1 to 0.2.2
- build(deps-dev): bump pytest from 8.0.0 to 8.0.1
- build(deps-dev): bump mkdocs-material from 9.5.9 to 9.5.10
- build(deps-dev): bump pytest from 8.0.1 to 8.0.2
- build(deps): bump typing-extensions from 4.9.0 to 4.10.0
- build(deps-dev): bump mkdocs-material from 9.5.10 to 9.5.11
- fix:  Improve type annotations
- feat(commands): add bump --exact
- fix(bump):  only get and validate commits if increment is not provided
- fix(bump): change --exact-increment to --increment-mode
- bump: version 3.15.0 → 3.16.0
- build(deps): bump tomlkit from 0.12.3 to 0.12.4
- feat(changelog): `changelog_message_build_hook` can remove message by returning a falsy value
- bump: version 3.16.0 → 3.17.0
- fix(bump): pre and post bump hooks were failing when an increment was provided (fix #1004)
- bump: version 3.17.0 → 3.17.1
- fix(changelog): ensure `changelog_message_builder_hook` can access and modify `change_type` (#1002)
- bump: version 3.17.1 → 3.17.2
- build(deps-dev): bump mkdocs-material from 9.5.11 to 9.5.13 (#1006)
- feat(changelog): `changelog_message_build_hook` can now generate multiple changelog entries from a single commit (#1003)
- bump: version 3.17.2 → 3.18.0
- build(deps): bump importlib-metadata from 7.0.1 to 7.0.2 (#1010)
- build(deps): bump argcomplete from 3.2.2 to 3.2.3 (#1009)
- fix(changelog): changelog hook was not called on dry run
- bump: version 3.18.0 → 3.18.1
- fix(git): force the default git locale on methods relying on parsing the output (#1012)
- bump: version 3.18.1 → 3.18.2
- build(deps-dev): bump pytest from 8.0.2 to 8.1.1 (#1014)
- build(deps): bump packaging from 23.2 to 24.0 (#1015)
- build(deps-dev): bump mypy from 1.8.0 to 1.9.0 (#1016)
- fix(warnings): all warnings should go to `stdout`
- bump: version 3.18.2 → 3.18.3
- build(deps-dev): bump ruff from 0.2.2 to 0.3.2
- build(deps-dev): bump types-deprecated from 1.2.9.20240106 to 1.2.9.20240311 (#1022)
- build(deps-dev): bump types-python-dateutil from 2.8.19.20240106 to 2.8.19.20240311 (#1021)
- build(deps-dev): bump types-pyyaml from 6.0.12.12 to 6.0.12.20240311 (#1020)
- fix(changelog): include latest change when dry run and incremental
- bump: version 3.18.3 → 3.18.4
- build(deps-dev): bump ruff from 0.3.2 to 0.3.3
- build(deps-dev): bump mkdocs-material from 9.5.13 to 9.5.14 (#1031)
- build(deps-dev): bump black from 24.2.0 to 24.3.0 (#1030)
- build(deps-dev): bump types-python-dateutil from 2.8.19.20240311 to 2.9.0.20240316 (#1029)
- feat(changelog): adds a `changelog_release_hook` called for each release in the changelog (#1018)
- bump: version 3.18.4 → 3.19.0
- feat(changelog): expose commits `sha1`, `author` and `author_email` in changelog tree (fix #987) (#1013)
- bump: version 3.19.0 → 3.20.0
- build(deps): bump importlib-metadata from 7.0.2 to 7.1.0
- build(deps-dev): bump pytest-mock from 3.12.0 to 3.14.0
- build(deps-dev): bump ruff from 0.3.3 to 0.3.4
- build(deps-dev): bump mkdocs-material from 9.5.14 to 9.5.15
- build(deps-dev): bump pytest-cov from 4.1.0 to 5.0.0
- feat(commit): add retry_after_failure config option and --no-retry flag
- test(commit): add tests for retry_after_failure config option and --no-retry flag
- refactor(utils): move backup path creation to utils
- refactor(git-hooks): make git hooks use get_backup_file_path
- refactor(commit): remove unused tempfile import
- test(commit): add test for --no-retry flag
- docs: add retry_after_failure config and retry options for commit command
- refactor(commit): use Optional[str] instead of str | None
- refactor(utils): convert git project root to posix path for backup file name
- test(utils): add test for get_backup_file_path when git.find_project_root returns None
- test(commit): create new test for backup file creation and use fixture for other retry test cases
- style: refine coding style based on reviews
- bump: version 3.20.0 → 3.21.0
- fix(command-init): "cz init" should list exisitng tag in reverse order
- bump: version 3.21.0 → 3.21.1
- fix(commitizen/git.py,-tests/test_git.py): Resolve tempfile path spaces issue in git commit function
- test(tests/test_git.py): use the IDs tool to clearly describe each test item
- bump: version 3.21.1 → 3.21.2
- refactor(defaults): move cz_conventional_commit defaults out of defaults.py
- bump: version 3.21.2 → 3.21.3
- build(deps-dev): bump mkdocs-material from 9.5.15 to 9.5.16
- docs(CHANGELOG): fix typo in the file
- build(deps-dev): bump ruff from 0.3.4 to 0.3.5
- build(deps-dev): bump mkdocs-material from 9.5.16 to 9.5.17
- build(pyproject.toml): add `rich` in dev.dependencies
- ci(scripts): a script to gen cli help screenshots
- docs(docs/images): add cli help screenshots (not used yet)
- build(deps): bump typing-extensions from 4.10.0 to 4.11.0
- ci(deps): bump peaceiris/actions-gh-pages from 2 to 4 (#1057)
- ci(github-actions): update env var used in doc publish actions (#1058)
- docs(images): update outdated gifs
- ci(github-actions): replace env with "with" for docpublish aciton
- feat(cli): add config option to specify config file path
- test(test_conf.py): add a test case for --config option
- test(test_conf.py): add test case for specify yaml and json files
- docs(README): add --config option in doc
- test(conf): add test case if config file is given in argument
- bump: version 3.21.3 → 3.22.0
- ci(github-actions): unify yaml style
- ci(github-actions): unpin poetry as #7611 has been closed
- ci(scripts): fix ill-formated code when running formatters
- ci(github-actions): replace "./scripts/test" with pre-commit for unifying the checking process
- ci(github-actions): skip no-commit-to-branch in CI which causes false negative when bumping version
- build(deps-dev): bump ruff from 0.3.5 to 0.3.6
- ci(github-actions): update peaceiris/actions-gh-pages to v4
- build(deps-dev): bump idna from 3.6 to 3.7
- build(deps): bump argcomplete from 3.2.3 to 3.3.0
- build(deps-dev): bump black from 24.3.0 to 24.4.0
- build(deps-dev): bump ruff from 0.3.6 to 0.3.7
- build(deps-dev): bump mkdocs-material from 9.5.17 to 9.5.18
- feat(bump): `version_files` now support glob patterns (fix #1067) (#1070)
- bump: version 3.22.0 → 3.23.0
- feat(schemes): adds support for SemVer 2.0 (dot in pre-releases) (fix #1025) (#1072)
- bump: version 3.23.0 → 3.24.0
- build(deps-dev): bump ruff from 0.3.7 to 0.4.0
- docs(getting_started): fix broken link
- build(deps-dev): bump ruff from 0.4.0 to 0.4.1
- build(deps-dev): bump mkdocs from 1.5.3 to 1.6.0
- build(deps-dev): bump mkdocs-material from 9.5.2 to 9.5.18
- build(deps-dev): bump mkdocs from 1.5.3 to 1.6.0
- build(deps-dev): bump black from 24.4.0 to 24.4.2
- build(deps-dev): bump mkdocs-material from 9.5.2 to 9.5.19
- build(deps-dev): bump ruff from 0.4.1 to 0.4.2
- build(deps-dev): bump mypy from 1.9.0 to 1.10.0
- build(deps-dev): bump pytest-xdist from 3.5.0 to 3.6.1
- build(deps): bump decli from 0.6.1 to 0.6.2
- build(deps-dev): bump pytest from 8.1.1 to 8.2.0
- build(deps-dev): bump mkdocs-material from 9.5.19 to 9.5.20
- feat: add an argument to limit the length of commit message
- fix: resolve test error by removing defaults
- refactor: check the length in Commit instead of Commitizen
- fix: strip the commit message for calculating length
- docs: emphasize the note on commit message length calculation
- refactor(commands/commit): replace comparison with chained comparison
- bump: version 3.24.0 → 3.25.0
- build(deps-dev): bump mkdocs-material from 9.5.20 to 9.5.21
- build(deps-dev): bump ruff from 0.4.2 to 0.4.3
- build(deps): bump jinja2 from 3.1.3 to 3.1.4
- build(deps): bump tomlkit from 0.12.4 to 0.12.5
- build(deps-dev): bump ruff from 0.4.3 to 0.4.4
- build(deps-dev): bump mkdocs-material from 9.5.21 to 9.5.22
- refactor: strip possessive from note about ci option
- bump: version 3.25.0 → 3.25.1
- docs: fix missing links, reorganize documentation and replace command help messages with images
- docs: initial documentation for undocumented commands
- build(deps-dev): bump mkdocs-material from 9.5.22 to 9.5.23
- feat(ci/cd): automates the generation of CLI screenshots
- bump: version 3.25.1 → 3.26.0
- build(deps-dev): bump pytest from 8.2.0 to 8.2.1
- docs(cli/screenshots) update CLI screenshots
- ci(workflow): move 'generate_cli_screenshots' steps to 'docspublish'
- ci: exclude *.svg files from trailing whitespace hook
- ci(docpublish): reword cli screenshot generation commit message
- docs(cli/screenshots): update CLI screenshots
- style: add py.typed file
- docs(cli/screenshots): update CLI screenshots
- fix(cli/commands): add description for subcommands
- refactor(tests/commands): move "other" tests for the correspondent file
- refactor(KNOWN_SCHEMES): replace set comprehension for list comprehension
- test(commands): add skip_if_below_py_3_10 as the message of argument changes in python 3.10
- bump: version 3.26.0 → 3.26.1
- docs(cli/screenshots): update CLI screenshots
- docs: fix a few typos in CHANGELOG.md and .pre-commit-hooks.yaml
- fix(base.py): add encoding when open changlelog_file
- bump: version 3.26.1 → 3.26.2
- feat(config_files): add suport for "cz.toml" config file
- test: extend tests for 'TestJsonConfig' and 'TestYamlConfig'
- bump: version 3.26.2 → 3.27.0
- build: add I into ruff lint and add "ruff check --fix" to format script to enable import sorting
- style: sort import
- build: remove black and use only ruff
- docs(CHANGELOG): fix typo
- style: move codespell configuration to pyproject.toml
- ci: add tomli as additional dependency for codespell since config now is in pyproject.toml
- ci: skip 'update-cli-screenshots' if no changes
- build(deps-dev): bump ruff from 0.4.4 to 0.4.5
- build(deps): bump typing-extensions from 4.11.0 to 4.12.0
- build(deps-dev): bump mkdocs-material from 9.5.24 to 9.5.25
- build(deps-dev): bump ruff from 0.4.5 to 0.4.6
- build(deps): bump typing-extensions from 4.12.0 to 4.12.1
- build(deps-dev): bump ruff from 0.4.6 to 0.4.7
- build(deps-dev): bump pytest from 8.2.1 to 8.2.2
- build(deps-dev): bump ruff from 0.4.7 to 0.4.8
- build(deps): bump packaging from 24.0 to 24.1
- build(deps): bump typing-extensions from 4.12.1 to 4.12.2
- build(deps-dev): bump mkdocs-material from 9.5.25 to 9.5.26
- feat: enable --prerelease none for CI/CD
