### PR TITLE
fix(defaults): add non-capitalized default constants back and deprecated warning

### DIFF
--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+import warnings
 from collections import OrderedDict
 from collections.abc import Iterable, MutableMapping, Sequence
 from typing import Any, TypedDict
@@ -153,3 +154,31 @@ def get_tag_regexes(
         **{f"${k}": v for k, v in regexs.items()},
         **{f"${{{k}}}": v for k, v in regexs.items()},
     }
+
+
+def __getattr__(name: str) -> Any:
+    # PEP-562: deprecate module-level variable
+
+    # {"deprecated key": (value, "new key")}
+    deprecated_vars = {
+        "bump_pattern": (BUMP_PATTERN, "BUMP_PATTERN"),
+        "bump_map": (BUMP_MAP, "BUMP_MAP"),
+        "bump_map_major_version_zero": (
+            BUMP_MAP_MAJOR_VERSION_ZERO,
+            "BUMP_MAP_MAJOR_VERSION_ZERO",
+        ),
+        "bump_message": (BUMP_MESSAGE, "BUMP_MESSAGE"),
+        "change_type_order": (CHANGE_TYPE_ORDER, "CHANGE_TYPE_ORDER"),
+        "encoding": (ENCODING, "ENCODING"),
+        "name": (DEFAULT_SETTINGS["name"], "DEFAULT_SETTINGS['name']"),
+    }
+    if name in deprecated_vars:
+        value, replacement = deprecated_vars[name]
+        warnings.warn(
+            f"{name} is deprecated and will be removed in a future version. "
+            f"Use {replacement} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return value
+    raise AttributeError(f"{name} is not an attribute of {__name__}")

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,31 @@
+import pytest
+
+from commitizen import defaults
+
+
+def test_getattr_deprecated_vars():
+    # Test each deprecated variable
+    with pytest.warns(DeprecationWarning) as record:
+        assert defaults.bump_pattern == defaults.BUMP_PATTERN
+        assert defaults.bump_map == defaults.BUMP_MAP
+        assert (
+            defaults.bump_map_major_version_zero == defaults.BUMP_MAP_MAJOR_VERSION_ZERO
+        )
+        assert defaults.bump_message == defaults.BUMP_MESSAGE
+        assert defaults.change_type_order == defaults.CHANGE_TYPE_ORDER
+        assert defaults.encoding == defaults.ENCODING
+        assert defaults.name == defaults.DEFAULT_SETTINGS["name"]
+
+    # Verify warning messages
+    assert len(record) == 7
+    for warning in record:
+        assert "is deprecated and will be removed in a future version" in str(
+            warning.message
+        )
+
+
+def test_getattr_non_existent():
+    # Test non-existent attribute
+    with pytest.raises(AttributeError) as exc_info:
+        _ = defaults.non_existent_attribute
+    assert "is not an attribute of" in str(exc_info.value)


### PR DESCRIPTION
relates: #1446

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

Related commit: https://github.com/commitizen-tools/commitizen/commit/94c02b3faf89cacf7186ad8a84e9200ede851574#diff-c951de16d627d82e01eb3ce8d7c4f0b28973ffe147520620762e7140ede2dd80

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [x] Update the documentation for the changes

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
