### PR TITLE
feat(commit): add '--allow-empty' flag to commit command

### DIFF
--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -93,6 +93,10 @@ class Commit:
         return message
 
     def __call__(self):
+        extra_args: str = self.arguments.get("extra_cli_args", "")
+
+        allow_empty: bool = "--allow-empty" in extra_args
+
         dry_run: bool = self.arguments.get("dry_run")
         write_message_to_file: bool = self.arguments.get("write_message_to_file")
         manual_edit: bool = self.arguments.get("edit")
@@ -101,7 +105,7 @@ class Commit:
         if is_all:
             c = git.add("-u")
 
-        if git.is_staging_clean() and not dry_run:
+        if git.is_staging_clean() and not (dry_run or allow_empty):
             raise NothingToCommitError("No files added to staging!")
 
         if write_message_to_file is not None and write_message_to_file.is_dir():
@@ -136,8 +140,6 @@ class Commit:
 
         always_signoff: bool = self.config.settings["always_signoff"]
         signoff: bool = self.arguments.get("signoff")
-
-        extra_args = self.arguments.get("extra_cli_args", "")
 
         if signoff:
             out.warn(

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -325,6 +325,55 @@ def test_commit_when_nothing_to_commit(config, mocker: MockFixture):
 
 
 @pytest.mark.usefixtures("staging_is_clean")
+def test_commit_with_allow_empty(config, mocker: MockFixture):
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "closes #21",
+        "footer": "",
+    }
+
+    commit_mock = mocker.patch("commitizen.git.commit")
+    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
+    success_mock = mocker.patch("commitizen.out.success")
+
+    commands.Commit(config, {"extra_cli_args": "--allow-empty"})()
+
+    commit_mock.assert_called_with(
+        "feat: user created\n\ncloses #21", args="--allow-empty"
+    )
+    success_mock.assert_called_once()
+
+
+@pytest.mark.usefixtures("staging_is_clean")
+def test_commit_with_signoff_and_allow_empty(config, mocker: MockFixture):
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "closes #21",
+        "footer": "",
+    }
+
+    commit_mock = mocker.patch("commitizen.git.commit")
+    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
+    success_mock = mocker.patch("commitizen.out.success")
+
+    config.settings["always_signoff"] = True
+    commands.Commit(config, {"extra_cli_args": "--allow-empty"})()
+
+    commit_mock.assert_called_with(
+        "feat: user created\n\ncloses #21", args="--allow-empty -s"
+    )
+    success_mock.assert_called_once()
+
+
+@pytest.mark.usefixtures("staging_is_clean")
 def test_commit_when_customized_expected_raised(config, mocker: MockFixture, capsys):
     _err = ValueError()
     _err.__context__ = CzException("This is the root custom err")


### PR DESCRIPTION
## Description

**feat(commit): add '--allow-empty' flag to commit command**

- Reworked over #1206 (commits follow-up)
- Reimplementation of #592, authorship preserved

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior

Allow to invoke cz and create a commit without any change in it

## Steps to Test This Pull Request

```bash
git cz c --allow-empty
```

## Additional context

-