### PR TITLE
feat(bump): add functionality to write the next version to stdout

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -353,6 +353,12 @@ data = {
                         "help": "Add additional build-metadata to the version-number",
                         "default": None,
                     },
+                    {
+                        "name": ["--get-next"],
+                        "action": "store_true",
+                        "help": "Determine the next version and write to stdout",
+                        "default": False,
+                    },
                 ],
             },
             {

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -67,6 +67,10 @@ class DryRunExit(ExpectedExit):
     pass
 
 
+class GetNextExit(ExpectedExit):
+    pass
+
+
 class NoneIncrementExit(CommitizenException):
     exit_code = ExitCode.NO_INCREMENT
 

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -297,8 +297,26 @@ cz bump --get-next
 Will output the next version, e.g. `1.2.3`. This can be useful for determining the next version based in CI for non
 production environments/builds.
 
-It will raise a `NoneIncrementExit` if the commits found are not eligible for a version bump.
-See [avoid raising errors](#avoid-raising-errors) for information on suppressing this exit.
+This behavior differs from the `--dry-run` flag. The `--dry-run` flag provides a more detailed output and can also show
+the changes as they would appear in the changelog file.
+
+The following output is the result of `cz bump --dry-run`:
+
+```
+bump: version 3.28.0 → 3.29.0
+tag to create: v3.29.0
+increment detected: MINOR
+```
+
+The following output is the result of `cz bump --get-next`:
+
+```
+3.29.0
+```
+
+The `--get-next` flag will raise a `NoneIncrementExit` if the found commits are not eligible for a version bump.
+
+For information on how to suppress this exit, see [avoid raising errors](#avoid-raising-errors).
 
 ## Avoid raising errors
 

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -294,7 +294,7 @@ and `manual version`.
 cz bump --get-next
 ```
 
-Will output the next version, e.g. `1.2.3`. This can be useful for determining the next version based in CI for non
+Will output the next version, e.g., `1.2.3`. This can be useful for determining the next version based on CI for non
 production environments/builds.
 
 This behavior differs from the `--dry-run` flag. The `--dry-run` flag provides a more detailed output and can also show

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -285,6 +285,21 @@ You should normally not use this functionality, but if you decide to do, keep in
 * Version `1.2.3+a`, and `1.2.3+b` are the same version! Tools should not use the string after `+` for version calculation. This is probably not a guarantee (example in helm) even tho it is in the spec.
 * It might be problematic having the metadata in place when doing upgrades depending on what tool you use.
 
+### `--get-next`
+
+Provides a way to determine the next version and write it to stdout. This parameter is not compatible with `--changelog`
+and `manual version`.
+
+```bash
+cz bump --get-next
+```
+
+Will output the next version, e.g. `1.2.3`. This can be useful for determining the next version based in CI for non
+production environments/builds.
+
+It will raise a `NoneIncrementExit` if the commits found are not eligible for a version bump.
+See [avoid raising errors](#avoid-raising-errors) for information on suppressing this exit.
+
 ## Avoid raising errors
 
 Some situations from commitizen raise an exit code different than 0.

--- a/tests/commands/test_bump_command/test_bump_command_shows_description_when_use_help_option.txt
+++ b/tests/commands/test_bump_command/test_bump_command_shows_description_when_use_help_option.txt
@@ -10,7 +10,7 @@ usage: cz bump [-h] [--dry-run] [--files-only] [--local-version] [--changelog]
                [--file-name FILE_NAME] [--prerelease-offset PRERELEASE_OFFSET]
                [--version-scheme {pep440,semver,semver2}]
                [--version-type {pep440,semver,semver2}]
-               [--build-metadata BUILD_METADATA]
+               [--build-metadata BUILD_METADATA] [--get-next]
                [MANUAL_VERSION]
 
 bump semantic version based on the git log
@@ -77,3 +77,4 @@ options:
                         Deprecated, use --version-scheme
   --build-metadata BUILD_METADATA
                         Add additional build-metadata to the version-number
+  --get-next            Determine the next version and write to stdout


### PR DESCRIPTION
Adds a --get-next flag which determines the next version and writes it to stdout.

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
The new `--get-next` flag can be used to determine the next version based on the available commits, and output it to stdout. This can be useful in CI, for example to determine the version for a preview build image.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
When provided, the `--get-next` flag makes commitizen behave similarly to `--dry-run`, it doesn't change any files and it doesn't create a tag. It determines the next version the same way a dry run does. It writes the next version to stdout, with no other output. 

The flag can't be used with `--changelog`, `--changelog-to-stdout` and `MANUAL_VERSION`, a `NotAllowed` exception will be raised if these options are provided together with `--get-next`.

An example use case is assigning the output to a variable in CI.

## Steps to Test This Pull Request

1. Make sure you have fetched tags locally
2. Add a commit that is eligible for a bump
3. Run `poetry run cz bump --get-next`
4. Compare the output with `poetry run cz bump --dry-run`

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
