### PR TITLE
refactor(git): retype get_commits parameter to make it more friendly to call sites

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -253,10 +253,7 @@ class Bump:
                 ) from exc
         else:
             if increment is None:
-                if current_tag:
-                    commits = git.get_commits(current_tag.name)
-                else:
-                    commits = git.get_commits()
+                commits = git.get_commits(current_tag.name if current_tag else None)
 
                 # No commits, there is no need to create an empty tag.
                 # Unless we previously had a prerelease.

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -110,7 +110,7 @@ class Check:
             return [git.GitCommit(rev="", title="", body=self._filter_comments(msg))]
 
         # Get commit messages from git log (--rev-range)
-        return git.get_commits(end=self.rev_range or "HEAD")
+        return git.get_commits(end=self.rev_range)
 
     @staticmethod
     def _filter_comments(msg: str) -> str:

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -203,15 +203,18 @@ def _create_commit_cmd_string(args: str, committer_date: str | None, name: str) 
 
 def get_commits(
     start: str | None = None,
-    end: str = "HEAD",
+    end: str | None = None,
     *,
     args: str = "",
 ) -> list[GitCommit]:
     """Get the commits between start and end."""
+    if end is None:
+        end = "HEAD"
     git_log_entries = _get_log_as_str_list(start, end, args)
     return [
         GitCommit.from_rev_and_commit(rev_and_commit)
-        for rev_and_commit in filter(None, git_log_entries)
+        for rev_and_commit in git_log_entries
+        if rev_and_commit
     ]
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

Wait for #1466 

## Description
<!-- Describe what the change is -->


## Checklist

- [ ] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `poetry all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes

- [ ] Run `poetry doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external) in the documentation

> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
