### PR TITLE
docs(bug_report): add fallback command if cz version --report is not …

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,6 +53,14 @@ body:
         ```bash
         cz version --report
         ```
+
+        If `cz version --report` is not available, please run the following commands to retrieve your environment information:
+
+        ```bash
+        echo "Commitizen Version: $(cz version)"
+        echo "Python Version: $(python3 -c 'import sys; print(sys.version)')"
+        echo "Operating System: $(python3 -c 'import platform; print(platform.system())')"
+        ```
       placeholder: |
         Commitizen Version: 4.0.0
         Python Version: 3.13.3 (main, Apr  8 2025, 13:54:08) [Clang 16.0.0 (clang-1600.0.26.6)]


### PR DESCRIPTION
…available

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

Just noticed in #1435, the command `cz version --report` is broken.

In case the command is not available, I added the alternative commands in `bug_report.yml`.


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
