### PR TITLE
fix(bump)!: only add version files and staged changes

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -344,6 +344,7 @@ class Bump:
         )
 
         provider.set_version(str(new_version))
+        files.extend(provider.get_files())
 
         if self.pre_bump_hooks:
             hooks.run(
@@ -420,7 +421,7 @@ class Bump:
             out.success("Done!")
 
     def _get_commit_args(self) -> str:
-        commit_args = ["-a"]
+        commit_args = []
         if self.no_verify:
             commit_args.append("--no-verify")
         return " ".join(commit_args)

--- a/commitizen/providers/base_provider.py
+++ b/commitizen/providers/base_provider.py
@@ -34,6 +34,12 @@ class VersionProvider(ABC):
         Set the new current version
         """
 
+    @abstractmethod
+    def get_files(self) -> list[str]:
+        """
+        Get the version files
+        """
+
 
 class FileProvider(VersionProvider):
     """
@@ -66,6 +72,9 @@ class JsonProvider(FileProvider):
     def get(self, document: dict[str, Any]) -> str:
         return document["version"]  # type: ignore
 
+    def get_files(self) -> list[str]:
+        return [str(self.file)]
+
     def set(self, document: dict[str, Any], version: str):
         document["version"] = version
 
@@ -86,6 +95,9 @@ class TomlProvider(FileProvider):
 
     def get(self, document: tomlkit.TOMLDocument) -> str:
         return document["project"]["version"]  # type: ignore
+
+    def get_files(self) -> list[str]:
+        return [str(self.file)]
 
     def set(self, document: tomlkit.TOMLDocument, version: str):
         document["project"]["version"] = version  # type: ignore

--- a/commitizen/providers/commitizen_provider.py
+++ b/commitizen/providers/commitizen_provider.py
@@ -13,3 +13,6 @@ class CommitizenProvider(VersionProvider):
 
     def set_version(self, version: str):
         self.config.set_key("version", version)
+
+    def get_files(self) -> list[str]:
+        return [str(self.config._path)]

--- a/commitizen/providers/npm_provider.py
+++ b/commitizen/providers/npm_provider.py
@@ -58,6 +58,15 @@ class NpmProvider(VersionProvider):
                 json.dumps(shrinkwrap_document, indent=self.indent) + "\n"
             )
 
+    def get_files(self) -> list[str]:
+        files = []
+        files.append(str(self.package_file))
+        if self.lock_file.exists():
+            files.append(str(self.lock_file))
+        if self.shrinkwrap_file.exists():
+            files.append(str(self.shrinkwrap_file))
+        return files
+
     def get_package_version(self, document: dict[str, Any]) -> str:
         return document["version"]  # type: ignore
 

--- a/commitizen/providers/scm_provider.py
+++ b/commitizen/providers/scm_provider.py
@@ -78,3 +78,7 @@ class ScmProvider(VersionProvider):
     def set_version(self, version: str):
         # Not necessary
         pass
+
+    def get_files(self) -> list[str]:
+        # No files for this provider
+        return []

--- a/docs/config.md
+++ b/docs/config.md
@@ -366,6 +366,9 @@ class MyProvider(VersionProvider):
     def set_version(self, version: str):
         self.file.write_text(version)
 
+    def get_files(self) -> list[str]:
+      return [str(file)]
+
 ```
 
 ```python title="setup.py"

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -535,6 +535,24 @@ def test_bump_major_version_zero_when_major_is_not_zero(mocker, tmp_commitizen_p
     assert expected_error_message in str(excinfo.value)
 
 
+def test_bump_not_add_unstaged(mocker: MockFixture, tmp_commitizen_project):
+    unstaged_file = "ui.py"
+    create_file_and_commit("feat: new file", unstaged_file)
+    tmp_file = tmp_commitizen_project.join(unstaged_file)
+    tmp_file.write("updated content")
+    # print("Before")
+    # cmd_res = cmd.run('git status')
+    # print(cmd_res.out)
+
+    testargs = ["cz", "bump", "--yes"]
+    mocker.patch.object(sys, "argv", testargs)
+    cli.main()
+    # print("After")
+    cmd_res = cmd.run("git diff --name-only")
+    # print(cmd_res.out)
+    assert unstaged_file in cmd_res.out
+
+
 def test_bump_files_only(mocker: MockFixture, tmp_commitizen_project):
     tmp_version_file = tmp_commitizen_project.join("__version__.py")
     tmp_version_file.write("0.1.0")

--- a/tests/providers/test_cargo_provider.py
+++ b/tests/providers/test_cargo_provider.py
@@ -58,3 +58,6 @@ def test_cargo_provider(
 
     provider.set_version("42.1")
     assert file.read_text() == dedent(expected)
+
+    files = provider.get_files()
+    assert filename in files

--- a/tests/providers/test_composer_provider.py
+++ b/tests/providers/test_composer_provider.py
@@ -45,3 +45,6 @@ def test_composer_provider(
 
     provider.set_version("42.1")
     assert file.read_text() == dedent(expected)
+
+    files = provider.get_files()
+    assert filename in files

--- a/tests/providers/test_npm_provider.py
+++ b/tests/providers/test_npm_provider.py
@@ -96,3 +96,10 @@ def test_npm_provider(
         assert pkg_lock.read_text() == dedent(pkg_lock_expected)
     if pkg_shrinkwrap_content:
         assert pkg_shrinkwrap.read_text() == dedent(pkg_shrinkwrap_expected)
+
+    files = provider.get_files()
+    assert NpmProvider.package_filename in files
+    if pkg_lock_content:
+        assert NpmProvider.lock_filename in files
+    if pkg_shrinkwrap_content:
+        assert NpmProvider.shrinkwrap_filename in files

--- a/tests/providers/test_pep621_provider.py
+++ b/tests/providers/test_pep621_provider.py
@@ -41,3 +41,6 @@ def test_cargo_provider(
 
     provider.set_version("42.1")
     assert file.read_text() == dedent(expected)
+
+    files = provider.get_files()
+    assert filename in files

--- a/tests/providers/test_poetry_provider.py
+++ b/tests/providers/test_poetry_provider.py
@@ -41,3 +41,6 @@ def test_cargo_provider(
 
     provider.set_version("42.1")
     assert file.read_text() == dedent(expected)
+
+    files = provider.get_files()
+    assert filename in files

--- a/tests/providers/test_scm_provider.py
+++ b/tests/providers/test_scm_provider.py
@@ -60,6 +60,10 @@ def test_scm_provider(
     # Should not fail on set_version()
     provider.set_version("43.1")
 
+    # Shouldn not have any files
+    files = provider.get_files()
+    assert files == []
+
 
 @pytest.mark.usefixtures("tmp_git_project")
 def test_scm_provider_default_without_commits_and_tags(config: BaseConfig):


### PR DESCRIPTION

## Description
Bump will now only add and commit version files along with any already committed changes.  Any unstaged changes will remain unstaged. 

NOTE: BREAKING CHANGE, since we added a new abstract method to VersionProvider any custom version provider will break.  (open to any suggestions on how to avoid this)

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
Only version files and already staged changes will be committed on bump. 


## Steps to Test This Pull Request
1. cz bump with unstaged changes
2. only version files (and any staged changes) will be added and committed, unstaged changes will remain unstaged


## Additional context
References issue #1194 
