### PR TITLE
docs(contributing): add Contributing TL;DR page

### DIFF
--- a/docs/contributing_tldr.md
+++ b/docs/contributing_tldr.md
@@ -9,6 +9,8 @@ Feel free to send a PR to update this file if you find anything useful. 🙇
 
 Please check the [pyproject.toml](https://github.com/commitizen-tools/commitizen/blob/master/pyproject.toml) for a comprehensive list of commands.
 
+### Code Changes
+
 ```bash
 # Ensure you have the correct dependencies
 poetry install
@@ -25,4 +27,11 @@ mypy --python-version 3.9
 # Run tests in parallel.
 pytest -n auto # This may take a while.
 pytest -n auto <test_suite>
+```
+
+### Documentation Changes
+
+```bash
+# Build the documentation locally and check for broken links
+poetry doc
 ```

--- a/docs/contributing_tldr.md
+++ b/docs/contributing_tldr.md
@@ -1,0 +1,28 @@
+Feel free to send a PR to update this file if you find anything useful. 🙇
+
+## Environment
+
+- Python `>=3.9`
+- [Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer) `>=2.0.0`
+
+## Useful commands
+
+Please check the [pyproject.toml](https://github.com/commitizen-tools/commitizen/blob/master/pyproject.toml) for a comprehensive list of commands.
+
+```bash
+# Ensure you have the correct dependencies
+poetry install
+
+# Make ruff happy
+poetry format
+
+# Check if ruff and mypy are happy
+poetry lint
+
+# Check if mypy is happy in python 3.9
+mypy --python-version 3.9
+
+# Run tests in parallel.
+pytest -n auto # This may take a while.
+pytest -n auto <test_suite>
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
   - Exit Codes: "exit_codes.md"
   - Third-Party Commitizen Templates: "third-party-commitizen.md"
   - Contributing: "contributing.md"
+  - Contributing TL;DR: "contributing_tldr.md"
   - Resources: "external_links.md"
 
 markdown_extensions:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

I believe the new page makes it easier for developers to understand how to contribute effectively.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly
  - [x] Check if there are any broken links in the documentation

> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```
