### PR TITLE
ci(pre-commit): update `pre-commit` hooks to latest version and fix detected errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-useless-excludes
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
@@ -30,13 +30,13 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.13.0
+    rev: 1.19.1
     hooks:
       - id: blacken-docs
         additional_dependencies: [ black~=23.11 ]
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.4.1
     hooks:
       - id: codespell
         name: Run codespell to check for common misspellings in files

--- a/commitizen/tags.py
+++ b/commitizen/tags.py
@@ -55,28 +55,30 @@ class TagRules:
 
     Example:
 
-    ```py
+    ```python
     settings = DEFAULT_SETTINGS.clone()
-    settings.update({
-        "tag_format": "v{version}"
-        "legacy_tag_formats": ["version{version}", "ver{version}"],
-        "ignored_tag_formats": ["ignored{version}"],
-    })
+    settings.update(
+        {
+            "tag_format": "v{version}",
+            "legacy_tag_formats": ["version{version}", "ver{version}"],
+            "ignored_tag_formats": ["ignored{version}"],
+        }
+    )
 
     rules = TagRules.from_settings(settings)
 
     assert rules.is_version_tag("v1.0.0")
     assert rules.is_version_tag("version1.0.0")
     assert rules.is_version_tag("ver1.0.0")
-    assert not rules.is_version_tag("ignored1.0.0", warn=True) # Does not warn
-    assert not rules.is_version_tag("warn1.0.0", warn=True) # Does warn
+    assert not rules.is_version_tag("ignored1.0.0", warn=True)  # Does not warn
+    assert not rules.is_version_tag("warn1.0.0", warn=True)  # Does warn
 
     assert rules.search_version("# My v1.0.0 version").version == "1.0.0"
     assert rules.extract_version("v1.0.0") == Version("1.0.0")
     try:
         assert rules.extract_version("not-a-v1.0.0")
     except InvalidVersion:
-        print "Does not match a tag format"
+        print("Does not match a tag format")
     ```
     """
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -352,7 +352,7 @@ Commitizen provides some version providers for some well known formats:
 | `scm`        | Fetch the version from git and does not need to set it back                                                                                                                                                             |
 | `pep621`     | Get and set version from `pyproject.toml` `project.version` field                                                                                                                                                       |
 | `poetry`     | Get and set version from `pyproject.toml` `tool.poetry.version` field                                                                                                                                                   |
-| `uv`         | Get and set version from `pyproject.toml` `project.version` field and `uv.lock` `pacakge.version` field whose `package.name` field is the same as `pyproject.toml` `project.name` field                                 |
+| `uv`         | Get and set version from `pyproject.toml` `project.version` field and `uv.lock` `package.version` field whose `package.name` field is the same as `pyproject.toml` `project.name` field                                 |
 | `cargo`      | Get and set version from `Cargo.toml` `project.version` field                                                                                                                                                           |
 | `npm`        | Get and set version from `package.json` `version` field, `package-lock.json` `version,packages.''.version` fields if the file exists, and `npm-shrinkwrap.json` `version,packages.''.version` fields if the file exists |
 | `composer`   | Get and set version from `composer.json` `project.version` field                                                                                                                                                        |
@@ -386,22 +386,21 @@ class MyProvider(VersionProvider):
 
     def set_version(self, version: str):
         self.file.write_text(version)
-
 ```
 
 ```python title="setup.py"
 from setuptools import setup
 
 setup(
-    name='my-commitizen-provider',
-    version='0.1.0',
-    py_modules=['my_provider'],
-    install_requires=['commitizen'],
-    entry_points = {
-        'commitizen.provider': [
-            'my-provider = my_provider:MyProvider',
+    name="my-commitizen-provider",
+    version="0.1.0",
+    py_modules=["my_provider"],
+    install_requires=["commitizen"],
+    entry_points={
+        "commitizen.provider": [
+            "my-provider = my_provider:MyProvider",
         ]
-    }
+    },
 )
 ```
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Update pre-commit hooks to their latest version to remove the warnings
Fix detected errors in latest commits

## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
No more pre-commit warning in CI
Doc fixed
