### PR TITLE
fix(commit): use os.unlink to remove temp file

### DIFF
--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -89,7 +89,7 @@ class Commit:
         subprocess.call(argv)
         with open(file_path) as temp_file:
             message = temp_file.read().strip()
-        file.unlink()
+        os.unlink(file.name)
         return message
 
     def __call__(self):

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -511,8 +511,6 @@ def test_manual_edit(editor, config, mocker: MockFixture, tmp_path):
 
         assert edited_message == test_message.strip()
 
-        temp_file.unlink()
-
 
 @skip_below_py_3_13
 def test_commit_command_shows_description_when_use_help_option(


### PR DESCRIPTION
NamedTemporaryFile doesn't have a unlink function when delete=False is used

Fix https://github.com/commitizen-tools/commitizen/issues/1352


## Description
Fix the traceback, when `cz c --edit` is used


## Checklist

- [ ] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
Save the commit message without an exception traceback.

## Steps to Test This Pull Request
1. Run cz commit -e
```
❯ cz c --edit
? Select the type of change you are committing fix: A bug fix. Correlates with PATCH in SemVer
? What is the scope of this change? (class or file name): (press [enter] to skip)
 test
? Write a short and imperative summary of the code changes: (lower case and no period)
 test
? Provide additional contextual information about the code changes: (press [enter] to skip)
 test
? Is this a BREAKING CHANGE? Correlates with MAJOR in SemVer No
? Footer. Information about Breaking Changes and reference issues that this commit closes: (press [enter] to skip)
 test
Traceback (most recent call last):
  File ".../commitizen/.venv/bin/cz", line 6, in <module>
    sys.exit(main())
  File "...//commitizen/commitizen/cli.py", line 656, in main
    args.func(conf, arguments)()
  File ".../commitizen/commitizen/commands/commit.py", line 130, in __call__
    m = self.manual_edit(m)
  File ".../commitizen/commitizen/commands/commit.py", line 92, in manual_edit
    file.unlink()
  File "/usr/lib/python3.10/tempfile.py", line 633, in __getattr__
    a = getattr(file, name)
AttributeError: '_io.TextIOWrapper' object has no attribute 'unlink'
```



## Additional context
https://github.com/commitizen-tools/commitizen/issues/1352
