### PR TITLE
fix(docs): fix the regex and examples in the monorepo documentation

### DIFF
--- a/docs/tutorials/monorepo_guidance.md
+++ b/docs/tutorials/monorepo_guidance.md
@@ -71,11 +71,11 @@ Example config and commit for `library-b`:
 
 ```toml
 [tool.commitizen.customize]
-changelog_pattern = "^(feat|fix)\\(library-b\\)(!)?:" #the pattern on types can be a wild card or any types you wish to include
+changelog_pattern = "^(feat|fix)\(library-b\)(!)?:" #the pattern on types can be a wild card or any types you wish to include
 ```
 
 A commit message looking like this, would be included:
 
 ```
-fix:(library-b) Some awesome message
+fix(library-b): Some awesome message
 ```


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
The regex in the monorepo example seems to follow the Python formatting, but the toml text should follow the raw string instead (unless this library internally calls eval?).

Also the example does not follow regex format in the setting.

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior

Update the regex pattern and update the example regex.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
