### PR TITLE
feat: add support for `Cargo.lock` version update

### DIFF
--- a/commitizen/providers/cargo_provider.py
+++ b/commitizen/providers/cargo_provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import tomlkit
 
 from commitizen.providers.base_provider import TomlProvider
@@ -13,6 +15,11 @@ class CargoProvider(TomlProvider):
     """
 
     filename = "Cargo.toml"
+    lock_filename = "Cargo.lock"
+
+    @property
+    def lock_file(self) -> Path:
+        return Path() / self.lock_filename
 
     def get(self, document: tomlkit.TOMLDocument) -> str:
         try:
@@ -28,3 +35,23 @@ class CargoProvider(TomlProvider):
         except tomlkit.exceptions.NonExistentKey:
             ...
         document["package"]["version"] = version  # type: ignore
+
+    def set_version(self, version: str) -> None:
+        super().set_version(version)
+        if self.lock_file.exists():
+            self.set_lock_version(version)
+
+    def set_lock_version(self, version: str) -> None:
+        cargo_toml_content = tomlkit.parse(self.file.read_text())
+        try:
+            package_name = cargo_toml_content["package"]["name"]  # type: ignore
+        except tomlkit.exceptions.NonExistentKey:
+            package_name = cargo_toml_content["workspace"]["package"]["name"]  # type: ignore
+
+        cargo_lock_content = tomlkit.parse(self.lock_file.read_text())
+        packages: tomlkit.items.AoT = cargo_lock_content["package"]  # type: ignore[assignment]
+        for i, package in enumerate(packages):
+            if package["name"] == package_name:
+                cargo_lock_content["package"][i]["version"] = version  # type: ignore[index]
+                break
+        self.lock_file.write_text(tomlkit.dumps(cargo_lock_content))

--- a/docs/config.md
+++ b/docs/config.md
@@ -353,7 +353,7 @@ Commitizen provides some version providers for some well known formats:
 | `pep621`     | Get and set version from `pyproject.toml` `project.version` field                                                                                                                                                       |
 | `poetry`     | Get and set version from `pyproject.toml` `tool.poetry.version` field                                                                                                                                                   |
 | `uv`         | Get and set version from `pyproject.toml` `project.version` field and `uv.lock` `package.version` field whose `package.name` field is the same as `pyproject.toml` `project.name` field                                 |
-| `cargo`      | Get and set version from `Cargo.toml` `project.version` field                                                                                                                                                           |
+| `cargo`      | Get and set version from `Cargo.toml` `package.version` field and `Cargo.lock` `package.version` field whose `package.name` field is the same as `Cargo.toml` `package.name` field                                      |
 | `npm`        | Get and set version from `package.json` `version` field, `package-lock.json` `version,packages.''.version` fields if the file exists, and `npm-shrinkwrap.json` `version,packages.''.version` fields if the file exists |
 | `composer`   | Get and set version from `composer.json` `project.version` field                                                                                                                                                        |
 

--- a/tests/providers/test_cargo_provider.py
+++ b/tests/providers/test_cargo_provider.py
@@ -15,7 +15,7 @@ name = "whatever"
 version = "0.1.0"
 """
 
-CARGO_EXPECTED = """\
+CARGO_TOML_EXPECTED = """\
 [package]
 name = "whatever"
 version = "42.1"
@@ -27,7 +27,7 @@ name = "whatever"
 version = "0.1.0"
 """
 
-CARGO_WORKSPACE_EXPECTED = """\
+CARGO_WORKSPACE_TOML_EXPECTED = """\
 [workspace.package]
 name = "whatever"
 version = "42.1"
@@ -37,8 +37,8 @@ version = "42.1"
 @pytest.mark.parametrize(
     "content, expected",
     (
-        (CARGO_TOML, CARGO_EXPECTED),
-        (CARGO_WORKSPACE_TOML, CARGO_WORKSPACE_EXPECTED),
+        (CARGO_TOML, CARGO_TOML_EXPECTED),
+        (CARGO_WORKSPACE_TOML, CARGO_WORKSPACE_TOML_EXPECTED),
     ),
 )
 def test_cargo_provider(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
As depicted in #1201:

> In Rust, when you change the version of the app, the `Cargo.lock` file must be changed too.

This PR introduces the capability of updating the package version in the `Cargo.lock` file, where the package name is the one defined in `Cargo.toml`, for the `cargo` version provider. 

## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
For [`cargo` version provider](https://commitizen-tools.github.io/commitizen/config/#version-providers), if a `Cargo.lock` file also exists within the same directory as `Cargo.toml`, the `Cargo.lock`'s `package.version` field whose `package.name` field is the same as `Cargo.toml`'s `package.name` field should be updated along with `Cargo.toml`.

## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
Resolves: #1201