### PR TITLE
fix(bump): manual version bump if prerelease offset is configured

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -187,11 +187,6 @@ class Bump:
                     "--major-version-zero cannot be combined with MANUAL_VERSION"
                 )
 
-            if prerelease_offset:
-                raise NotAllowed(
-                    "--prerelease-offset cannot be combined with MANUAL_VERSION"
-                )
-
             if get_next:
                 raise NotAllowed("--get-next cannot be combined with MANUAL_VERSION")
 

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -599,7 +599,7 @@ post_bump_hooks = [
 
 ### `prerelease_offset`
 
-Offset with which to start counting prereleses.
+Offset with which to start counting prereleases.
 
 Defaults to: `0`
 

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1041,23 +1041,6 @@ def test_bump_with_hooks_and_increment(mocker: MockFixture, tmp_commitizen_proje
     assert tag_exists is True
 
 
-@pytest.mark.usefixtures("tmp_commitizen_project")
-def test_bump_manual_version_disallows_prerelease_offset(mocker):
-    create_file_and_commit("feat: new file")
-
-    manual_version = "0.2.0"
-    testargs = ["cz", "bump", "--yes", "--prerelease-offset", "42", manual_version]
-    mocker.patch.object(sys, "argv", testargs)
-
-    with pytest.raises(NotAllowed) as excinfo:
-        cli.main()
-
-    expected_error_message = (
-        "--prerelease-offset cannot be combined with MANUAL_VERSION"
-    )
-    assert expected_error_message in str(excinfo.value)
-
-
 @pytest.mark.usefixtures("tmp_git_project")
 def test_bump_use_version_provider(mocker: MockFixture):
     mock = mocker.MagicMock(name="provider")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

If a prerelease offset is configured (I introduced this about 2 years ago with PR #614), no bump is possible with the manual version.
To do this, the configuration must first be changed and then reset after the bump.

For this reason, it makes more sense to remove the check that prevents the manual bump.

## Checklist

- [ ] Add test cases to all the changes you introduce
	- I'm not sure where best to cover this case. Please give me a hint in which existing test file I could extend this.
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] ~Update the documentation for the changes~

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

Bumping a manual version works without changing the configuration file.

## Steps to Test This Pull Request

1. Use the follwoing Configuration
```toml
[tool.commitizen]
changelog_incremental = true
tag_format = "v$version"
update_changelog_on_bump = true
version = "1.2.0b13"
prerelease_offset = 1
```
2. `cz  bump 9.8.7`


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
