### PR TITLE
fix(tags): import `Self` from `typing` for Python 3.11+

### DIFF
--- a/commitizen/tags.py
+++ b/commitizen/tags.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import re
+import sys
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
 from string import Template
 from typing import TYPE_CHECKING, NamedTuple
-
-from typing_extensions import Self
 
 from commitizen import out
 from commitizen.defaults import DEFAULT_SETTINGS, Settings, get_tag_regexes
@@ -23,6 +22,12 @@ from commitizen.version_schemes import (
 
 if TYPE_CHECKING:
     from commitizen.version_schemes import VersionScheme
+
+    # Self is Python 3.11+ but backported in typing-extensions
+    if sys.version_info < (3, 11):
+        from typing_extensions import Self
+    else:
+        from typing import Self
 
 
 class VersionTag(NamedTuple):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
`typing-extensions` is not installed for Python 3.11+, so fix the import properly.

> [!Note]
> CI was not failing as `typing-extensions` is a transitive dependency of multiple test/lint dependencies but is missing as soon as `commitizen` is installed alone.


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
`commitizen` import/run does not fail on `Self`git s

## Additional context
I might merge this PR without review as soon as the CI pass as the latest release is broken for Python 3.11+
