### PR TITLE
fix(get-next-bump): fix to permit usage of --get-next option even when update_changelog_on_bump is set to true

### DIFF
--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1482,6 +1482,26 @@ def test_bump_get_next(mocker: MockFixture, capsys):
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_get_next_update_changelog_on_bump(
+    mocker: MockFixture, capsys, config_path
+):
+    create_file_and_commit("feat: new file")
+    with open(config_path, "a", encoding="utf-8") as fp:
+        fp.write("update_changelog_on_bump = true\n")
+
+    testargs = ["cz", "bump", "--yes", "--get-next"]
+    mocker.patch.object(sys, "argv", testargs)
+    with pytest.raises(GetNextExit):
+        cli.main()
+
+    out, _ = capsys.readouterr()
+    assert "0.2.0" in out
+
+    tag_exists = git.tag_exist("0.2.0")
+    assert tag_exists is False
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
 def test_bump_get_next__changelog_is_not_allowed(mocker: MockFixture):
     create_file_and_commit("feat: new file")
 


### PR DESCRIPTION
## Description
<!-- Describe what the change is -->

With the configuration options `update_changelog_on_bump` set to `True`, the command `cz bump --get-next` crashed, due to the mutual exclusive options `--get-next` and `--changelog`/`--changelog-to-stdout`. 

Changing this behavior to still throw a conflict when using both CLI options, but let `--get-next` take the precedence over `update_changelog_on_bump` configuration.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `./scripts/format` and `./scripts/test` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

Now the configuration options `update_changelog_on_bump` can be set to whatever you want when using the `cz bump --get-next` command.


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->

1. Build a commitizen config with `update_changelog_on_bump` flag set to true.
2. Add some commits to the target test project.
3. Run `cz bump --get-next`
4. The command should work and not throw an error.

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
