### PR TITLE
fix: display invalid tag information

### DIFF
--- a/commitizen/tags.py
+++ b/commitizen/tags.py
@@ -146,7 +146,9 @@ class TagRules:
             m for regex in self.version_regexes if (m := regex.fullmatch(tag.name))
         )
         if not (m := next(candidates, None)):
-            raise InvalidVersion()
+            raise InvalidVersion(
+                f"Invalid version tag: '{tag.name}' does not match any configured tag format"
+            )
         if "version" in m.groupdict():
             return self.scheme(m.group("version"))
 


### PR DESCRIPTION
and the regex used for validation

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

Starting in 4.4.0 due to #1297 when an invalid tag is present an exception is thrown. I would expect the tag is ignored.

This PR only improves the message, not the root cause

Before

```
packaging.version.InvalidVersion: Invalid version tag
```

After

```
packaging.version.InvalidVersion: Invalid version tag: '2.2.44.aa00000' does not match any configured tag format: re.compile('v?(?P<version>([0-9]+)\\.([0-9]+)(?:\\.([0-9]+))?(?:-([0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*))?(?:\\+[0-9A-Za-z.]+)?(\\w+)?)')
```

## Checklist

- [ ] Add test cases to all the changes you introduce
- [ ] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request

1. create a non semver tag, ie. 2.2.44.aa00000
2. run `cz bump --dry-run` 


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
