### PR TITLE
fix(docs): fix url link and table formatting in the customization docs

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -177,6 +177,7 @@ commitizen:
 | `default`   | `Any`  | `None`  | (OPTIONAL) The default value for this question.                                                                                                                                                 |
 | `filter`    | `str`  | `None`  | (OPTIONAL) Validator for user's answer. **(Work in Progress)**                                                                                                                                  |
 | `multiline` | `bool` | `False` | (OPTIONAL) Enable multiline support when `type = input`.                                                                                                                                            |
+
 [different-question-types]: https://github.com/tmbo/questionary#different-question-types
 
 #### Shortcut keys

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -164,7 +164,7 @@ commitizen:
 | `change_type_map`   | `dict` | `None`  | (OPTIONAL) Dictionary mapping the type of the commit to a changelog entry                                                                                                                                                        |
 
 [jinja2]: https://jinja.palletsprojects.com/en/2.10.x/
-[changelog-spec]: https://commitizen-tools.github.io/commitizen/changelog/
+[changelog-spec]: https://commitizen-tools.github.io/commitizen/commands/changelog/
 
 #### Detailed `questions` content
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
The docs currently is missing a space, which makes the reference part of the table, and one of the url reference is broken.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
The table and the reference are separate and the urls link to the right pages.


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
