### PR TITLE
feat(customize.py/test_cz_customize.py): inherit from ConventionalCom…

### DIFF
--- a/commitizen/cz/customize/customize.py
+++ b/commitizen/cz/customize/customize.py
@@ -54,7 +54,7 @@ class CustomizeCommitsCz(ConventionalCommitsCz):
             self.change_type_map = change_type_map
 
     def questions(self) -> Questions:
-        custom_questions = self.custom_settings.get("questions", [{}])
+        custom_questions = self.custom_settings.get("questions")
         if custom_questions:
             return custom_questions
         return super().questions()

--- a/commitizen/cz/customize/customize.py
+++ b/commitizen/cz/customize/customize.py
@@ -1,26 +1,21 @@
 from __future__ import annotations
 
+from commitizen.cz.conventional_commits import ConventionalCommitsCz
+
 try:
     from jinja2 import Template
 except ImportError:
     from string import Template  # type: ignore
 
 
-from commitizen import defaults
 from commitizen.config import BaseConfig
-from commitizen.cz.base import BaseCommitizen
 from commitizen.defaults import Questions
 from commitizen.exceptions import MissingCzCustomizeConfigError
 
 __all__ = ["CustomizeCommitsCz"]
 
 
-class CustomizeCommitsCz(BaseCommitizen):
-    bump_pattern = defaults.bump_pattern
-    bump_map = defaults.bump_map
-    bump_map_major_version_zero = defaults.bump_map_major_version_zero
-    change_type_order = defaults.change_type_order
-
+class CustomizeCommitsCz(ConventionalCommitsCz):
     def __init__(self, config: BaseConfig):
         super().__init__(config)
 
@@ -59,25 +54,40 @@ class CustomizeCommitsCz(BaseCommitizen):
             self.change_type_map = change_type_map
 
     def questions(self) -> Questions:
-        return self.custom_settings.get("questions", [{}])
+        custom_questions = self.custom_settings.get("questions", [{}])
+        if custom_questions:
+            return custom_questions
+        return super().questions()
 
     def message(self, answers: dict) -> str:
-        message_template = Template(self.custom_settings.get("message_template", ""))
-        if getattr(Template, "substitute", None):
-            return message_template.substitute(**answers)  # type: ignore
-        else:
-            return message_template.render(**answers)
+        custom_message = self.custom_settings.get("message_template")
+        if custom_message:
+            message_template = Template(custom_message)
+            if getattr(Template, "substitute", None):
+                return message_template.substitute(**answers)  # type: ignore
+            else:
+                return message_template.render(**answers)
+        return super().message(answers)
 
-    def example(self) -> str | None:
-        return self.custom_settings.get("example")
+    def example(self) -> str:
+        custom_example = self.custom_settings.get("example")
+        if custom_example:
+            return custom_example
+        return super().example()
 
-    def schema_pattern(self) -> str | None:
-        return self.custom_settings.get("schema_pattern")
+    def schema_pattern(self) -> str:
+        custom_schema_pattern = self.custom_settings.get("schema_pattern")
+        if custom_schema_pattern:
+            return custom_schema_pattern
+        return super().schema_pattern()
 
-    def schema(self) -> str | None:
-        return self.custom_settings.get("schema")
+    def schema(self) -> str:
+        custom_schema = self.custom_settings.get("schema")
+        if custom_schema:
+            return custom_schema
+        return super().schema()
 
-    def info(self) -> str | None:
+    def info(self) -> str:
         info_path = self.custom_settings.get("info_path")
         info = self.custom_settings.get("info")
         if info_path:
@@ -86,4 +96,4 @@ class CustomizeCommitsCz(BaseCommitizen):
             return content
         elif info:
             return info
-        return None
+        return super().info()

--- a/tests/test_cz_customize.py
+++ b/tests/test_cz_customize.py
@@ -1,6 +1,7 @@
 import pytest
 
 from commitizen.config import BaseConfig, JsonConfig, TomlConfig, YAMLConfig
+from commitizen.cz.conventional_commits import ConventionalCommitsCz
 from commitizen.cz.customize import CustomizeCommitsCz
 from commitizen.exceptions import MissingCzCustomizeConfigError
 
@@ -564,7 +565,8 @@ def test_info_with_info_path(tmpdir, config_info):
 
 def test_info_without_info(config_without_info):
     cz = CustomizeCommitsCz(config_without_info)
-    assert cz.info() is None
+    cz_super = ConventionalCommitsCz(config_without_info)
+    assert cz.info() == cz_super.info()
 
 
 def test_commit_parser(config):


### PR DESCRIPTION
> enable cz_customize default behavior follow ConventionalCommitsCz without trivial settings

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
try to Enable cover `cz_conventional_commits` via [tool.commitizen.customize] #1270 


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior

```toml
[tool.commitizen]
name = "cz_customize"
tag_format = "$version"
version_scheme = "semver"
version_provider = "pep621"
update_changelog_on_bump = true
major_version_zero = true
changelog_incremental = false

[tool.commitizen.customize]
commit_parser = "^((?P<change_type>feat|fix|refactor|perf|docs|style|refactor|ci|BREAKING CHANGE)(?:\\((?P<scope>[^()\r\n]*)\\)|\\()?(?P<breaking>!)?|\\w+!):\\s(?P<message>.*)?"
changelog_pattern = "^((BREAKING[\\-\\ ]CHANGE|\\w+)(\\(.+\\))?!?):"
change_type_map = {"feat"="Feat","fix"="Fix","refactor"= "Refactor","perf"="Perf","docs"="Docs","style"="Style","ci"="CI"}
```

now `[tool.commitizen.customize]` will cover the `ConventionalCommitsCz` settings


## Steps to Test This Pull Request
1. add example `[tool.commitizen.customize]` into your `pyproject.toml`
2. `cz commit -a`,select `docs`,`cz ch --dry-run`,docs item will appear in your `CHANGELOG.md`

here is my [test-repo](https://github.com/Atticuszz/python-uv)
