### PR TITLE
fix(commit): resolve 'always_signoff' configuration and '-s' CLI issues

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -168,6 +168,12 @@ data = {
                         "default": 0,
                         "help": "length limit of the commit message; 0 for no limit",
                     },
+                    {
+                        "name": ["--"],
+                        "action": "store_true",
+                        "dest": "double_dash",
+                        "help": "Positional arguments separator (recommended)",
+                    },
                 ],
             },
             {

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -134,9 +134,8 @@ class Commit:
         if dry_run:
             raise DryRunExit()
 
-        signoff: bool = (
-            self.arguments.get("signoff") or self.config.settings["always_signoff"]
-        )
+        always_signoff: bool = self.config.settings["always_signoff"]
+        signoff: bool = self.arguments.get("signoff")
 
         extra_args = self.arguments.get("extra_cli_args", "")
 
@@ -144,6 +143,8 @@ class Commit:
             out.warn(
                 "signoff mechanic is deprecated, please use `cz commit -- -s` instead."
             )
+
+        if always_signoff or signoff:
             extra_args = f"{extra_args} -s".strip()
 
         c = git.commit(m, args=extra_args)

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -138,13 +138,13 @@ class Commit:
             self.arguments.get("signoff") or self.config.settings["always_signoff"]
         )
 
+        extra_args = self.arguments.get("extra_cli_args", "")
+
         if signoff:
             out.warn(
                 "signoff mechanic is deprecated, please use `cz commit -- -s` instead."
             )
-            extra_args = self.arguments.get("extra_cli_args", "--") + " -s"
-        else:
-            extra_args = self.arguments.get("extra_cli_args", "")
+            extra_args = f"{extra_args} -s".strip()
 
         c = git.commit(m, args=extra_args)
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,13 +51,13 @@ cz c
 Run in the terminal
 
 ```bash
-cz commit --signoff
+cz commit -- --signoff
 ```
 
 or the shortcut
 
 ```bash
-cz commit -s
+cz commit -- -s
 ```
 
 ### Get project version

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -260,7 +260,7 @@ def test_commit_command_with_signoff_option(config, mocker: MockFixture):
 
     commands.Commit(config, {"signoff": True})()
 
-    commit_mock.assert_called_once_with(ANY, args="-- -s")
+    commit_mock.assert_called_once_with(ANY, args="-s")
     success_mock.assert_called_once()
 
 
@@ -283,7 +283,32 @@ def test_commit_command_with_always_signoff_enabled(config, mocker: MockFixture)
     config.settings["always_signoff"] = True
     commands.Commit(config, {})()
 
-    commit_mock.assert_called_once_with(ANY, args="-- -s")
+    commit_mock.assert_called_once_with(ANY, args="-s")
+    success_mock.assert_called_once()
+
+
+@pytest.mark.usefixtures("staging_is_clean")
+def test_commit_command_with_gpgsign_and_always_signoff_enabled(
+    config, mocker: MockFixture
+):
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "",
+        "footer": "",
+    }
+
+    commit_mock = mocker.patch("commitizen.git.commit")
+    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
+    success_mock = mocker.patch("commitizen.out.success")
+
+    config.settings["always_signoff"] = True
+    commands.Commit(config, {"extra_cli_args": "-S"})()
+
+    commit_mock.assert_called_once_with(ANY, args="-S -s")
     success_mock.assert_called_once()
 
 

--- a/tests/commands/test_commit_command/test_commit_command_shows_description_when_use_help_option.txt
+++ b/tests/commands/test_commit_command/test_commit_command_shows_description_when_use_help_option.txt
@@ -1,6 +1,6 @@
 usage: cz commit [-h] [--retry] [--no-retry] [--dry-run]
                  [--write-message-to-file FILE_PATH] [-s] [-a] [-e]
-                 [-l MESSAGE_LENGTH_LIMIT]
+                 [-l MESSAGE_LENGTH_LIMIT] [--]
 
 create new commit
 
@@ -19,3 +19,4 @@ options:
   -e, --edit            edit the commit message before committing
   -l, --message-length-limit MESSAGE_LENGTH_LIMIT
                         length limit of the commit message; 0 for no limit
+  --                    Positional arguments separator (recommended)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,12 +35,19 @@ def git_sandbox(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     gitconfig = tmp_path / ".git" / "config"
     if not gitconfig.parent.exists():
         gitconfig.parent.mkdir()
+
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+
     r = cmd.run(f"git config --file {gitconfig} user.name {SIGNER}")
     assert r.return_code == 0, r.err
     r = cmd.run(f"git config --file {gitconfig} user.email {SIGNER_MAIL}")
     assert r.return_code == 0, r.err
-    cmd.run("git config --global init.defaultBranch master")
+
+    r = cmd.run(f"git config --file {gitconfig} safe.directory '*'")
+    assert r.return_code == 0, r.err
+
+    r = cmd.run("git config --global init.defaultBranch master")
+    assert r.return_code == 0, r.err
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

The `always_signoff` configuration or the CLI `-s` argument fail upon `git commit` call
due to the passed syntax being `git commit -- -s` rather than `git commit -s`.

The `--` is needed only on the commitizen CLI, and if no git argument is passed, the `--` should not be forced.

> signoff mechanic is deprecated, please use `cz commit -- -s` instead.
> fatal: /tmp/...: '/tmp/... is outside repository at '...'

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior

* Warning and successful if `-s`
* Warning and successful if `-s --`
* No warning and successful if `-- -s`
* No warning and successful if `-- -s`
* No warning and successful with `always_signoff: true`
* No warning and successful if `--` with `always_signoff: true`
* No warning and successful if `-s` with `always_signoff: true`
* No warning and successful if `-s --` with `always_signoff: true`
* No warning and successful if `-- -s` with `always_signoff: true`

## Steps to Test This Pull Request

**.cz.yaml:**
```yaml
---
commitizen:

  # commitizen configurations
  always_signoff: true
```

* `cz c`
* `cz c --`
* `cz c -s`
* `cz c -s --`
* `cz c -- s`

## Additional context

Related to issue #1135 and #1146

**Tested with the `python:3.12` Docker image:** 
```bash
docker run -i --rm --entrypoint bash python:3.12 <<EOF
{
  git clone -b signoff https://github.com/AdrianDC/commitizen.git /tmp/commitizen
  cd /tmp/commitizen/
  pip install poetry
  poetry install
  ./scripts/format
  ./scripts/test
}
EOF
```