### PR TITLE
docs(commit): add multiline option `questions` content table

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -175,7 +175,7 @@ commitizen:
 | `message`   | `str`  | `None`  | Detail description for the question.                                                                                                                                                            |
 | `choices`   | `list` | `None`  | (OPTIONAL) The choices when `type = list`. Either use a list of values or a list of dictionaries with `name` and `value` keys. Keyboard shortcuts can be defined via `key`. See examples above. |
 | `default`   | `Any`  | `None`  | (OPTIONAL) The default value for this question.                                                                                                                                                 |
-| `filter`    | `str`  | `None`  | (Optional) Validator for user's answer. **(Work in Progress)**                                                                                                                                  |
+| `filter`    | `str`  | `None`  | (OPTIONAL) Validator for user's answer. **(Work in Progress)**                                                                                                                                  |
 | `multiline` | `bool` | `False` | (OPTIONAL) Enable multiline support when `type = input`.                                                                                                                                            |
 [different-question-types]: https://github.com/tmbo/questionary#different-question-types
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -168,14 +168,15 @@ commitizen:
 
 #### Detailed `questions` content
 
-| Parameter | Type   | Default | Description                                                                                                                                                                                     |
-| --------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`    | `str`  | `None`  | The type of questions. Valid type: `list`, `input` and etc. [See More][different-question-types]                                                                                                |
-| `name`    | `str`  | `None`  | The key for the value answered by user. It's used in `message_template`                                                                                                                         |
-| `message` | `str`  | `None`  | Detail description for the question.                                                                                                                                                            |
-| `choices` | `list` | `None`  | (OPTIONAL) The choices when `type = list`. Either use a list of values or a list of dictionaries with `name` and `value` keys. Keyboard shortcuts can be defined via `key`. See examples above. |
-| `default` | `Any`  | `None`  | (OPTIONAL) The default value for this question.                                                                                                                                                 |
-| `filter`  | `str`  | `None`  | (Optional) Validator for user's answer. **(Work in Progress)**                                                                                                                                  |
+| Parameter   | Type   | Default | Description                                                                                                                                                                                     |
+| ----------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`      | `str`  | `None`  | The type of questions. Valid type: `list`, `input` and etc. [See More][different-question-types]                                                                                                |
+| `name`      | `str`  | `None`  | The key for the value answered by user. It's used in `message_template`                                                                                                                         |
+| `message`   | `str`  | `None`  | Detail description for the question.                                                                                                                                                            |
+| `choices`   | `list` | `None`  | (OPTIONAL) The choices when `type = list`. Either use a list of values or a list of dictionaries with `name` and `value` keys. Keyboard shortcuts can be defined via `key`. See examples above. |
+| `default`   | `Any`  | `None`  | (OPTIONAL) The default value for this question.                                                                                                                                                 |
+| `filter`    | `str`  | `None`  | (Optional) Validator for user's answer. **(Work in Progress)**                                                                                                                                  |
+| `multiline` | `bool` | `False` | (OPTIONAL) Enable multiline support when `type = input`.                                                                                                                                            |
 [different-question-types]: https://github.com/tmbo/questionary#different-question-types
 
 #### Shortcut keys


### PR DESCRIPTION
## Description
I suggest to mention the multline support for input question in the documentation since it is already supported and a multiline description in the body is essential for good commits


## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [ ] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
Question `type = input` and option `multiline = True`, multiline input is possible


## Steps to Test This Pull Request
- created `.cz.yaml` and added the option `multiline: true` to the question `type: text` and  `type: input`
- in https://github.com/commitizen-tools/commitizen/issues/264#issuecomment-1620234279 [marcosdotme](https://github.com/marcosdotme) tested it in toml and reported it works 

## Additional context
Closes: https://github.com/commitizen-tools/commitizen/issues/264
