### PR TITLE
feat(cli): add --tag-format argument to changelog command

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -450,6 +450,10 @@ data = {
                         "help": "Export the changelog template into this file instead of rendering it",
                     },
                     *deepcopy(tpl_arguments),
+                    {
+                        "name": "--tag-format",
+                        "help": "The format of the tag, wrap around simple quotes",
+                    },
                 ],
             },
             {

--- a/tests/commands/test_changelog_command/test_changelog_command_shows_description_when_use_help_option.txt
+++ b/tests/commands/test_changelog_command/test_changelog_command_shows_description_when_use_help_option.txt
@@ -3,7 +3,7 @@ usage: cz changelog [-h] [--dry-run] [--file-name FILE_NAME]
                     [--start-rev START_REV] [--merge-prerelease]
                     [--version-scheme {pep440,semver,semver2}]
                     [--export-template EXPORT_TEMPLATE] [--template TEMPLATE]
-                    [--extra EXTRA]
+                    [--extra EXTRA] [--tag-format TAG_FORMAT]
                     [rev_range]
 
 generate changelog (note that it will overwrite existing file)
@@ -37,3 +37,5 @@ options:
                         changelog template file name (relative to the current
                         working directory)
   --extra, -e EXTRA     a changelog extra variable (in the form 'key=value')
+  --tag-format TAG_FORMAT
+                        The format of the tag, wrap around simple quotes


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
This PR adds missing "--tag-format" argument to `cz changelog` command, similar to `cz bump` command.
The changelog command implementation already checks "tag_format" argument but cli support was just missing.
## Checklist

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and test
- [x] Test the changes on the local machine manually
- [x] Update the documentation for the changes

## Expected behavior
<!-- A clear and concise description of what you expected to happen -->
Tag format can be given as argument to `cz changelog` command. The changelog command already checks "tag_format" argument: https://github.com/commitizen-tools/commitizen/blob/be02801f92cb948ba86d8c1a9a306be4172e4efe/commitizen/commands/changelog.py#L85

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
