### PR TITLE
docs(external_links): typo

### DIFF
--- a/docs/external_links.md
+++ b/docs/external_links.md
@@ -4,7 +4,7 @@
 
 | Name                                                                      | Speaker         | Occasion                                             | Language | Extra                                                                                                                            |
 | ------------------------------------------------------------------------- | --------------- | ---------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| commitizen-tools: What can we gain from crafting a git message convention | Wei Lee         | Taipey.py 2020 June Meetup, Remote Python Pizza 2020 | English  | [slides](https://speakerdeck.com/leew/commitizen-tools-what-can-we-gain-from-crafting-a-git-message-convention-at-taipey-dot-py) |
+| commitizen-tools: What can we gain from crafting a git message convention | Wei Lee         | Taipei.py 2020 June Meetup, Remote Python Pizza 2020 | English  | [slides](https://speakerdeck.com/leew/commitizen-tools-what-can-we-gain-from-crafting-a-git-message-convention-at-taipey-dot-py) |
 | Automating release cycles                                                 | Santiago Fraire | PyAmsterdam June 24, 2020, Online                    | English  | [slides](https://woile.github.io/commitizen-presentation/)                                                                       |
 | [Automatizando Releases con Commitizen y Github Actions][automatizando]   | Santiago Fraire | PyConAr 2020, Remote                                 | Español  | [slides](https://woile.github.io/automating-releases-github-actions-presentation/#/)                                             |
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

Ping @Lee-W 


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly
  - [x] Check if there are any broken links in the documentation

> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```
