### PR TITLE
fix: ignore invalid tags

### DIFF
--- a/commitizen/providers/scm_provider.py
+++ b/commitizen/providers/scm_provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from packaging.version import InvalidVersion
+
 from commitizen.git import get_tags
 from commitizen.providers.base_provider import VersionProvider
 from commitizen.tags import TagRules
@@ -18,7 +20,13 @@ class ScmProvider(VersionProvider):
         rules = TagRules.from_settings(self.config.settings)
         tags = get_tags(reachable_only=True)
         version_tags = rules.get_version_tags(tags)
-        versions = sorted(rules.extract_version(t) for t in version_tags)
+        versions = []
+        for t in version_tags:
+            try:
+                versions.append(rules.extract_version(t))
+            except InvalidVersion:
+                continue
+        versions = sorted(versions)
         if not versions:
             return "0.0.0"
         return str(versions[-1])

--- a/tests/providers/test_scm_provider.py
+++ b/tests/providers/test_scm_provider.py
@@ -23,6 +23,7 @@ from tests.utils import (
         ("$version", "0.1.0", "0.1.0"),
         ("$version", "v0.1.0", "0.1.0"),
         ("$version", "v-0.1.0", "0.0.0"),
+        ("$version", "1.0.0.xxxx", "0.0.0"),
         # If tag_format is not None or $version, TAG_FORMAT_REGEXS are used, which are
         # much more lenient but require a v prefix.
         ("v$version", "v0.1.0", "0.1.0"),


### PR DESCRIPTION
Starting in 4.4.0 due to #1297 when an invalid tag is present an exception is thrown

This commit ignores the invalid tags

Follow up from #1375

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

Starting in 4.4.0 due to #1297 when an invalid tag is present an exception is thrown

This commit ignores the invalid tags

Follow up from #1375

## Checklist

- [x] Add test cases to all the changes you introduce
- [ ] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [ ] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->

in https://github.com/carlossg/commitizen-test.git the fix changes from

```
❯ cz bump --dry-run
Traceback (most recent call last):
  File "/opt/homebrew/bin/cz", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/opt/homebrew/Cellar/commitizen/4.7.0/libexec/lib/python3.13/site-packages/commitizen/cli.py", line 656, in main
    args.func(conf, arguments)()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/opt/homebrew/Cellar/commitizen/4.7.0/libexec/lib/python3.13/site-packages/commitizen/commands/bump.py", line 147, in __call__
    current_version = self.scheme(provider.get_version())
                                  ~~~~~~~~~~~~~~~~~~~~^^
  File "/opt/homebrew/Cellar/commitizen/4.7.0/libexec/lib/python3.13/site-packages/commitizen/providers/scm_provider.py", line 21, in get_version
    versions = sorted(rules.extract_version(t) for t in version_tags)
  File "/opt/homebrew/Cellar/commitizen/4.7.0/libexec/lib/python3.13/site-packages/commitizen/providers/scm_provider.py", line 21, in <genexpr>
    versions = sorted(rules.extract_version(t) for t in version_tags)
                      ~~~~~~~~~~~~~~~~~~~~~^^^
  File "/opt/homebrew/Cellar/commitizen/4.7.0/libexec/lib/python3.13/site-packages/commitizen/tags.py", line 149, in extract_version
    raise InvalidVersion(
        f"Invalid version tag: '{tag.name}' does not match any configured tag format"
    )
packaging.version.InvalidVersion: Invalid version tag: '1.0.0.fb3a1d1' does not match any configured tag format
```

to

```
❯ cz bump --dry-run
bump: version 1.0.0 → 1.1.0
tag to create: 1.1.0
increment detected: MINOR
```



## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
