### PR TITLE
refactor(BaseCommitizen): remove unused process_commit

### DIFF
--- a/commitizen/cz/base.py
+++ b/commitizen/cz/base.py
@@ -99,10 +99,3 @@ class BaseCommitizen(metaclass=ABCMeta):
     def info(self) -> str:
         """Information about the standardized commit message."""
         raise NotImplementedError("Not Implemented yet")
-
-    def process_commit(self, commit: str) -> str:
-        """Process commit for changelog.
-
-        If not overwritten, it returns the first line of commit.
-        """
-        return commit.split("\n")[0]

--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 from commitizen import defaults
 from commitizen.cz.base import BaseCommitizen
@@ -198,8 +197,3 @@ class ConventionalCommitsCz(BaseCommitizen):
         filepath = os.path.join(dir_path, "conventional_commits_info.txt")
         with open(filepath, encoding=self.config.settings["encoding"]) as f:
             return f.read()
-
-    def process_commit(self, commit: str) -> str:
-        if m := re.match(self.schema_pattern(), commit):
-            return m.group(3).strip()
-        return ""

--- a/tests/test_cz_base.py
+++ b/tests/test_cz_base.py
@@ -42,9 +42,3 @@ def test_info(config):
     cz = DummyCz(config)
     with pytest.raises(NotImplementedError):
         cz.info()
-
-
-def test_process_commit(config):
-    cz = DummyCz(config)
-    message = cz.process_commit("test(test_scope): this is test msg")
-    assert message == "test(test_scope): this is test msg"

--- a/tests/test_cz_conventional_commits.py
+++ b/tests/test_cz_conventional_commits.py
@@ -130,26 +130,3 @@ def test_info(config):
     conventional_commits = ConventionalCommitsCz(config)
     info = conventional_commits.info()
     assert isinstance(info, str)
-
-
-@pytest.mark.parametrize(
-    ("commit_message", "expected_message"),
-    [
-        (
-            "test(test_scope): this is test msg",
-            "this is test msg",
-        ),
-        (
-            "test(test_scope)!: this is test msg",
-            "this is test msg",
-        ),
-        (
-            "test!(test_scope): this is test msg",
-            "",
-        ),
-    ],
-)
-def test_process_commit(commit_message, expected_message, config):
-    conventional_commits = ConventionalCommitsCz(config)
-    message = conventional_commits.process_commit(commit_message)
-    assert message == expected_message


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

Discussed with @Lee-W offline. `process_commit` is introduced in #179 and nobody is using it(?


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)
