### PR TITLE
fix(bump): don't fail if an invalid version tag is present (fix #1410)

### DIFF
--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -1788,13 +1788,13 @@ def test_changelog_ignored_tags(
     out = open(changelog_path).read()
     _, err = capsys.readouterr()
     assert "## ignore-0.1.0" not in out
-    assert "InvalidVersion ignore-0.1.0" not in err
+    assert "Invalid version tag: 'ignore-0.1.0'" not in err
     assert "## ignored" not in out
-    assert "InvalidVersion ignored" not in err
+    assert "Invalid version tag: 'ignored'" not in err
     assert "## not-ignored" not in out
-    assert "InvalidVersion not-ignored" in err
+    assert "Invalid version tag: 'not-ignored'" in err
     assert "## v0.3.0" in out
-    assert "InvalidVersion v0.3.0" not in err
+    assert "Invalid version tag: 'v0.3.0'" not in err
 
 
 def test_changelog_template_extra_quotes(

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1635,7 +1635,7 @@ def test_tags_rules_get_version_tags(capsys: pytest.CaptureFixture):
     }
 
     captured = capsys.readouterr()
-    assert captured.err.count("InvalidVersion") == 2
+    assert captured.err.count("Invalid version tag:") == 2
     assert captured.err.count("not-a-version") == 2
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Fix a regression introduced in the 4.4.0 by #1297: `bump` command is failing when an invalid tag is present and not listed in `ignored_tags` while it was just warning about before.

This PR restores this behavior (bump will work if an invalid tag is present, but a warning will be emitted).

The error/warning message is now the same whatever the place it is triggered.


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is ~maintained~ restored
  - [x] Document any manual testing steps performed
- [x] Update the documentation for the changes (N/A)

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly (N/A)

## Expected Behavior
Cf. #1410

## Steps to Test This Pull Request
Cf. #1410


## Additional Context
Supersedes and closes #1410 
