### PR TITLE
docs(README): fix broken bullet points

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -163,12 +163,14 @@ cz bump
 ```
 
 This command:
+
 - Bumps your project's version
 - Creates a git tag
 - Updates the changelog (if `update_changelog_on_bump` is enabled)
 - Updates version files
 
 You can customize:
+
 - [Version files](https://commitizen-tools.github.io/commitizen/commands/bump/#version_files)
 - [Version scheme](https://commitizen-tools.github.io/commitizen/commands/bump/#version_scheme)
 - [Version provider](https://commitizen-tools.github.io/commitizen/config/#version-providers)
@@ -187,6 +189,7 @@ cz changelog --dry-run "$(cz version -p)"
 ```
 
 This command is particularly useful for automation scripts and CI/CD pipelines.
+
 For example, you can use the output of the command `cz changelog --dry-run "$(cz version -p)"` to notify your team about a new release in Slack.
 
 #### Pre-commit Integration


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

I didn't notice this in the previous PR...


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly
  - [x] Check if there are any broken links in the documentation

> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```
