### PR TITLE
feat(commands/commit): add manual-edit functionality after answering questions

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -157,6 +157,12 @@ data = {
                         "help": "Tell the command to automatically stage files that have been modified and deleted, but new files you have not told Git about are not affected.",
                     },
                     {
+                        "name": ["-e", "--edit"],
+                        "action": "store_true",
+                        "default": False,
+                        "help": "edit the commit message before committing",
+                    },
+                    {
                         "name": ["-l", "--message-length-limit"],
                         "type": int,
                         "default": 0,

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -271,6 +271,13 @@ def get_eol_style() -> EOLTypes:
         return map["native"]
 
 
+def get_core_editor() -> str | None:
+    c = cmd.run("git var GIT_EDITOR")
+    if c.out:
+        return c.out.strip()
+    return None
+
+
 def smart_open(*args, **kargs):
     """Open a file with the EOL style determined from Git."""
     return open(*args, newline=get_eol_style().get_eol_for_open(), **kargs)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,7 +22,7 @@ If you're a first-time contributor, you can check the issues with [good first is
    (We use [CodeCov](https://codecov.io/) to ensure our test coverage does not drop.)
 7. Use [commitizen](https://github.com/commitizen-tools/commitizen) to do git commit. We follow [conventional commits](https://www.conventionalcommits.org/).
 8. Run `./scripts/format` and `./scripts/test` to ensure you follow the coding style and the tests pass.
-9. Optionally, update the `./docs/README.md`.
+9. Optionally, update the `./docs/README.md` or `docs/images/cli_help` (through running `scripts/gen_cli_help_screenshots.py`).
 9. **Do not** update the `CHANGELOG.md`, it will be automatically created after merging to `master`.
 10. **Do not** update the versions in the project, they will be automatically updated.
 10. If your changes are about documentation. Run `poetry run mkdocs serve` to serve documentation locally and check whether there is any warning or error.

--- a/docs/images/cli_help/cz_commit___help.svg
+++ b/docs/images/cli_help/cz_commit___help.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 994 586.8" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" viewBox="0 0 994 611.1999999999999" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,125 +19,129 @@
         font-weight: 700;
     }
 
-    .terminal-3906085552-matrix {
+    .terminal-4094976563-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-3906085552-title {
+    .terminal-4094976563-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-3906085552-r1 { fill: #c5c8c6 }
-.terminal-3906085552-r2 { fill: #c5c8c6;font-weight: bold }
-.terminal-3906085552-r3 { fill: #68a0b3;font-weight: bold }
+    .terminal-4094976563-r1 { fill: #c5c8c6 }
+.terminal-4094976563-r2 { fill: #c5c8c6;font-weight: bold }
+.terminal-4094976563-r3 { fill: #68a0b3;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-3906085552-clip-terminal">
-      <rect x="0" y="0" width="975.0" height="535.8" />
+    <clipPath id="terminal-4094976563-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="560.1999999999999" />
     </clipPath>
-    <clipPath id="terminal-3906085552-line-0">
+    <clipPath id="terminal-4094976563-line-0">
     <rect x="0" y="1.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-1">
+<clipPath id="terminal-4094976563-line-1">
     <rect x="0" y="25.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-2">
+<clipPath id="terminal-4094976563-line-2">
     <rect x="0" y="50.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-3">
+<clipPath id="terminal-4094976563-line-3">
     <rect x="0" y="74.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-4">
+<clipPath id="terminal-4094976563-line-4">
     <rect x="0" y="99.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-5">
+<clipPath id="terminal-4094976563-line-5">
     <rect x="0" y="123.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-6">
+<clipPath id="terminal-4094976563-line-6">
     <rect x="0" y="147.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-7">
+<clipPath id="terminal-4094976563-line-7">
     <rect x="0" y="172.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-8">
+<clipPath id="terminal-4094976563-line-8">
     <rect x="0" y="196.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-9">
+<clipPath id="terminal-4094976563-line-9">
     <rect x="0" y="221.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-10">
+<clipPath id="terminal-4094976563-line-10">
     <rect x="0" y="245.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-11">
+<clipPath id="terminal-4094976563-line-11">
     <rect x="0" y="269.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-12">
+<clipPath id="terminal-4094976563-line-12">
     <rect x="0" y="294.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-13">
+<clipPath id="terminal-4094976563-line-13">
     <rect x="0" y="318.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-14">
+<clipPath id="terminal-4094976563-line-14">
     <rect x="0" y="343.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-15">
+<clipPath id="terminal-4094976563-line-15">
     <rect x="0" y="367.5" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-16">
+<clipPath id="terminal-4094976563-line-16">
     <rect x="0" y="391.9" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-17">
+<clipPath id="terminal-4094976563-line-17">
     <rect x="0" y="416.3" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-18">
+<clipPath id="terminal-4094976563-line-18">
     <rect x="0" y="440.7" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-19">
+<clipPath id="terminal-4094976563-line-19">
     <rect x="0" y="465.1" width="976" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-3906085552-line-20">
+<clipPath id="terminal-4094976563-line-20">
     <rect x="0" y="489.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-4094976563-line-21">
+    <rect x="0" y="513.9" width="976" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="584.8" rx="8"/>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="609.2" rx="8"/>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-3906085552-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-4094976563-clip-terminal)">
     
-    <g class="terminal-3906085552-matrix">
-    <text class="terminal-3906085552-r1" x="0" y="20" textLength="219.6" clip-path="url(#terminal-3906085552-line-0)">$&#160;cz&#160;commit&#160;--help</text><text class="terminal-3906085552-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-3906085552-line-0)">
-</text><text class="terminal-3906085552-r1" x="0" y="44.4" textLength="207.4" clip-path="url(#terminal-3906085552-line-1)">usage:&#160;cz&#160;commit&#160;</text><text class="terminal-3906085552-r2" x="207.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-1)">[</text><text class="terminal-3906085552-r1" x="219.6" y="44.4" textLength="24.4" clip-path="url(#terminal-3906085552-line-1)">-h</text><text class="terminal-3906085552-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-1)">]</text><text class="terminal-3906085552-r2" x="268.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-1)">[</text><text class="terminal-3906085552-r1" x="280.6" y="44.4" textLength="85.4" clip-path="url(#terminal-3906085552-line-1)">--retry</text><text class="terminal-3906085552-r2" x="366" y="44.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-1)">]</text><text class="terminal-3906085552-r2" x="390.4" y="44.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-1)">[</text><text class="terminal-3906085552-r1" x="402.6" y="44.4" textLength="122" clip-path="url(#terminal-3906085552-line-1)">--no-retry</text><text class="terminal-3906085552-r2" x="524.6" y="44.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-1)">]</text><text class="terminal-3906085552-r2" x="549" y="44.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-1)">[</text><text class="terminal-3906085552-r1" x="561.2" y="44.4" textLength="109.8" clip-path="url(#terminal-3906085552-line-1)">--dry-run</text><text class="terminal-3906085552-r2" x="671" y="44.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-1)">]</text><text class="terminal-3906085552-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-1)">
-</text><text class="terminal-3906085552-r2" x="207.4" y="68.8" textLength="12.2" clip-path="url(#terminal-3906085552-line-2)">[</text><text class="terminal-3906085552-r1" x="219.6" y="68.8" textLength="402.6" clip-path="url(#terminal-3906085552-line-2)">--write-message-to-file&#160;FILE_PATH</text><text class="terminal-3906085552-r2" x="622.2" y="68.8" textLength="12.2" clip-path="url(#terminal-3906085552-line-2)">]</text><text class="terminal-3906085552-r2" x="646.6" y="68.8" textLength="12.2" clip-path="url(#terminal-3906085552-line-2)">[</text><text class="terminal-3906085552-r1" x="658.8" y="68.8" textLength="24.4" clip-path="url(#terminal-3906085552-line-2)">-s</text><text class="terminal-3906085552-r2" x="683.2" y="68.8" textLength="12.2" clip-path="url(#terminal-3906085552-line-2)">]</text><text class="terminal-3906085552-r2" x="707.6" y="68.8" textLength="12.2" clip-path="url(#terminal-3906085552-line-2)">[</text><text class="terminal-3906085552-r1" x="719.8" y="68.8" textLength="24.4" clip-path="url(#terminal-3906085552-line-2)">-a</text><text class="terminal-3906085552-r2" x="744.2" y="68.8" textLength="12.2" clip-path="url(#terminal-3906085552-line-2)">]</text><text class="terminal-3906085552-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-3906085552-line-2)">
-</text><text class="terminal-3906085552-r2" x="207.4" y="93.2" textLength="12.2" clip-path="url(#terminal-3906085552-line-3)">[</text><text class="terminal-3906085552-r1" x="219.6" y="93.2" textLength="280.6" clip-path="url(#terminal-3906085552-line-3)">-l&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-3906085552-r2" x="500.2" y="93.2" textLength="12.2" clip-path="url(#terminal-3906085552-line-3)">]</text><text class="terminal-3906085552-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-3906085552-line-3)">
-</text><text class="terminal-3906085552-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-3906085552-line-4)">
-</text><text class="terminal-3906085552-r1" x="0" y="142" textLength="207.4" clip-path="url(#terminal-3906085552-line-5)">create&#160;new&#160;commit</text><text class="terminal-3906085552-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-3906085552-line-5)">
-</text><text class="terminal-3906085552-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-6)">
-</text><text class="terminal-3906085552-r1" x="0" y="190.8" textLength="97.6" clip-path="url(#terminal-3906085552-line-7)">options:</text><text class="terminal-3906085552-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-3906085552-line-7)">
-</text><text class="terminal-3906085552-r1" x="0" y="215.2" textLength="671" clip-path="url(#terminal-3906085552-line-8)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-3906085552-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-3906085552-line-8)">
-</text><text class="terminal-3906085552-r1" x="0" y="239.6" textLength="500.2" clip-path="url(#terminal-3906085552-line-9)">&#160;&#160;--retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;retry&#160;last&#160;commit</text><text class="terminal-3906085552-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-3906085552-line-9)">
-</text><text class="terminal-3906085552-r1" x="0" y="264" textLength="878.4" clip-path="url(#terminal-3906085552-line-10)">&#160;&#160;--no-retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;skip&#160;retry&#160;if&#160;retry_after_failure&#160;is&#160;set&#160;to&#160;true</text><text class="terminal-3906085552-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-3906085552-line-10)">
-</text><text class="terminal-3906085552-r1" x="0" y="288.4" textLength="915" clip-path="url(#terminal-3906085552-line-11)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;output&#160;to&#160;stdout,&#160;no&#160;commit,&#160;no&#160;modified&#160;files</text><text class="terminal-3906085552-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-11)">
-</text><text class="terminal-3906085552-r1" x="0" y="312.8" textLength="427" clip-path="url(#terminal-3906085552-line-12)">&#160;&#160;--write-message-to-file&#160;FILE_PATH</text><text class="terminal-3906085552-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-3906085552-line-12)">
-</text><text class="terminal-3906085552-r1" x="0" y="337.2" textLength="780.8" clip-path="url(#terminal-3906085552-line-13)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;write&#160;message&#160;to&#160;file&#160;before&#160;committing&#160;</text><text class="terminal-3906085552-r2" x="780.8" y="337.2" textLength="12.2" clip-path="url(#terminal-3906085552-line-13)">(</text><text class="terminal-3906085552-r1" x="793" y="337.2" textLength="73.2" clip-path="url(#terminal-3906085552-line-13)">can&#160;be</text><text class="terminal-3906085552-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-3906085552-line-13)">
-</text><text class="terminal-3906085552-r1" x="0" y="361.6" textLength="573.4" clip-path="url(#terminal-3906085552-line-14)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;combined&#160;with&#160;--dry-run</text><text class="terminal-3906085552-r2" x="573.4" y="361.6" textLength="12.2" clip-path="url(#terminal-3906085552-line-14)">)</text><text class="terminal-3906085552-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-3906085552-line-14)">
-</text><text class="terminal-3906085552-r1" x="0" y="386" textLength="524.6" clip-path="url(#terminal-3906085552-line-15)">&#160;&#160;-s,&#160;--signoff&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sign&#160;off&#160;the&#160;commit</text><text class="terminal-3906085552-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-3906085552-line-15)">
-</text><text class="terminal-3906085552-r1" x="0" y="410.4" textLength="902.8" clip-path="url(#terminal-3906085552-line-16)">&#160;&#160;-a,&#160;--all&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Tell&#160;the&#160;command&#160;to&#160;automatically&#160;stage&#160;files&#160;that</text><text class="terminal-3906085552-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-16)">
-</text><text class="terminal-3906085552-r1" x="0" y="434.8" textLength="951.6" clip-path="url(#terminal-3906085552-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;have&#160;been&#160;modified&#160;and&#160;deleted,&#160;but&#160;new&#160;files&#160;you&#160;have</text><text class="terminal-3906085552-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-3906085552-line-17)">
-</text><text class="terminal-3906085552-r1" x="0" y="459.2" textLength="732" clip-path="url(#terminal-3906085552-line-18)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;not&#160;told&#160;Git&#160;about&#160;are&#160;not&#160;affected.</text><text class="terminal-3906085552-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-3906085552-line-18)">
-</text><text class="terminal-3906085552-r1" x="0" y="483.6" textLength="854" clip-path="url(#terminal-3906085552-line-19)">&#160;&#160;-l&#160;MESSAGE_LENGTH_LIMIT,&#160;--message-length-limit&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-3906085552-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-3906085552-line-19)">
-</text><text class="terminal-3906085552-r1" x="0" y="508" textLength="732" clip-path="url(#terminal-3906085552-line-20)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;length&#160;limit&#160;of&#160;the&#160;commit&#160;message;&#160;</text><text class="terminal-3906085552-r3" x="732" y="508" textLength="12.2" clip-path="url(#terminal-3906085552-line-20)">0</text><text class="terminal-3906085552-r1" x="744.2" y="508" textLength="158.6" clip-path="url(#terminal-3906085552-line-20)">&#160;for&#160;no&#160;limit</text><text class="terminal-3906085552-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-3906085552-line-20)">
-</text><text class="terminal-3906085552-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-3906085552-line-21)">
+    <g class="terminal-4094976563-matrix">
+    <text class="terminal-4094976563-r1" x="0" y="20" textLength="219.6" clip-path="url(#terminal-4094976563-line-0)">$&#160;cz&#160;commit&#160;--help</text><text class="terminal-4094976563-r1" x="976" y="20" textLength="12.2" clip-path="url(#terminal-4094976563-line-0)">
+</text><text class="terminal-4094976563-r1" x="0" y="44.4" textLength="207.4" clip-path="url(#terminal-4094976563-line-1)">usage:&#160;cz&#160;commit&#160;</text><text class="terminal-4094976563-r2" x="207.4" y="44.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-1)">[</text><text class="terminal-4094976563-r1" x="219.6" y="44.4" textLength="24.4" clip-path="url(#terminal-4094976563-line-1)">-h</text><text class="terminal-4094976563-r2" x="244" y="44.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-1)">]</text><text class="terminal-4094976563-r2" x="268.4" y="44.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-1)">[</text><text class="terminal-4094976563-r1" x="280.6" y="44.4" textLength="85.4" clip-path="url(#terminal-4094976563-line-1)">--retry</text><text class="terminal-4094976563-r2" x="366" y="44.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-1)">]</text><text class="terminal-4094976563-r2" x="390.4" y="44.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-1)">[</text><text class="terminal-4094976563-r1" x="402.6" y="44.4" textLength="122" clip-path="url(#terminal-4094976563-line-1)">--no-retry</text><text class="terminal-4094976563-r2" x="524.6" y="44.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-1)">]</text><text class="terminal-4094976563-r2" x="549" y="44.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-1)">[</text><text class="terminal-4094976563-r1" x="561.2" y="44.4" textLength="109.8" clip-path="url(#terminal-4094976563-line-1)">--dry-run</text><text class="terminal-4094976563-r2" x="671" y="44.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-1)">]</text><text class="terminal-4094976563-r1" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-1)">
+</text><text class="terminal-4094976563-r2" x="207.4" y="68.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-2)">[</text><text class="terminal-4094976563-r1" x="219.6" y="68.8" textLength="402.6" clip-path="url(#terminal-4094976563-line-2)">--write-message-to-file&#160;FILE_PATH</text><text class="terminal-4094976563-r2" x="622.2" y="68.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-2)">]</text><text class="terminal-4094976563-r2" x="646.6" y="68.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-2)">[</text><text class="terminal-4094976563-r1" x="658.8" y="68.8" textLength="24.4" clip-path="url(#terminal-4094976563-line-2)">-s</text><text class="terminal-4094976563-r2" x="683.2" y="68.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-2)">]</text><text class="terminal-4094976563-r2" x="707.6" y="68.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-2)">[</text><text class="terminal-4094976563-r1" x="719.8" y="68.8" textLength="24.4" clip-path="url(#terminal-4094976563-line-2)">-a</text><text class="terminal-4094976563-r2" x="744.2" y="68.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-2)">]</text><text class="terminal-4094976563-r2" x="768.6" y="68.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-2)">[</text><text class="terminal-4094976563-r1" x="780.8" y="68.8" textLength="24.4" clip-path="url(#terminal-4094976563-line-2)">-e</text><text class="terminal-4094976563-r2" x="805.2" y="68.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-2)">]</text><text class="terminal-4094976563-r1" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-2)">
+</text><text class="terminal-4094976563-r2" x="207.4" y="93.2" textLength="12.2" clip-path="url(#terminal-4094976563-line-3)">[</text><text class="terminal-4094976563-r1" x="219.6" y="93.2" textLength="280.6" clip-path="url(#terminal-4094976563-line-3)">-l&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-4094976563-r2" x="500.2" y="93.2" textLength="12.2" clip-path="url(#terminal-4094976563-line-3)">]</text><text class="terminal-4094976563-r1" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-4094976563-line-3)">
+</text><text class="terminal-4094976563-r1" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-4094976563-line-4)">
+</text><text class="terminal-4094976563-r1" x="0" y="142" textLength="207.4" clip-path="url(#terminal-4094976563-line-5)">create&#160;new&#160;commit</text><text class="terminal-4094976563-r1" x="976" y="142" textLength="12.2" clip-path="url(#terminal-4094976563-line-5)">
+</text><text class="terminal-4094976563-r1" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-6)">
+</text><text class="terminal-4094976563-r1" x="0" y="190.8" textLength="97.6" clip-path="url(#terminal-4094976563-line-7)">options:</text><text class="terminal-4094976563-r1" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-7)">
+</text><text class="terminal-4094976563-r1" x="0" y="215.2" textLength="671" clip-path="url(#terminal-4094976563-line-8)">&#160;&#160;-h,&#160;--help&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;this&#160;help&#160;message&#160;and&#160;exit</text><text class="terminal-4094976563-r1" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-4094976563-line-8)">
+</text><text class="terminal-4094976563-r1" x="0" y="239.6" textLength="500.2" clip-path="url(#terminal-4094976563-line-9)">&#160;&#160;--retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;retry&#160;last&#160;commit</text><text class="terminal-4094976563-r1" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-4094976563-line-9)">
+</text><text class="terminal-4094976563-r1" x="0" y="264" textLength="878.4" clip-path="url(#terminal-4094976563-line-10)">&#160;&#160;--no-retry&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;skip&#160;retry&#160;if&#160;retry_after_failure&#160;is&#160;set&#160;to&#160;true</text><text class="terminal-4094976563-r1" x="976" y="264" textLength="12.2" clip-path="url(#terminal-4094976563-line-10)">
+</text><text class="terminal-4094976563-r1" x="0" y="288.4" textLength="915" clip-path="url(#terminal-4094976563-line-11)">&#160;&#160;--dry-run&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;show&#160;output&#160;to&#160;stdout,&#160;no&#160;commit,&#160;no&#160;modified&#160;files</text><text class="terminal-4094976563-r1" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-11)">
+</text><text class="terminal-4094976563-r1" x="0" y="312.8" textLength="427" clip-path="url(#terminal-4094976563-line-12)">&#160;&#160;--write-message-to-file&#160;FILE_PATH</text><text class="terminal-4094976563-r1" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-12)">
+</text><text class="terminal-4094976563-r1" x="0" y="337.2" textLength="780.8" clip-path="url(#terminal-4094976563-line-13)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;write&#160;message&#160;to&#160;file&#160;before&#160;committing&#160;</text><text class="terminal-4094976563-r2" x="780.8" y="337.2" textLength="12.2" clip-path="url(#terminal-4094976563-line-13)">(</text><text class="terminal-4094976563-r1" x="793" y="337.2" textLength="73.2" clip-path="url(#terminal-4094976563-line-13)">can&#160;be</text><text class="terminal-4094976563-r1" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-4094976563-line-13)">
+</text><text class="terminal-4094976563-r1" x="0" y="361.6" textLength="573.4" clip-path="url(#terminal-4094976563-line-14)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;combined&#160;with&#160;--dry-run</text><text class="terminal-4094976563-r2" x="573.4" y="361.6" textLength="12.2" clip-path="url(#terminal-4094976563-line-14)">)</text><text class="terminal-4094976563-r1" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-4094976563-line-14)">
+</text><text class="terminal-4094976563-r1" x="0" y="386" textLength="524.6" clip-path="url(#terminal-4094976563-line-15)">&#160;&#160;-s,&#160;--signoff&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;sign&#160;off&#160;the&#160;commit</text><text class="terminal-4094976563-r1" x="976" y="386" textLength="12.2" clip-path="url(#terminal-4094976563-line-15)">
+</text><text class="terminal-4094976563-r1" x="0" y="410.4" textLength="902.8" clip-path="url(#terminal-4094976563-line-16)">&#160;&#160;-a,&#160;--all&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;Tell&#160;the&#160;command&#160;to&#160;automatically&#160;stage&#160;files&#160;that</text><text class="terminal-4094976563-r1" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-16)">
+</text><text class="terminal-4094976563-r1" x="0" y="434.8" textLength="951.6" clip-path="url(#terminal-4094976563-line-17)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;have&#160;been&#160;modified&#160;and&#160;deleted,&#160;but&#160;new&#160;files&#160;you&#160;have</text><text class="terminal-4094976563-r1" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-17)">
+</text><text class="terminal-4094976563-r1" x="0" y="459.2" textLength="732" clip-path="url(#terminal-4094976563-line-18)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;not&#160;told&#160;Git&#160;about&#160;are&#160;not&#160;affected.</text><text class="terminal-4094976563-r1" x="976" y="459.2" textLength="12.2" clip-path="url(#terminal-4094976563-line-18)">
+</text><text class="terminal-4094976563-r1" x="0" y="483.6" textLength="793" clip-path="url(#terminal-4094976563-line-19)">&#160;&#160;-e,&#160;--edit&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;edit&#160;the&#160;commit&#160;message&#160;before&#160;committing</text><text class="terminal-4094976563-r1" x="976" y="483.6" textLength="12.2" clip-path="url(#terminal-4094976563-line-19)">
+</text><text class="terminal-4094976563-r1" x="0" y="508" textLength="854" clip-path="url(#terminal-4094976563-line-20)">&#160;&#160;-l&#160;MESSAGE_LENGTH_LIMIT,&#160;--message-length-limit&#160;MESSAGE_LENGTH_LIMIT</text><text class="terminal-4094976563-r1" x="976" y="508" textLength="12.2" clip-path="url(#terminal-4094976563-line-20)">
+</text><text class="terminal-4094976563-r1" x="0" y="532.4" textLength="732" clip-path="url(#terminal-4094976563-line-21)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;length&#160;limit&#160;of&#160;the&#160;commit&#160;message;&#160;</text><text class="terminal-4094976563-r3" x="732" y="532.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-21)">0</text><text class="terminal-4094976563-r1" x="744.2" y="532.4" textLength="158.6" clip-path="url(#terminal-4094976563-line-21)">&#160;for&#160;no&#160;limit</text><text class="terminal-4094976563-r1" x="976" y="532.4" textLength="12.2" clip-path="url(#terminal-4094976563-line-21)">
+</text><text class="terminal-4094976563-r1" x="976" y="556.8" textLength="12.2" clip-path="url(#terminal-4094976563-line-22)">
 </text>
     </g>
     </g>

--- a/tests/commands/test_commit_command/test_commit_command_shows_description_when_use_help_option.txt
+++ b/tests/commands/test_commit_command/test_commit_command_shows_description_when_use_help_option.txt
@@ -1,5 +1,5 @@
 usage: cz commit [-h] [--retry] [--no-retry] [--dry-run]
-                 [--write-message-to-file FILE_PATH] [-s] [-a]
+                 [--write-message-to-file FILE_PATH] [-s] [-a] [-e]
                  [-l MESSAGE_LENGTH_LIMIT]
 
 create new commit
@@ -16,5 +16,6 @@ options:
   -a, --all             Tell the command to automatically stage files that
                         have been modified and deleted, but new files you have
                         not told Git about are not affected.
+  -e, --edit            edit the commit message before committing
   -l, --message-length-limit MESSAGE_LENGTH_LIMIT
                         length limit of the commit message; 0 for no limit

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -283,6 +283,26 @@ def test_eoltypes_get_eol_for_open():
     assert git.EOLTypes.get_eol_for_open(git.EOLTypes.CRLF) == "\r\n"
 
 
+def test_get_core_editor(mocker):
+    mocker.patch.dict(os.environ, {"GIT_EDITOR": "nano"})
+    assert git.get_core_editor() == "nano"
+
+    mocker.patch.dict(os.environ, clear=True)
+    mocker.patch(
+        "commitizen.cmd.run",
+        return_value=cmd.Command(
+            out="vim", err="", stdout=b"", stderr=b"", return_code=0
+        ),
+    )
+    assert git.get_core_editor() == "vim"
+
+    mocker.patch(
+        "commitizen.cmd.run",
+        return_value=cmd.Command(out="", err="", stdout=b"", stderr=b"", return_code=1),
+    )
+    assert git.get_core_editor() is None
+
+
 def test_create_tag_with_message(tmp_commitizen_project):
     with tmp_commitizen_project.as_cwd():
         create_file_and_commit("feat(test): test")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Add one argument `-e/--edit` to commit command, to allow user to continue editing after filling up all the questions.
(Kudos to @MrMino! The `pytest-edit` project inspired me to come up with this idea.)


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
if `-e/--edit` enabled, the terminal would pop up editor with commit message after finishing the answering.


## Steps to Test This Pull Request
1. check out to this branch
2. make a commit with `cz c -e`

