### PR TITLE
build(deps): remove `importlib_metadata` for Python >=3.10

### DIFF
--- a/commitizen/changelog_formats/__init__.py
+++ b/commitizen/changelog_formats/__init__.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import sys
 from typing import ClassVar, Protocol
 
-import importlib_metadata as metadata
+if sys.version_info >= (3, 10):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 from commitizen.changelog import Metadata
 from commitizen.config.base_config import BaseConfig

--- a/commitizen/cz/__init__.py
+++ b/commitizen/cz/__init__.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import importlib
 import pkgutil
+import sys
 import warnings
 from typing import Iterable
 
-import importlib_metadata as metadata
+if sys.version_info >= (3, 10):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 from commitizen.cz.base import BaseCommitizen
 

--- a/commitizen/providers/__init__.py
+++ b/commitizen/providers/__init__.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import sys
 from typing import cast
 
-import importlib_metadata as metadata
+if sys.version_info >= (3, 10):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
 
 from commitizen.config.base_config import BaseConfig
 from commitizen.exceptions import VersionProviderUnknown

--- a/commitizen/version_schemes.py
+++ b/commitizen/version_schemes.py
@@ -15,7 +15,11 @@ from typing import (
     runtime_checkable,
 )
 
-import importlib_metadata as metadata
+if sys.version_info >= (3, 10):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
 from packaging.version import InvalidVersion  # noqa: F401: Rexpose the common exception
 from packaging.version import Version as _BaseVersion
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1784,4 +1784,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "ae23361204d1cc38d6ea93cceaa273548efffef705c09120767bb4e79196181a"
+content-hash = "5c50eb89395cfaea68afc05bf419017823990724552f6d6fa25d426122fc9525"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ argcomplete = ">=1.12.1,<3.5"
 typing-extensions = { version = "^4.0.1", python = "<3.8" }
 charset-normalizer = ">=2.1.0,<4"
 # Use the Python 3.11 and 3.12 compatible API: https://github.com/python/importlib_metadata#compatibility
-importlib_metadata = { version = ">=4.13,<8"}
+importlib_metadata = { version = ">=4.13,<8", python = "<3.10"}
 
 [tool.poetry.group.dev.dependencies]
 # dev tool

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,7 +1,11 @@
 import sys
 from textwrap import dedent
 
-import importlib_metadata as metadata
+if sys.version_info >= (3, 10):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
 import pytest
 
 from commitizen import BaseCommitizen, defaults, factory

--- a/tests/test_version_schemes.py
+++ b/tests/test_version_schemes.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-import importlib_metadata as metadata
+import sys
+
+if sys.version_info >= (3, 10):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
 import pytest
 from pytest_mock import MockerFixture
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
[importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html) as used by `commitizen` was first shipped with Python 3.10. The backport from [importlib_metadata](https://importlib-metadata.readthedocs.io/) is only required for Python <3.10.

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
`commitizen` no longer has a direct "runtime" dependency on the `importlib_metadata` backport for Python >=3.10, while using the backport for Python <3.10.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
