### PR TITLE
docs: `Allowed Prefixes` default value typo

### DIFF
--- a/docs/commands/check.md
+++ b/docs/commands/check.md
@@ -70,7 +70,7 @@ permit them. Since `git commit` accepts an `--allow-empty-message` flag (primari
 ### Allowed Prefixes
 
 If the commit message starts by some specific prefixes, `cz check` returns `True` without checkign the regex.
-By default, the the following prefixes are allowed: `Merge`, `Revert`, `Pull Request`, `fixup!` and `squash!`.
+By default, the the following prefixes are allowed: `Merge`, `Revert`, `Pull request`, `fixup!` and `squash!`.
 
 ```bash
 cz check --message MESSAGE --allowed-prefixes 'Merge' 'Revert' 'Custom Prefix'


### PR DESCRIPTION
## Description

The descriptions of the default values for allowed_prefixes are different on the [Commands check](https://commitizen-tools.github.io/commitizen/commands/check/#allowed-prefixes) and [Configuration](https://commitizen-tools.github.io/commitizen/config/#allowed_prefixes) pages.

The capitalization of "Pull request" is inconsistent; in practice, "request" must be lowercase to allow skipping the check.

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior

## Steps to Test This Pull Request

## Additional context
