### PR TITLE
feat: filter search for commit change type

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -170,13 +170,15 @@ commitizen:
 
 | Parameter   | Type   | Default | Description                                                                                                                                                                                     |
 | ----------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`      | `str`  | `None`  | The type of questions. Valid type: `list`, `input` and etc. [See More][different-question-types]                                                                                                |
+| `type`      | `str`  | `None`  | The type of questions. Valid types: `list`, `select`, `input` and etc. The `select` type provides an interactive searchable list interface. [See More][different-question-types]                  |
 | `name`      | `str`  | `None`  | The key for the value answered by user. It's used in `message_template`                                                                                                                         |
 | `message`   | `str`  | `None`  | Detail description for the question.                                                                                                                                                            |
-| `choices`   | `list` | `None`  | (OPTIONAL) The choices when `type = list`. Either use a list of values or a list of dictionaries with `name` and `value` keys. Keyboard shortcuts can be defined via `key`. See examples above. |
+| `choices`   | `list` | `None`  | (OPTIONAL) The choices when `type = list` or `type = select`. Either use a list of values or a list of dictionaries with `name` and `value` keys. Keyboard shortcuts can be defined via `key`. See examples above. |
 | `default`   | `Any`  | `None`  | (OPTIONAL) The default value for this question.                                                                                                                                                 |
 | `filter`    | `str`  | `None`  | (OPTIONAL) Validator for user's answer. **(Work in Progress)**                                                                                                                                  |
-| `multiline` | `bool` | `False` | (OPTIONAL) Enable multiline support when `type = input`.                                                                                                                                            |
+| `multiline` | `bool` | `False` | (OPTIONAL) Enable multiline support when `type = input`.                                                                                                                                        |
+| `use_search_filter` | `bool` | `False` | (OPTIONAL) Enable search/filter functionality for list/select type questions. This allows users to type and filter through the choices.                                                  |
+| `use_jk_keys` | `bool` | `True` | (OPTIONAL) Enable/disable j/k keys for navigation in list/select type questions. Set to false if you prefer arrow keys only.                                                                    |
 
 [different-question-types]: https://github.com/tmbo/questionary#different-question-types
 
@@ -445,8 +447,8 @@ Commitizen gives you the possibility to provide your own changelog template, by:
 
 - providing one with your customization class
 - providing one from the current working directory and setting it:
-    - as [configuration][template-config]
-    - as `--template` parameter to both `bump` and `changelog` commands
+  - as [configuration][template-config]
+  - as `--template` parameter to both `bump` and `changelog` commands
 - either by providing a template with the same name as the default template
 
 By default, the template used is the `CHANGELOG.md.j2` file from the commitizen repository.

--- a/tests/test_cz_search_filter.py
+++ b/tests/test_cz_search_filter.py
@@ -1,0 +1,76 @@
+import pytest
+
+from commitizen.config import TomlConfig
+from commitizen.cz.customize import CustomizeCommitsCz
+
+TOML_WITH_SEARCH_FILTER = r"""
+[tool.commitizen]
+name = "cz_customize"
+
+[tool.commitizen.customize]
+message_template = "{{change_type}}:{% if scope %} ({{scope}}){% endif %}{% if breaking %}!{% endif %} {{message}}"
+
+[[tool.commitizen.customize.questions]]
+type = "select"
+name = "change_type"
+message = "Select the type of change you are committing"
+use_search_filter = true
+use_jk_keys = false
+choices = [
+    {value = "fix", name = "fix: A bug fix. Correlates with PATCH in SemVer"},
+    {value = "feat", name = "feat: A new feature. Correlates with MINOR in SemVer"},
+    {value = "docs", name = "docs: Documentation only changes"},
+    {value = "style", name = "style: Changes that do not affect the meaning of the code"},
+    {value = "refactor", name = "refactor: A code change that neither fixes a bug nor adds a feature"},
+    {value = "perf", name = "perf: A code change that improves performance"},
+    {value = "test", name = "test: Adding missing or correcting existing tests"},
+    {value = "build", name = "build: Changes that affect the build system or external dependencies"},
+    {value = "ci", name = "ci: Changes to CI configuration files and scripts"}
+]
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "scope"
+message = "What is the scope of this change? (class or file name): (press [enter] to skip)"
+
+[[tool.commitizen.customize.questions]]
+type = "input"
+name = "message"
+message = "Write a short and imperative summary of the code changes: (lower case and no period)"
+"""
+
+
+@pytest.fixture
+def config():
+    return TomlConfig(data=TOML_WITH_SEARCH_FILTER, path="not_exist.toml")
+
+
+def test_questions_with_search_filter(config):
+    """Test that questions are properly configured with search filter"""
+    cz = CustomizeCommitsCz(config)
+    questions = cz.questions()
+
+    # Test that the first question (change_type) has search filter enabled
+    assert questions[0]["type"] == "select"
+    assert questions[0]["name"] == "change_type"
+    assert questions[0]["use_search_filter"] is True
+    assert questions[0]["use_jk_keys"] is False
+
+    # Test that the choices are properly configured
+    choices = questions[0]["choices"]
+    assert len(choices) == 9  # We have 9 commit types
+    assert choices[0]["value"] == "fix"
+    assert choices[1]["value"] == "feat"
+
+
+def test_message_template(config):
+    """Test that the message template is properly configured"""
+    cz = CustomizeCommitsCz(config)
+    template = cz.message(
+        {
+            "change_type": "feat",
+            "scope": "search",
+            "message": "add search filter support",
+        }
+    )
+    assert template == "feat: (search) add search filter support"


### PR DESCRIPTION
## Description
Added search filter functionality to commit type selection in Conventional Commits. This allows users to quickly find commit types by typing part of the type name or description, enhancing user experience especially when working with many commit types.

Changes Made
1. Added use_search_filter: True to enable search filtering in the commit type selection.
2. Set use_jk_keys: False to prevent conflicts with search functionality (as j/k keys can be part of the search term).
3. Because the interaction questionary can not test directly so I test to verify search filter functionality and parameter works correctly.
4. Added newline at the end of file to comply with PEP 8 standards.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
When a user types characters during commit type selection, the list of options is filtered to show only those containing the typed characters. For example, typing "fix" will show the item that contains "fix" .

## Steps to Test This Pull Request
1. Run cz commit to start the commit process
2. When the commit type selection appears, type what you want to search. eg: "fix"
3. Verify that the list filters to show the all "fix" items 
5. Try other search terms to confirm filtering works as expected

## Additional context