### PR TITLE
feat(commands)!: deprecate '-s' signoff parameter

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -147,11 +147,6 @@ data = {
                         "help": "write message to file before committing (can be combined with --dry-run)",
                     },
                     {
-                        "name": ["-s", "--signoff"],
-                        "action": "store_true",
-                        "help": "sign off the commit",
-                    },
-                    {
                         "name": ["-a", "--all"],
                         "action": "store_true",
                         "help": "Tell the command to automatically stage files that have been modified and deleted, but new files you have not told Git about are not affected.",

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -162,6 +162,12 @@ data = {
                         "default": 0,
                         "help": "length limit of the commit message; 0 for no limit",
                     },
+                    {
+                        "name": ["--"],
+                        "action": "store_true",
+                        "dest": "double_dash",
+                        "help": "Positional arguments separator (recommended)",
+                    },
                 ],
             },
             {

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -110,9 +110,8 @@ class Commit:
         if dry_run:
             raise DryRunExit()
 
-        signoff: bool = (
-            self.arguments.get("signoff") or self.config.settings["always_signoff"]
-        )
+        always_signoff: bool = self.config.settings["always_signoff"]
+        signoff: bool = self.arguments.get("signoff")
 
         extra_args = self.arguments.get("extra_cli_args", "")
 
@@ -120,6 +119,8 @@ class Commit:
             out.warn(
                 "signoff mechanic is deprecated, please use `cz commit -- -s` instead."
             )
+
+        if always_signoff or signoff:
             extra_args = f"{extra_args} -s".strip()
 
         c = git.commit(m, args=extra_args)

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -114,13 +114,13 @@ class Commit:
             self.arguments.get("signoff") or self.config.settings["always_signoff"]
         )
 
+        extra_args = self.arguments.get("extra_cli_args", "")
+
         if signoff:
             out.warn(
                 "signoff mechanic is deprecated, please use `cz commit -- -s` instead."
             )
-            extra_args = self.arguments.get("extra_cli_args", "--") + " -s"
-        else:
-            extra_args = self.arguments.get("extra_cli_args", "")
+            extra_args = f"{extra_args} -s".strip()
 
         c = git.commit(m, args=extra_args)
 

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -111,16 +111,10 @@ class Commit:
             raise DryRunExit()
 
         always_signoff: bool = self.config.settings["always_signoff"]
-        signoff: bool = self.arguments.get("signoff")
 
         extra_args = self.arguments.get("extra_cli_args", "")
 
-        if signoff:
-            out.warn(
-                "signoff mechanic is deprecated, please use `cz commit -- -s` instead."
-            )
-
-        if always_signoff or signoff:
+        if always_signoff:
             extra_args = f"{extra_args} -s".strip()
 
         c = git.commit(m, args=extra_args)

--- a/docs/commands/commit.md
+++ b/docs/commands/commit.md
@@ -27,11 +27,8 @@ cz commit <commitizen-args> -- <git-cli-args>
 
 # e.g., cz commit --dry-run -- -a -S
 ```
-For example, using the `-S` option on `git commit` to sign a commit is now commitizen compatible: `cz c -- -S`
 
-!!! note
-    Deprecation warning: A commit can be signed off using `cz commit --signoff` or the shortcut `cz commit -s`.
-    This syntax is now deprecated in favor of the new `cz commit -- -s` syntax.
+For example, using the `-S` option on `git commit` to sign a commit is now commitizen compatible: `cz c -- -S`
 
 ### Retry
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -51,13 +51,13 @@ cz c
 Run in the terminal
 
 ```bash
-cz commit --signoff
+cz commit -- --signoff
 ```
 
 or the shortcut
 
 ```bash
