### PR TITLE
build(pre-commit): migrate pre-commit conifg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ default_install_hook_types:
   - pre-push
 
 default_stages:
-  - commit
-  - push
+  - pre-commit
+  - pre-push
 
 repos:
   - repo: meta
@@ -55,7 +55,7 @@ repos:
       - id: commitizen-branch
         stages:
           - post-commit
-          - push
+          - pre-push
 
   - repo: local
     hooks:
@@ -70,6 +70,6 @@ repos:
         name: linter and test
         language: system
         pass_filenames: false
-        stages: [ push ]
+        stages: [ pre-push ]
         entry: ./scripts/test
         types: [ python ]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

When running `pre-commit run --all-files`, the following error was encountered.

```
[WARNING] hook id `commitizen-branch` uses deprecated stage names (push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `linter and test` uses deprecated stage names (push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] top-level `default_stages` uses deprecated stage names (commit, push) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```

This commit only only migrates the pre-commit config to the latest version.

## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

Run `pre-commit run --all-files` without encountering warning

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

Run `pre-commit run --all-files`


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
