### PR TITLE
fix: cz bump subdir

### DIFF
--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -32,21 +32,28 @@ class Changelog:
             raise NotAGitProjectError()
 
         self.config: BaseConfig = config
+        changelog_file_name = args.get("file_name") or cast(
+            str, self.config.settings.get("changelog_file")
+        )
+        if not isinstance(changelog_file_name, str):
+            raise NotAllowed(
+                "Changelog file name is broken.\n"
+                "Check the flag `--file-name` in the terminal "
+                f"or the setting `changelog_file` in {self.config.path}"
+            )
+        self.file_name = (
+            str(Path(self.config.path.parent) / changelog_file_name)
+            if self.config.path is not None
+            else changelog_file_name
+        )
+
         self.encoding = self.config.settings["encoding"]
         self.cz = factory.commiter_factory(self.config)
 
         self.start_rev = args.get("start_rev") or self.config.settings.get(
             "changelog_start_rev"
         )
-        self.file_name = args.get("file_name") or cast(
-            str, self.config.settings.get("changelog_file")
-        )
-        if not isinstance(self.file_name, str):
-            raise NotAllowed(
-                "Changelog file name is broken.\n"
-                "Check the flag `--file-name` in the terminal "
-                f"or the setting `changelog_file` in {self.config.path}"
-            )
+
         self.changelog_format = get_changelog_format(self.config, self.file_name)
 
         self.incremental = args["incremental"] or self.config.settings.get(

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import os.path
 from difflib import SequenceMatcher
 from operator import itemgetter
@@ -42,7 +43,7 @@ class Changelog:
                 f"or the setting `changelog_file` in {self.config.path}"
             )
         self.file_name = (
-            str(Path(self.config.path.parent) / changelog_file_name)
+            os.path.join(str(self.config.path.parent), changelog_file_name)
             if self.config.path is not None
             else changelog_file_name
         )

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -1640,7 +1641,7 @@ def test_tags_rules_get_version_tags(capsys: pytest.CaptureFixture):
 
 def test_changelog_file_name_from_args_and_config():
     mock_config = Mock(spec=BaseConfig)
-    mock_config.path.parent = "/my/project/"
+    mock_config.path.parent = "/my/project"
     mock_config.settings = {
         "name": "cz_conventional_commits",
         "changelog_file": "CHANGELOG.md",
@@ -1660,8 +1661,12 @@ def test_changelog_file_name_from_args_and_config():
         "unreleased_version": "1.0.1",
     }
     changelog = Changelog(mock_config, args)
-    assert changelog.file_name == "/my/project/CUSTOM.md"
+    assert os.path.normpath(changelog.file_name) == os.path.normpath(
+        os.path.join("/my/project", "CUSTOM.md")
+    )
 
     args = {"incremental": None, "dry_run": False, "unreleased_version": "1.0.1"}
     changelog = Changelog(mock_config, args)
-    assert changelog.file_name == "/my/project/CHANGELOG.md"
+    assert os.path.normpath(changelog.file_name) == os.path.normpath(
+        os.path.join("/my/project", "CHANGELOG.md")
+    )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

<!-- Describe what the change is -->
<!-- Example: -->
This pull request fixes the construction of the changelog file name in [changelog.py](cci:7://file:///home/yusin0903/commitizen/commitizen/commands/changelog.py:0:0-0:0) to ensure type safety and correct path handling. It also adds proper error handling for missing or invalid changelog file names.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior

<!-- A clear and concise description of what you expected to happen -->
<!-- Example: -->
The changelog command should now correctly resolve the changelog file path, regardless of whether the config path is set, and should raise a clear error if the file name is missing or invalid.

## Steps to Test This Pull Request

<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
1. Run `poetry all` and ensure all checks pass.
2. Run the changelog command with and without the `--file-name` argument.
3. Verify that the changelog file is created at the expected location.
4. Check that an error is raised if the changelog file name is missing or invalid.

## Additional context
Sorry, I don' t know why my last branch have hide word problem. So I open lots of  PR and close them . 

By the way, I saw the github action warning 
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101Show more
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
<!-- Example: -->
