### PR TITLE
Add "stages" explicitly to the hook example

### DIFF
--- a/docs/tutorials/auto_check.md
+++ b/docs/tutorials/auto_check.md
@@ -25,6 +25,7 @@ repos:
     rev: v1.17.0
     hooks:
       - id: commitizen
+        stages: [commit-msg]
 ```
 
 - Step 3: Install the configuration into git hook through `pre-commit`


### PR DESCRIPTION

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Add "stages" explicitly to the hook example

As mentioned here: https://github.com/commitizen-tools/commitizen/issues/177#issuecomment-621939385, without the stages explicitly set, the hook always fails.

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
The hook should work when the message is correct on commit stage.

## Steps to Test This Pull Request
1. Add the hook as it is today.
2. Write a correct commit such as chore or feat
3. See the hook failing


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
