### PR TITLE
docs: Revert removal of escape in monorepo toml example

### DIFF
--- a/docs/tutorials/monorepo_guidance.md
+++ b/docs/tutorials/monorepo_guidance.md
@@ -71,7 +71,7 @@ Example config and commit for `library-b`:
 
 ```toml
 [tool.commitizen.customize]
-changelog_pattern = "^(feat|fix)\(library-b\)(!)?:" #the pattern on types can be a wild card or any types you wish to include
+changelog_pattern = "^(feat|fix)\\(library-b\\)(!)?:" #the pattern on types can be a wild card or any types you wish to include
 ```
 
 A commit message looking like this, would be included:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Sorry I messed up, I forgot that you're required to escape the `\` in TOML. See #1398. I should have not removed it. Though the example should still be fixed so I'm only reverting the escapes. I'm really sorry D:.


## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
TOML requires `\` to be escaped as `\\`


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
