### PR TITLE
docs(taplo): add toml formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
       - id: debug-statements
       - id: no-commit-to-branch
       - id: check-merge-conflict
-      - id: check-toml
+      - id: check-toml # TOML linter (syntax checker)
       - id: check-yaml
         args: [ '--unsafe' ] # for mkdocs.yml
       - id: detect-private-key
@@ -55,17 +55,22 @@ repos:
         stages:
           - post-commit
 
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+
   - repo: local
     hooks:
       - id: format
-        name: Format
+        name: Format Python code via Poetry
         language: system
         pass_filenames: false
         entry: poetry format
         types: [ python ]
 
       - id: linter and test
-        name: Linters
+        name: Linters via Poetry
         language: system
         pass_filenames: false
         entry: poetry lint

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,4 @@
+include = ["pyproject.toml", ".taplo.toml"]
+
+[formatting]
+indent_string = "    "


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

I noticed that I accidentally introduced unexpected style change in `pyproject.toml` (50fd65f), so I think it would be better if we have a consistent `toml` formatter.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [x] Update the documentation for the changes

## Expected Behavior

Pre-commit hook now has `taplo` and it should work even without installing `taplo` locally.

## Steps to Test This Pull Request

1. Randomly insert white spaces in `pyproject.toml` and save without formatting to make the formatting bad.
2. `git commit`
3. The broken format should be fixed.


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->

https://taplo.tamasfe.dev/configuration/formatter-options.html
