### PR TITLE
docs: correct case GitHub

### DIFF
--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -191,7 +191,7 @@ understand that the user wants to create a changelog. It is recommended to be
 explicit and use `--changelog` (or the setting `update_changelog_on_bump`).
 
 This command is useful to "transport" the newly created changelog.
-It can be sent to an auditing system, or to create a Github Release.
+It can be sent to an auditing system, or to create a GitHub Release.
 
 Example:
 

--- a/docs/tutorials/github_actions.md
+++ b/docs/tutorials/github_actions.md
@@ -1,4 +1,4 @@
-## Create a new release with Github Actions
+## Create a new release with GitHub Actions
 
 ### Automatic bumping of version
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
       - Auto check commits: "tutorials/auto_check.md"
       - Auto prepare commit message: "tutorials/auto_prepare_commit_message.md"
       - GitLab CI: "tutorials/gitlab_ci.md"
-      - Github Actions: "tutorials/github_actions.md"
+      - GitHub Actions: "tutorials/github_actions.md"
       - Jenkins pipeline: "tutorials/jenkins_pipeline.md"
       - Developmental releases: "tutorials/dev_releases.md"
       - Monorepo support: "tutorials/monorepo_guidance.md"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly
  - [x] Check if there are any broken links in the documentation

> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```
