### PR TITLE
feat: add custom validation

### DIFF
--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
 import sys
 from typing import Any
 
@@ -65,7 +64,7 @@ class Check:
         """Validate if commit messages follows the conventional pattern.
 
         Raises:
-            InvalidCommitMessageError: if the commit provided not follows the conventional pattern
+            InvalidCommitMessageError: if the commit provided does not follow the conventional pattern
         """
         commits = self._get_commits()
         if not commits:
@@ -73,22 +72,22 @@ class Check:
 
         pattern = self.cz.schema_pattern()
         ill_formated_commits = [
-            commit
+            (commit, check[1])
             for commit in commits
-            if not self.validate_commit_message(commit.message, pattern)
+            if not (
+                check := self.cz.validate_commit_message(
+                    commit.message,
+                    pattern,
+                    allow_abort=self.allow_abort,
+                    allowed_prefixes=self.allowed_prefixes,
+                    max_msg_length=self.max_msg_length,
+                )
+            )[0]
         ]
-        displayed_msgs_content = "\n".join(
-            [
-                f'commit "{commit.rev}": "{commit.message}"'
-                for commit in ill_formated_commits
-            ]
-        )
-        if displayed_msgs_content:
+
+        if ill_formated_commits:
             raise InvalidCommitMessageError(
-                "commit validation: failed!\n"
-                "please enter a commit message in the commitizen format.\n"
-                f"{displayed_msgs_content}\n"
-                f"pattern: {pattern}"
+                self.cz.format_exception_message(ill_formated_commits)
             )
         out.success("Commit validation: successful!")
 
@@ -139,15 +138,3 @@ class Check:
             if not line.startswith("#"):
                 lines.append(line)
         return "\n".join(lines)
-
-    def validate_commit_message(self, commit_msg: str, pattern: str) -> bool:
-        if not commit_msg:
-            return self.allow_abort
-
-        if any(map(commit_msg.startswith, self.allowed_prefixes)):
-            return True
-        if self.max_msg_length:
-            msg_len = len(commit_msg.partition("\n")[0].strip())
-            if msg_len > self.max_msg_length:
-                return False
-        return bool(re.match(pattern, commit_msg))

--- a/commitizen/cz/base.py
+++ b/commitizen/cz/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from abc import ABCMeta, abstractmethod
 from typing import Any, Callable, Iterable, Protocol
 
@@ -94,6 +95,46 @@ class BaseCommitizen(metaclass=ABCMeta):
     def schema_pattern(self) -> str | None:
         """Regex matching the schema used for message validation."""
         raise NotImplementedError("Not Implemented yet")
+
+    def validate_commit_message(
+        self,
+        commit_msg: str,
+        pattern: str | None,
+        allow_abort: bool,
+        allowed_prefixes: list[str],
+        max_msg_length: int,
+    ) -> tuple[bool, list]:
+        """Validate commit message against the pattern."""
+        if not commit_msg:
+            return allow_abort, []
+
+        if pattern is None:
+            return True, []
+
+        if any(map(commit_msg.startswith, allowed_prefixes)):
+            return True, []
+        if max_msg_length:
+            msg_len = len(commit_msg.partition("\n")[0].strip())
+            if msg_len > max_msg_length:
+                return False, []
+        return bool(re.match(pattern, commit_msg)), []
+
+    def format_exception_message(
+        self, ill_formated_commits: list[tuple[git.GitCommit, list]]
+    ) -> str:
+        """Format commit errors."""
+        displayed_msgs_content = "\n".join(
+            [
+                f'commit "{commit.rev}": "{commit.message}"'
+                for commit, _ in ill_formated_commits
+            ]
+        )
+        return (
+            "commit validation: failed!\n"
+            "please enter a commit message in the commitizen format.\n"
+            f"{displayed_msgs_content}\n"
+            f"pattern: {self.schema_pattern}"
+        )
 
     def info(self) -> str | None:
         """Information about the standardized commit message."""

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1,4 +1,4 @@
-Customizing commitizen is not hard at all.
+from commitizen import BaseCommitizenCustomizing commitizen is not hard at all.
 We have two different ways to do so.
 
 ## 1. Customize in configuration file
@@ -307,6 +307,72 @@ cz -n cz_strange bump
 ```
 
 [convcomms]: https://github.com/commitizen-tools/commitizen/blob/master/commitizen/cz/conventional_commits/conventional_commits.py
+
+### Custom commit validation and error message
+
+The commit message validation can be customized by overriding the `validate_commit_message` and `format_error_message`
+methods from `BaseCommitizen`. This allows for a more detailed feedback to the user where the error originates from.
+
+```python
+import re
+
+from commitizen.cz.base import BaseCommitizen
+from commitizen import git
+
+
+class CustomValidationCz(BaseCommitizen):
+    def validate_commit_message(
+        self,
+        commit_msg: str,
+        pattern: str | None,
+        allow_abort: bool,
+        allowed_prefixes: list[str],
+        max_msg_length: int,
+    ) -> tuple[bool, list]:
+        """Validate commit message against the pattern."""
+        if not commit_msg:
+            return allow_abort, [] if allow_abort else [f"commit message is empty"]
+
+        if pattern is None:
+            return True, []
+
+        if any(map(commit_msg.startswith, allowed_prefixes)):
+            return True, []
+        if max_msg_length:
+            msg_len = len(commit_msg.partition("\n")[0].strip())
+            if msg_len > max_msg_length:
+                return False, [
+                    f"commit message is too long. Max length is {max_msg_length}"
+                ]
+        pattern_match = re.match(pattern, commit_msg)
+        if pattern_match:
+            return True, []
+        else:
+            # Perform additional validation of the commit message format
+            # and add custom error messages as needed
+            return False, ["commit message does not match the pattern"]
+
+    def format_exception_message(
+        self, ill_formated_commits: list[tuple[git.GitCommit, list]]
+    ) -> str:
+        """Format commit errors."""
+        displayed_msgs_content = "\n".join(
+            [
+                (
+                    f'commit "{commit.rev}": "{commit.message}"'
+                    f"errors:\n"
+                    "\n".join((f"- {error}" for error in errors))
+                )
+                for commit, errors in ill_formated_commits
+            ]
+        )
+        return (
+            "commit validation: failed!\n"
+            "please enter a commit message in the commitizen format.\n"
+            f"{displayed_msgs_content}\n"
+            f"pattern: {self.schema_pattern}"
+        )
+```
 
 ### Custom changelog generator
 


### PR DESCRIPTION
## Description
This PR adds functionality to customise the commit message validation and to format the `InvalidCommitMessageError` to give better/more detailed feedback to the user.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
The developer of a custom commitizen class can override the `validate_commit_message` and `format_error_message` methods to perform more complex commit message format checks then just a regex match and give more detailed feedback on failure.


## Steps to Test This Pull Request
Run the the `test_check_command_with_custom_validator_succeed` and `test_check_command_with_custom_validator_fail` tests in `test_check_command.py`.


## Additional context
This PR implements and fixes the comments from #648.