-cz commit -s
+cz commit -- -s
 ```
 
 ### Get project version

--- a/poetry.lock
+++ b/poetry.lock
@@ -1425,29 +1425,29 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ruff"
-version = "0.6.1"
+version = "0.6.2"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.6.1-py3-none-linux_armv6l.whl", hash = "sha256:b4bb7de6a24169dc023f992718a9417380301b0c2da0fe85919f47264fb8add9"},
-    {file = "ruff-0.6.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:45efaae53b360c81043e311cdec8a7696420b3d3e8935202c2846e7a97d4edae"},
-    {file = "ruff-0.6.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bc60c7d71b732c8fa73cf995efc0c836a2fd8b9810e115be8babb24ae87e0850"},
-    {file = "ruff-0.6.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c7477c3b9da822e2db0b4e0b59e61b8a23e87886e727b327e7dcaf06213c5cf"},
-    {file = "ruff-0.6.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a0af7ab3f86e3dc9f157a928e08e26c4b40707d0612b01cd577cc84b8905cc9"},
-    {file = "ruff-0.6.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:392688dbb50fecf1bf7126731c90c11a9df1c3a4cdc3f481b53e851da5634fa5"},
-    {file = "ruff-0.6.1-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5278d3e095ccc8c30430bcc9bc550f778790acc211865520f3041910a28d0024"},
-    {file = "ruff-0.6.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fe6d5f65d6f276ee7a0fc50a0cecaccb362d30ef98a110f99cac1c7872df2f18"},
-    {file = "ruff-0.6.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2e0dd11e2ae553ee5c92a81731d88a9883af8db7408db47fc81887c1f8b672e"},
-    {file = "ruff-0.6.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d812615525a34ecfc07fd93f906ef5b93656be01dfae9a819e31caa6cfe758a1"},
-    {file = "ruff-0.6.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:faaa4060f4064c3b7aaaa27328080c932fa142786f8142aff095b42b6a2eb631"},
-    {file = "ruff-0.6.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:99d7ae0df47c62729d58765c593ea54c2546d5de213f2af2a19442d50a10cec9"},
-    {file = "ruff-0.6.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9eb18dfd7b613eec000e3738b3f0e4398bf0153cb80bfa3e351b3c1c2f6d7b15"},
-    {file = "ruff-0.6.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c62bc04c6723a81e25e71715aa59489f15034d69bf641df88cb38bdc32fd1dbb"},
-    {file = "ruff-0.6.1-py3-none-win32.whl", hash = "sha256:9fb4c4e8b83f19c9477a8745e56d2eeef07a7ff50b68a6998f7d9e2e3887bdc4"},
-    {file = "ruff-0.6.1-py3-none-win_amd64.whl", hash = "sha256:c2ebfc8f51ef4aca05dad4552bbcf6fe8d1f75b2f6af546cc47cc1c1ca916b5b"},
-    {file = "ruff-0.6.1-py3-none-win_arm64.whl", hash = "sha256:3bc81074971b0ffad1bd0c52284b22411f02a11a012082a76ac6da153536e014"},
-    {file = "ruff-0.6.1.tar.gz", hash = "sha256:af3ffd8c6563acb8848d33cd19a69b9bfe943667f0419ca083f8ebe4224a3436"},
+    {file = "ruff-0.6.2-py3-none-linux_armv6l.whl", hash = "sha256:5c8cbc6252deb3ea840ad6a20b0f8583caab0c5ef4f9cca21adc5a92b8f79f3c"},
+    {file = "ruff-0.6.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:17002fe241e76544448a8e1e6118abecbe8cd10cf68fde635dad480dba594570"},
+    {file = "ruff-0.6.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3dbeac76ed13456f8158b8f4fe087bf87882e645c8e8b606dd17b0b66c2c1158"},
+    {file = "ruff-0.6.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:094600ee88cda325988d3f54e3588c46de5c18dae09d683ace278b11f9d4d534"},
+    {file = "ruff-0.6.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:316d418fe258c036ba05fbf7dfc1f7d3d4096db63431546163b472285668132b"},
+    {file = "ruff-0.6.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d72b8b3abf8a2d51b7b9944a41307d2f442558ccb3859bbd87e6ae9be1694a5d"},
+    {file = "ruff-0.6.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2aed7e243be68487aa8982e91c6e260982d00da3f38955873aecd5a9204b1d66"},
+    {file = "ruff-0.6.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d371f7fc9cec83497fe7cf5eaf5b76e22a8efce463de5f775a1826197feb9df8"},
+    {file = "ruff-0.6.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8f310d63af08f583363dfb844ba8f9417b558199c58a5999215082036d795a1"},
+    {file = "ruff-0.6.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7db6880c53c56addb8638fe444818183385ec85eeada1d48fc5abe045301b2f1"},
+    {file = "ruff-0.6.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1175d39faadd9a50718f478d23bfc1d4da5743f1ab56af81a2b6caf0a2394f23"},
+    {file = "ruff-0.6.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b939f9c86d51635fe486585389f54582f0d65b8238e08c327c1534844b3bb9a"},
+    {file = "ruff-0.6.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d0d62ca91219f906caf9b187dea50d17353f15ec9bb15aae4a606cd697b49b4c"},
+    {file = "ruff-0.6.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7438a7288f9d67ed3c8ce4d059e67f7ed65e9fe3aa2ab6f5b4b3610e57e3cb56"},
+    {file = "ruff-0.6.2-py3-none-win32.whl", hash = "sha256:279d5f7d86696df5f9549b56b9b6a7f6c72961b619022b5b7999b15db392a4da"},
+    {file = "ruff-0.6.2-py3-none-win_amd64.whl", hash = "sha256:d9f3469c7dd43cd22eb1c3fc16926fb8258d50cb1b216658a07be95dd117b0f2"},
+    {file = "ruff-0.6.2-py3-none-win_arm64.whl", hash = "sha256:f28fcd2cd0e02bdf739297516d5643a945cc7caf09bd9bcb4d932540a5ea4fa9"},
+    {file = "ruff-0.6.2.tar.gz", hash = "sha256:239ee6beb9e91feb8e0ec384204a763f36cb53fb895a1a364618c6abb076b3be"},
 ]
 
 [[package]]

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -260,7 +260,7 @@ def test_commit_command_with_signoff_option(config, mocker: MockFixture):
 
     commands.Commit(config, {"signoff": True})()
 
-    commit_mock.assert_called_once_with(ANY, args="-- -s")
+    commit_mock.assert_called_once_with(ANY, args="-s")
     success_mock.assert_called_once()
 
 
@@ -283,7 +283,32 @@ def test_commit_command_with_always_signoff_enabled(config, mocker: MockFixture)
     config.settings["always_signoff"] = True
     commands.Commit(config, {})()
 
-    commit_mock.assert_called_once_with(ANY, args="-- -s")
+    commit_mock.assert_called_once_with(ANY, args="-s")
+    success_mock.assert_called_once()
+
+
+@pytest.mark.usefixtures("staging_is_clean")
+def test_commit_command_with_gpgsign_and_always_signoff_enabled(
+    config, mocker: MockFixture
+):
+    prompt_mock = mocker.patch("questionary.prompt")
+    prompt_mock.return_value = {
+        "prefix": "feat",
+        "subject": "user created",
+        "scope": "",
+        "is_breaking_change": False,
+        "body": "",
+        "footer": "",
+    }
+
+    commit_mock = mocker.patch("commitizen.git.commit")
+    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
+    success_mock = mocker.patch("commitizen.out.success")
+
+    config.settings["always_signoff"] = True
+    commands.Commit(config, {"extra_cli_args": "-S"})()
+
+    commit_mock.assert_called_once_with(ANY, args="-S -s")
     success_mock.assert_called_once()
 
 

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -243,28 +243,6 @@ def test_commit_command_with_invalid_write_message_to_file_option(
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_with_signoff_option(config, mocker: MockFixture):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "",
-        "footer": "",
-    }
-
-    commit_mock = mocker.patch("commitizen.git.commit")
-    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
-    success_mock = mocker.patch("commitizen.out.success")
-
-    commands.Commit(config, {"signoff": True})()
-
-    commit_mock.assert_called_once_with(ANY, args="-s")
-    success_mock.assert_called_once()
-
-
-@pytest.mark.usefixtures("staging_is_clean")
 def test_commit_command_with_always_signoff_enabled(config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {

--- a/tests/commands/test_commit_command/test_commit_command_shows_description_when_use_help_option.txt
+++ b/tests/commands/test_commit_command/test_commit_command_shows_description_when_use_help_option.txt
@@ -1,6 +1,6 @@
 usage: cz commit [-h] [--retry] [--no-retry] [--dry-run]
                  [--write-message-to-file FILE_PATH] [-s] [-a]
-                 [-l MESSAGE_LENGTH_LIMIT]
+                 [-l MESSAGE_LENGTH_LIMIT] [--]
 
 create new commit
 
@@ -18,3 +18,4 @@ options:
                         not told Git about are not affected.
   -l, --message-length-limit MESSAGE_LENGTH_LIMIT
                         length limit of the commit message; 0 for no limit
+  --                    Positional arguments separator (recommended)

--- a/tests/commands/test_commit_command/test_commit_command_shows_description_when_use_help_option.txt
+++ b/tests/commands/test_commit_command/test_commit_command_shows_description_when_use_help_option.txt
@@ -1,5 +1,5 @@
 usage: cz commit [-h] [--retry] [--no-retry] [--dry-run]
-                 [--write-message-to-file FILE_PATH] [-s] [-a]
+                 [--write-message-to-file FILE_PATH] [-a]
                  [-l MESSAGE_LENGTH_LIMIT] [--]
 
 create new commit
@@ -12,7 +12,6 @@ options:
   --write-message-to-file FILE_PATH
                         write message to file before committing (can be
                         combined with --dry-run)
-  -s, --signoff         sign off the commit
   -a, --all             Tell the command to automatically stage files that
                         have been modified and deleted, but new files you have
                         not told Git about are not affected.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,12 +35,19 @@ def git_sandbox(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     gitconfig = tmp_path / ".git" / "config"
     if not gitconfig.parent.exists():
         gitconfig.parent.mkdir()
+
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+
     r = cmd.run(f"git config --file {gitconfig} user.name {SIGNER}")
     assert r.return_code == 0, r.err
     r = cmd.run(f"git config --file {gitconfig} user.email {SIGNER_MAIL}")
     assert r.return_code == 0, r.err
-    cmd.run("git config --global init.defaultBranch master")
+
+    r = cmd.run(f"git config --file {gitconfig} safe.directory '*'")
+    assert r.return_code == 0, r.err
+
+    r = cmd.run("git config --global init.defaultBranch master")
+    assert r.return_code == 0, r.err
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

**feat(commands)!: deprecate '-s' signoff parameter**

Follow-up to #1206, deprecating -s for major v4.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior

-

## Steps to Test This Pull Request

-

## Additional context

-