### PR TITLE
Redo #1466, #1479 and #1480

### DIFF
--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -63,7 +63,7 @@ class Metadata:
     latest_version_position: int | None = None
     latest_version_tag: str | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.latest_version and not self.latest_version_tag:
             # Test syntactic sugar
             # latest version tag is optional if same as latest version
@@ -169,8 +169,8 @@ def process_commit_message(
     commit: GitCommit,
     changes: dict[str | None, list],
     change_type_map: dict[str, str] | None = None,
-):
-    message: dict = {
+) -> None:
+    message: dict[str, Any] = {
         "sha1": commit.rev,
         "parents": commit.parents,
         "author": commit.author,

--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import re
 from collections import OrderedDict, defaultdict
-from collections.abc import Generator, Iterable, Mapping
+from collections.abc import Generator, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date
 from typing import TYPE_CHECKING, Any
@@ -225,7 +225,7 @@ def render_changelog(
     tree: Iterable,
     loader: BaseLoader,
     template: str,
-    **kwargs,
+    **kwargs: Any,
 ) -> str:
     jinja_template = get_changelog_template(loader, template)
     changelog: str = jinja_template.render(tree=tree, **kwargs)
@@ -282,7 +282,7 @@ def incremental_build(
 
 
 def get_smart_tag_range(
-    tags: list[GitTag], newest: str, oldest: str | None = None
+    tags: Sequence[GitTag], newest: str, oldest: str | None = None
 ) -> list[GitTag]:
     """Smart because it finds the N+1 tag.
 
@@ -308,10 +308,10 @@ def get_smart_tag_range(
 
 
 def get_oldest_and_newest_rev(
-    tags: list[GitTag],
+    tags: Sequence[GitTag],
     version: str,
     rules: TagRules,
-) -> tuple[str | None, str | None]:
+) -> tuple[str | None, str]:
     """Find the tags for the given version.
 
     `version` may come in different formats:

--- a/commitizen/changelog_formats/__init__.py
+++ b/commitizen/changelog_formats/__init__.py
@@ -25,7 +25,7 @@ class ChangelogFormat(Protocol):
 
     config: BaseConfig
 
-    def __init__(self, config: BaseConfig):
+    def __init__(self, config: BaseConfig) -> None:
         self.config = config
 
     @property

--- a/commitizen/changelog_formats/base.py
+++ b/commitizen/changelog_formats/base.py
@@ -20,7 +20,7 @@ class BaseFormat(ChangelogFormat, metaclass=ABCMeta):
     extension: ClassVar[str] = ""
     alternative_extensions: ClassVar[set[str]] = set()
 
-    def __init__(self, config: BaseConfig):
+    def __init__(self, config: BaseConfig) -> None:
         # Constructor needs to be redefined because `Protocol` prevent instantiation by default
         # See: https://bugs.python.org/issue44807
         self.config = config

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -47,17 +47,17 @@ class ParseKwargs(argparse.Action):
         self,
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
-        kwarg: object,
+        values: object,
         option_string: str | None = None,
     ) -> None:
-        if not isinstance(kwarg, str):
+        if not isinstance(values, str):
             return
-        if "=" not in kwarg:
+        if "=" not in values:
             raise InvalidCommandArgumentError(
                 f"Option {option_string} expect a key=value format"
             )
         kwargs = getattr(namespace, self.dest, None) or {}
-        key, value = kwarg.split("=", 1)
+        key, value = values.split("=", 1)
         if not key:
             raise InvalidCommandArgumentError(
                 f"Option {option_string} expect a key=value format"

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from functools import partial
 from pathlib import Path
 from types import TracebackType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import argcomplete
 from decli import cli
@@ -48,7 +48,7 @@ class ParseKwargs(argparse.Action):
         self,
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
-        kwarg: str | Sequence[Any] | None,
+        kwarg: str | Sequence[object] | None,
         option_string: str | None = None,
     ) -> None:
         if not isinstance(kwarg, str):

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -681,7 +681,7 @@ def main() -> None:
         )
         sys.excepthook = no_raise_debug_excepthook
 
-    args.func(conf, arguments)()  # type: ignore
+    args.func(conf, arguments)()  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -681,7 +681,7 @@ def main() -> None:
         )
         sys.excepthook = no_raise_debug_excepthook
 
-    args.func(conf, arguments)()  # type: ignore[arg-type]
+    args.func(conf, arguments)()
 
 
 if __name__ == "__main__":

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -682,7 +682,7 @@ def main() -> None:
         )
         sys.excepthook = no_raise_debug_excepthook
 
-    args.func(conf, arguments)()
+    args.func(conf, arguments)()  # type: ignore
 
 
 if __name__ == "__main__":

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-from collections.abc import Sequence
 from copy import deepcopy
 from functools import partial
 from pathlib import Path
@@ -48,7 +47,7 @@ class ParseKwargs(argparse.Action):
         self,
         parser: argparse.ArgumentParser,
         namespace: argparse.Namespace,
-        kwarg: str | Sequence[object] | None,
+        kwarg: object,
         option_string: str | None = None,
     ) -> None:
         if not isinstance(kwarg, str):

--- a/commitizen/cmd.py
+++ b/commitizen/cmd.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
-from typing import NamedTuple
+from collections.abc import Mapping
+from typing import NamedTuple, Union
 
 from charset_normalizer import from_bytes
 
@@ -28,7 +29,7 @@ def _try_decode(bytes_: bytes) -> str:
             raise CharacterSetDecodeError() from e
 
 
-def run(cmd: str, env=None) -> Command:
+def run(cmd: str, env: Union[Mapping[str, str], None] = None) -> Command:
     if env is not None:
         env = {**os.environ, **env}
     process = subprocess.Popen(

--- a/commitizen/cmd.py
+++ b/commitizen/cmd.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
 import subprocess
 from collections.abc import Mapping
-from typing import NamedTuple, Union
+from typing import NamedTuple
 
 from charset_normalizer import from_bytes
 
@@ -29,7 +31,7 @@ def _try_decode(bytes_: bytes) -> str:
             raise CharacterSetDecodeError() from e
 
 
-def run(cmd: str, env: Union[Mapping[str, str], None] = None) -> Command:
+def run(cmd: str, env: Mapping[str, str] | None = None) -> Command:
     if env is not None:
         env = {**os.environ, **env}
     process = subprocess.Popen(

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -37,7 +37,7 @@ from commitizen.version_schemes import (
 logger = getLogger("commitizen")
 
 
-class BumpArguments(Settings, total=False):
+class BumpArgs(Settings, total=False):
     allow_no_commit: bool | None
     annotated_tag_message: str | None
     annotated_tag: bool
@@ -65,7 +65,7 @@ class BumpArguments(Settings, total=False):
 class Bump:
     """Show prompt for the user to create a guided commit."""
 
-    def __init__(self, config: BaseConfig, arguments: BumpArguments) -> None:
+    def __init__(self, config: BaseConfig, arguments: BumpArgs) -> None:
         if not git.is_git_project():
             raise NotAGitProjectError()
 
@@ -73,7 +73,7 @@ class Bump:
         self.encoding = config.settings["encoding"]
         self.arguments = arguments
         self.bump_settings = cast(
-            BumpArguments,
+            BumpArgs,
             {
                 **config.settings,
                 **{

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -231,8 +231,8 @@ class Bump:
         else:
             # If user specified changelog_to_stdout, they probably want the
             # changelog to be generated as well, this is the most intuitive solution
-            self.changelog_flag = bool(
-                self.changelog_flag or self.changelog_to_stdout or self.changelog_config
+            self.changelog_flag = any(
+                (self.changelog_flag, self.changelog_to_stdout, self.changelog_config)
             )
 
         rules = TagRules.from_settings(cast(Settings, self.bump_settings))
@@ -410,14 +410,18 @@ class Bump:
 
         c = git.tag(
             new_tag_version,
-            signed=bool(
-                self.bump_settings.get("gpg_sign")
-                or self.config.settings.get("gpg_sign")
+            signed=any(
+                (
+                    self.bump_settings.get("gpg_sign"),
+                    self.config.settings.get("gpg_sign"),
+                )
             ),
-            annotated=bool(
-                self.bump_settings.get("annotated_tag")
-                or self.config.settings.get("annotated_tag")
-                or self.bump_settings.get("annotated_tag_message")
+            annotated=any(
+                (
+                    self.bump_settings.get("annotated_tag"),
+                    self.config.settings.get("annotated_tag"),
+                    self.bump_settings.get("annotated_tag_message"),
+                )
             ),
             msg=self.bump_settings.get("annotated_tag_message", None),
             # TODO: also get from self.config.settings?

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -79,6 +79,7 @@ class Bump:
                 **{
                     k: v
                     for k, v in {
+                        # All these are for making mypy happy
                         "annotated_tag_message": arguments.get("annotated_tag_message"),
                         "annotated_tag": arguments.get("annotated_tag"),
                         "bump_message": arguments.get("bump_message"),

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -40,7 +40,6 @@ logger = getLogger("commitizen")
 class BumpArgs(Settings, total=False):
     allow_no_commit: bool | None
     annotated_tag_message: str | None
-    annotated_tag: bool
     build_metadata: str | None
     changelog_to_stdout: bool
     changelog: bool
@@ -51,7 +50,6 @@ class BumpArgs(Settings, total=False):
     files_only: bool | None
     get_next: bool
     git_output_to_stderr: bool
-    gpg_sign: bool
     increment_mode: str
     increment: Increment | None
     local_version: bool
@@ -222,7 +220,7 @@ class Bump:
 
         if get_next:
             # if trying to use --get-next, we should not allow --changelog or --changelog-to-stdout
-            if self.changelog_flag or bool(self.changelog_to_stdout):
+            if self.changelog_flag or self.changelog_to_stdout:
                 raise NotAllowed(
                     "--changelog or --changelog-to-stdout is not allowed with --get-next"
                 )
@@ -234,9 +232,7 @@ class Bump:
             # If user specified changelog_to_stdout, they probably want the
             # changelog to be generated as well, this is the most intuitive solution
             self.changelog_flag = bool(
-                self.changelog_flag
-                or bool(self.changelog_to_stdout)
-                or self.changelog_config
+                self.changelog_flag or self.changelog_to_stdout or self.changelog_config
             )
 
         rules = TagRules.from_settings(cast(Settings, self.bump_settings))

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -101,7 +101,7 @@ class Bump:
         )
         self.extras = arguments["extras"]
 
-    def is_initial_tag(
+    def _is_initial_tag(
         self, current_tag: git.GitTag | None, is_yes: bool = False
     ) -> bool:
         """Check if reading the whole git tree up to HEAD is needed."""
@@ -118,7 +118,7 @@ class Bump:
         )
         return bool(questionary.confirm("Is this the first tag created?").ask())
 
-    def find_increment(self, commits: list[git.GitCommit]) -> Increment | None:
+    def _find_increment(self, commits: list[git.GitCommit]) -> Increment | None:
         # Update the bump map to ensure major version doesn't increment.
         is_major_version_zero: bool = self.bump_settings["major_version_zero"]
         # self.cz.bump_map = defaults.bump_map_major_version_zero
@@ -135,7 +135,7 @@ class Bump:
             )
         return bump.find_increment(commits, regex=bump_pattern, increments_map=bump_map)
 
-    def __call__(self) -> None:  # noqa: C901
+    def __call__(self) -> None:
         """Steps executed to bump."""
         provider = get_provider(self.config)
 
@@ -227,7 +227,7 @@ class Bump:
             current_tag, "name", rules.normalize_tag(current_version)
         )
 
-        is_initial = self.is_initial_tag(current_tag, is_yes)
+        is_initial = self._is_initial_tag(current_tag, is_yes)
 
         if manual_version:
             try:
@@ -255,7 +255,7 @@ class Bump:
                         "[NO_COMMITS_FOUND]\nNo new commits found."
                     )
 
-                increment = self.find_increment(commits)
+                increment = self._find_increment(commits)
 
             # It may happen that there are commits, but they are not eligible
             # for an increment, this generates a problem when using prerelease (#281)

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -78,22 +78,21 @@ class Bump:
                 **config.settings,
                 **{
                     k: v
-                    for k, v in {
-                        # All these are for making mypy happy
-                        "annotated_tag_message": arguments.get("annotated_tag_message"),
-                        "annotated_tag": arguments.get("annotated_tag"),
-                        "bump_message": arguments.get("bump_message"),
-                        "file_name": arguments.get("file_name"),
-                        "gpg_sign": arguments.get("gpg_sign"),
-                        "increment_mode": arguments.get("increment_mode"),
-                        "increment": arguments.get("increment"),
-                        "major_version_zero": arguments.get("major_version_zero"),
-                        "prerelease_offset": arguments.get("prerelease_offset"),
-                        "prerelease": arguments.get("prerelease"),
-                        "tag_format": arguments.get("tag_format"),
-                        "template": arguments.get("template"),
-                    }.items()
-                    if v is not None
+                    for k in (
+                        "annotated_tag_message",
+                        "annotated_tag",
+                        "bump_message",
+                        "file_name",
+                        "gpg_sign",
+                        "increment_mode",
+                        "increment",
+                        "major_version_zero",
+                        "prerelease_offset",
+                        "prerelease",
+                        "tag_format",
+                        "template",
+                    )
+                    if (v := arguments.get(k)) is not None
                 },
             },
         )

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -342,14 +342,14 @@ class Bump:
                 "dry_run": dry_run,
             }
             if self.changelog_to_stdout:
-                changelog_cmd = Changelog(self.config, {**args, "dry_run": True})
+                changelog_cmd = Changelog(self.config, {**args, "dry_run": True})  # type: ignore
                 try:
                     changelog_cmd()
                 except DryRunExit:
                     pass
 
             args["file_name"] = self.file_name
-            changelog_cmd = Changelog(self.config, args)
+            changelog_cmd = Changelog(self.config, args)  # type: ignore
             changelog_cmd()
             files.append(changelog_cmd.file_name)
 

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -40,7 +40,7 @@ logger = getLogger("commitizen")
 class Bump:
     """Show prompt for the user to create a guided commit."""
 
-    def __init__(self, config: BaseConfig, arguments: dict):
+    def __init__(self, config: BaseConfig, arguments: dict) -> None:
         if not git.is_git_project():
             raise NotAGitProjectError()
 

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -136,7 +136,7 @@ class Changelog:
             raise NoRevisionError()
         return start_rev
 
-    def write_changelog(
+    def _write_changelog(
         self, changelog_out: str, lines: list[str], changelog_meta: changelog.Metadata
     ):
         with smart_open(self.file_name, "w", encoding=self.encoding) as changelog_file:
@@ -153,7 +153,7 @@ class Changelog:
 
             changelog_file.write(changelog_out)
 
-    def export_template(self) -> None:
+    def _export_template(self) -> None:
         tpl = changelog.get_changelog_template(self.cz.template_loader, self.template)
         src = Path(tpl.filename)  # type: ignore
         Path(self.export_template_to).write_text(src.read_text())  # type: ignore
@@ -173,7 +173,7 @@ class Changelog:
         )
 
         if self.export_template_to:
-            return self.export_template()
+            return self._export_template()
 
         if not changelog_pattern or not commit_parser:
             raise NoPatternMapError(
@@ -240,4 +240,4 @@ class Changelog:
             with open(self.file_name, encoding=self.encoding) as changelog_file:
                 lines = changelog_file.readlines()
 
-        self.write_changelog(changelog_out, lines, changelog_meta)
+        self._write_changelog(changelog_out, lines, changelog_meta)

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -29,7 +29,7 @@ from commitizen.version_schemes import get_version_scheme
 class Changelog:
     """Generate a changelog based on the commit history."""
 
-    def __init__(self, config: BaseConfig, args: Mapping[str, Any]):
+    def __init__(self, config: BaseConfig, args: Mapping[str, Any]) -> None:
         if not git.is_git_project():
             raise NotAGitProjectError()
 

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -138,7 +138,7 @@ class Changelog:
 
     def _write_changelog(
         self, changelog_out: str, lines: list[str], changelog_meta: changelog.Metadata
-    ):
+    ) -> None:
         with smart_open(self.file_name, "w", encoding=self.encoding) as changelog_file:
             partial_changelog: str | None = None
             if self.incremental:

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -176,6 +176,7 @@ class Changelog:
 
     def _export_template(self) -> None:
         tpl = changelog.get_changelog_template(self.cz.template_loader, self.template)
+        # TODO: fix the following type ignores
         src = Path(tpl.filename)  # type: ignore
         Path(self.export_template_to).write_text(src.read_text())  # type: ignore
 

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -19,7 +19,7 @@ class Check:
 
     def __init__(
         self, config: BaseConfig, arguments: dict[str, Any], cwd: str = os.getcwd()
-    ):
+    ) -> None:
         """Initial check command.
 
         Args:

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 import sys
-from typing import Any
+from typing import TypedDict
 
 from commitizen import factory, git, out
 from commitizen.config import BaseConfig
@@ -13,10 +13,20 @@ from commitizen.exceptions import (
 )
 
 
+class CheckArgs(TypedDict, total=False):
+    commit_msg_file: str
+    commit_msg: str
+    rev_range: str
+    allow_abort: bool
+    message_length_limit: int
+    allowed_prefixes: list[str]
+    message: str
+
+
 class Check:
     """Check if the current commit msg matches the commitizen format."""
 
-    def __init__(self, config: BaseConfig, arguments: dict[str, Any]) -> None:
+    def __init__(self, config: BaseConfig, arguments: CheckArgs) -> None:
         """Initial check command.
 
         Args:
@@ -24,16 +34,15 @@ class Check:
             arguments: All the flags provided by the user
             cwd: Current work directory
         """
-        self.commit_msg_file: str | None = arguments.get("commit_msg_file")
-        self.commit_msg: str | None = arguments.get("message")
-        self.rev_range: str | None = arguments.get("rev_range")
-        self.allow_abort: bool = bool(
+        self.commit_msg_file = arguments.get("commit_msg_file")
+        self.commit_msg = arguments.get("message")
+        self.rev_range = arguments.get("rev_range")
+        self.allow_abort = bool(
             arguments.get("allow_abort", config.settings["allow_abort"])
         )
-        self.max_msg_length: int = arguments.get("message_length_limit", 0)
+        self.max_msg_length = arguments.get("message_length_limit", 0)
 
         # we need to distinguish between None and [], which is a valid value
-
         allowed_prefixes = arguments.get("allowed_prefixes")
         self.allowed_prefixes: list[str] = (
             allowed_prefixes

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -17,7 +17,9 @@ from commitizen.exceptions import (
 class Check:
     """Check if the current commit msg matches the commitizen format."""
 
-    def __init__(self, config: BaseConfig, arguments: dict[str, Any], cwd=os.getcwd()):
+    def __init__(
+        self, config: BaseConfig, arguments: dict[str, Any], cwd: str = os.getcwd()
+    ):
         """Initial check command.
 
         Args:
@@ -48,7 +50,7 @@ class Check:
         self.encoding = config.settings["encoding"]
         self.cz = factory.committer_factory(self.config)
 
-    def _valid_command_argument(self):
+    def _valid_command_argument(self) -> None:
         num_exclusive_args_provided = sum(
             arg is not None
             for arg in (self.commit_msg_file, self.commit_msg, self.rev_range)
@@ -61,7 +63,7 @@ class Check:
                 "See 'cz check -h' for more information"
             )
 
-    def __call__(self):
+    def __call__(self) -> None:
         """Validate if commit messages follows the conventional pattern.
 
         Raises:
@@ -97,7 +99,7 @@ class Check:
             # Get commit message from file (--commit-msg-file)
             return commit_file.read()
 
-    def _get_commits(self):
+    def _get_commits(self) -> list[git.GitCommit]:
         if (msg := self._get_commit_message()) is not None:
             return [git.GitCommit(rev="", title="", body=self._filter_comments(msg))]
 

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -26,7 +26,7 @@ class CheckArgs(TypedDict, total=False):
 class Check:
     """Check if the current commit msg matches the commitizen format."""
 
-    def __init__(self, config: BaseConfig, arguments: CheckArgs) -> None:
+    def __init__(self, config: BaseConfig, arguments: CheckArgs, *args: object) -> None:
         """Initial check command.
 
         Args:

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import re
 import sys
 from typing import Any
@@ -17,9 +16,7 @@ from commitizen.exceptions import (
 class Check:
     """Check if the current commit msg matches the commitizen format."""
 
-    def __init__(
-        self, config: BaseConfig, arguments: dict[str, Any], cwd: str = os.getcwd()
-    ) -> None:
+    def __init__(self, config: BaseConfig, arguments: dict[str, Any]) -> None:
         """Initial check command.
 
         Args:

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -5,6 +5,8 @@ import os
 import shutil
 import subprocess
 import tempfile
+from pathlib import Path
+from typing import Union, cast
 
 import questionary
 
@@ -105,11 +107,13 @@ class Commit:
             return self.read_backup_message() or self.prompt_commit_questions()
         return self.prompt_commit_questions()
 
-    def __call__(self):
-        extra_args: str = self.arguments.get("extra_cli_args", "")
-        dry_run: bool = self.arguments.get("dry_run")
-        write_message_to_file: bool = self.arguments.get("write_message_to_file")
-        signoff: bool = self.arguments.get("signoff")
+    def __call__(self) -> None:
+        extra_args = cast(str, self.arguments.get("extra_cli_args", ""))
+        dry_run = cast(bool, self.arguments.get("dry_run"))
+        write_message_to_file = cast(
+            Union[Path, None], self.arguments.get("write_message_to_file")
+        )
+        signoff = cast(bool, self.arguments.get("signoff"))
 
         if self.arguments.get("all"):
             git.add("-u")

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -41,7 +41,7 @@ class Commit:
         self.arguments = arguments
         self.temp_file: str = get_backup_file_path()
 
-    def read_backup_message(self) -> str | None:
+    def _read_backup_message(self) -> str | None:
         # Check the commit backup file exists
         if not os.path.isfile(self.temp_file):
             return None
@@ -50,7 +50,7 @@ class Commit:
         with open(self.temp_file, encoding=self.encoding) as f:
             return f.read().strip()
 
-    def prompt_commit_questions(self) -> str:
+    def _prompt_commit_questions(self) -> str:
         # Prompt user for the commit message
         cz = self.cz
         questions = cz.questions()
@@ -96,7 +96,7 @@ class Commit:
 
     def _get_message(self) -> str:
         if self.arguments.get("retry"):
-            m = self.read_backup_message()
+            m = self._read_backup_message()
             if m is None:
                 raise NoCommitBackupError()
             return m
@@ -104,8 +104,8 @@ class Commit:
         if self.config.settings.get("retry_after_failure") and not self.arguments.get(
             "no_retry"
         ):
-            return self.read_backup_message() or self.prompt_commit_questions()
-        return self.prompt_commit_questions()
+            return self._read_backup_message() or self._prompt_commit_questions()
+        return self._prompt_commit_questions()
 
     def __call__(self) -> None:
         extra_args = cast(str, self.arguments.get("extra_cli_args", ""))

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -31,7 +31,7 @@ from commitizen.git import smart_open
 class Commit:
     """Show prompt for the user to create a guided commit."""
 
-    def __init__(self, config: BaseConfig, arguments: dict):
+    def __init__(self, config: BaseConfig, arguments: dict) -> None:
         if not git.is_git_project():
             raise NotAGitProjectError()
 

--- a/commitizen/commands/example.py
+++ b/commitizen/commands/example.py
@@ -5,9 +5,9 @@ from commitizen.config import BaseConfig
 class Example:
     """Show an example so people understands the rules."""
 
-    def __init__(self, config: BaseConfig, *args):
+    def __init__(self, config: BaseConfig, *args: object):
         self.config: BaseConfig = config
         self.cz = factory.committer_factory(self.config)
 
-    def __call__(self):
+    def __call__(self) -> None:
         out.write(self.cz.example())

--- a/commitizen/commands/example.py
+++ b/commitizen/commands/example.py
@@ -5,7 +5,7 @@ from commitizen.config import BaseConfig
 class Example:
     """Show an example so people understands the rules."""
 
-    def __init__(self, config: BaseConfig, *args: object):
+    def __init__(self, config: BaseConfig, *args: object) -> None:
         self.config: BaseConfig = config
         self.cz = factory.committer_factory(self.config)
 

--- a/commitizen/commands/info.py
+++ b/commitizen/commands/info.py
@@ -5,9 +5,9 @@ from commitizen.config import BaseConfig
 class Info:
     """Show in depth explanation of your rules."""
 
-    def __init__(self, config: BaseConfig, *args):
+    def __init__(self, config: BaseConfig, *args: object):
         self.config: BaseConfig = config
         self.cz = factory.committer_factory(self.config)
 
-    def __call__(self):
+    def __call__(self) -> None:
         out.write(self.cz.info())

--- a/commitizen/commands/info.py
+++ b/commitizen/commands/info.py
@@ -5,7 +5,7 @@ from commitizen.config import BaseConfig
 class Info:
     """Show in depth explanation of your rules."""
 
-    def __init__(self, config: BaseConfig, *args: object):
+    def __init__(self, config: BaseConfig, *args: object) -> None:
         self.config: BaseConfig = config
         self.cz = factory.committer_factory(self.config)
 

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -79,7 +79,7 @@ class ProjectInfo:
 
 
 class Init:
-    def __init__(self, config: BaseConfig, *args):
+    def __init__(self, config: BaseConfig, *args: object):
         self.config: BaseConfig = config
         self.encoding = config.settings["encoding"]
         self.cz = factory.committer_factory(self.config)

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -79,7 +79,7 @@ class ProjectInfo:
 
 
 class Init:
-    def __init__(self, config: BaseConfig, *args: object):
+    def __init__(self, config: BaseConfig, *args: object) -> None:
         self.config: BaseConfig = config
         self.encoding = config.settings["encoding"]
         self.cz = factory.committer_factory(self.config)

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -85,7 +85,7 @@ class Init:
         self.cz = factory.committer_factory(self.config)
         self.project_info = ProjectInfo()
 
-    def __call__(self):
+    def __call__(self) -> None:
         if self.config.path:
             out.line(f"Config file {self.config.path} already exists")
             return
@@ -120,7 +120,7 @@ class Init:
             self.config = JsonConfig(data="{}", path=config_path)
         elif "yaml" in config_path:
             self.config = YAMLConfig(data="", path=config_path)
-        values_to_add = {}
+        values_to_add: dict[str, Any] = {}
         values_to_add["name"] = cz_name
         values_to_add["tag_format"] = tag_format
         values_to_add["version_scheme"] = version_scheme

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -207,7 +207,7 @@ class Init:
                 raise NoAnswersError("Tag is required!")
         return latest_tag
 
-    def _ask_tag_format(self, latest_tag) -> str:
+    def _ask_tag_format(self, latest_tag: str) -> str:
         is_correct_format = False
         if latest_tag.startswith("v"):
             tag_format = r"v$version"
@@ -302,7 +302,7 @@ class Init:
         ).unsafe_ask()
         return update_changelog_on_bump
 
-    def _exec_install_pre_commit_hook(self, hook_types: list[str]):
+    def _exec_install_pre_commit_hook(self, hook_types: list[str]) -> None:
         cmd_str = self._gen_pre_commit_cmd(hook_types)
         c = cmd.run(cmd_str)
         if c.return_code != 0:
@@ -323,7 +323,7 @@ class Init:
         )
         return cmd_str
 
-    def _install_pre_commit_hook(self, hook_types: list[str] | None = None):
+    def _install_pre_commit_hook(self, hook_types: list[str] | None = None) -> None:
         pre_commit_config_filename = ".pre-commit-config.yaml"
         cz_hook_config = {
             "repo": "https://github.com/commitizen-tools/commitizen",
@@ -369,6 +369,6 @@ class Init:
         self._exec_install_pre_commit_hook(hook_types)
         out.write("commitizen pre-commit hook is now installed in your '.git'\n")
 
-    def _update_config_file(self, values: dict[str, Any]):
+    def _update_config_file(self, values: dict[str, Any]) -> None:
         for key, value in values.items():
             self.config.set_key(key, value)

--- a/commitizen/commands/list_cz.py
+++ b/commitizen/commands/list_cz.py
@@ -6,7 +6,7 @@ from commitizen.cz import registry
 class ListCz:
     """List currently installed rules."""
 
-    def __init__(self, config: BaseConfig, *args: object):
+    def __init__(self, config: BaseConfig, *args: object) -> None:
         self.config: BaseConfig = config
 
     def __call__(self) -> None:

--- a/commitizen/commands/list_cz.py
+++ b/commitizen/commands/list_cz.py
@@ -6,8 +6,8 @@ from commitizen.cz import registry
 class ListCz:
     """List currently installed rules."""
 
-    def __init__(self, config: BaseConfig, *args):
+    def __init__(self, config: BaseConfig, *args: object):
         self.config: BaseConfig = config
 
-    def __call__(self):
+    def __call__(self) -> None:
         out.write("\n".join(registry.keys()))

--- a/commitizen/commands/schema.py
+++ b/commitizen/commands/schema.py
@@ -5,7 +5,7 @@ from commitizen.config import BaseConfig
 class Schema:
     """Show structure of the rule."""
 
-    def __init__(self, config: BaseConfig, *args: object):
+    def __init__(self, config: BaseConfig, *args: object) -> None:
         self.config: BaseConfig = config
         self.cz = factory.committer_factory(self.config)
 

--- a/commitizen/commands/schema.py
+++ b/commitizen/commands/schema.py
@@ -5,9 +5,9 @@ from commitizen.config import BaseConfig
 class Schema:
     """Show structure of the rule."""
 
-    def __init__(self, config: BaseConfig, *args):
+    def __init__(self, config: BaseConfig, *args: object):
         self.config: BaseConfig = config
         self.cz = factory.committer_factory(self.config)
 
-    def __call__(self):
+    def __call__(self) -> None:
         out.write(self.cz.schema())

--- a/commitizen/commands/version.py
+++ b/commitizen/commands/version.py
@@ -1,7 +1,6 @@
 import platform
 import sys
-from collections.abc import Mapping
-from typing import Any
+from typing import TypedDict
 
 from commitizen import out
 from commitizen.__version__ import __version__
@@ -9,12 +8,18 @@ from commitizen.config import BaseConfig
 from commitizen.providers import get_provider
 
 
+class VersionArgs(TypedDict, total=False):
+    report: bool
+    project: bool
+    verbose: bool
+
+
 class Version:
     """Get the version of the installed commitizen or the current project."""
 
-    def __init__(self, config: BaseConfig, *args: Mapping[str, Any]) -> None:
+    def __init__(self, config: BaseConfig, arguments: VersionArgs) -> None:
         self.config: BaseConfig = config
-        self.parameter = args[0]
+        self.parameter = arguments
         self.operating_system = platform.system()
         self.python_version = sys.version
 

--- a/commitizen/commands/version.py
+++ b/commitizen/commands/version.py
@@ -1,5 +1,7 @@
 import platform
 import sys
+from collections.abc import Mapping
+from typing import Any
 
 from commitizen import out
 from commitizen.__version__ import __version__
@@ -10,13 +12,13 @@ from commitizen.providers import get_provider
 class Version:
     """Get the version of the installed commitizen or the current project."""
 
-    def __init__(self, config: BaseConfig, *args):
+    def __init__(self, config: BaseConfig, *args: Mapping[str, Any]):
         self.config: BaseConfig = config
         self.parameter = args[0]
         self.operating_system = platform.system()
         self.python_version = sys.version
 
-    def __call__(self):
+    def __call__(self) -> None:
         if self.parameter.get("report"):
             out.write(f"Commitizen Version: {__version__}")
             out.write(f"Python Version: {self.python_version}")

--- a/commitizen/commands/version.py
+++ b/commitizen/commands/version.py
@@ -12,7 +12,7 @@ from commitizen.providers import get_provider
 class Version:
     """Get the version of the installed commitizen or the current project."""
 
-    def __init__(self, config: BaseConfig, *args: Mapping[str, Any]):
+    def __init__(self, config: BaseConfig, *args: Mapping[str, Any]) -> None:
         self.config: BaseConfig = config
         self.parameter = args[0]
         self.operating_system = platform.system()

--- a/commitizen/config/base_config.py
+++ b/commitizen/config/base_config.py
@@ -6,7 +6,7 @@ from commitizen.defaults import DEFAULT_SETTINGS, Settings
 
 
 class BaseConfig:
-    def __init__(self):
+    def __init__(self) -> None:
         self._settings: Settings = DEFAULT_SETTINGS.copy()
         self.encoding = self.settings["encoding"]
         self._path: Path | None = None

--- a/commitizen/config/base_config.py
+++ b/commitizen/config/base_config.py
@@ -26,16 +26,11 @@ class BaseConfig:
         return self._settings
 
     @property
-    def path(self) -> Path | None:
-        return self._path
+    def path(self) -> Path:
+        return self._path  # type: ignore
 
     @path.setter
     def path(self, path: str | Path) -> None:
-        """
-        mypy does not like this until 1.16
-        See https://github.com/python/mypy/pull/18510
-        TODO: remove "type: ignore" from the call sites when 1.16 is available
-        """
         self._path = Path(path)
 
     def set_key(self, key: str, value: Any) -> Self:

--- a/commitizen/config/base_config.py
+++ b/commitizen/config/base_config.py
@@ -41,3 +41,6 @@ class BaseConfig:
 
     def _parse_setting(self, data: bytes | str) -> None:
         raise NotImplementedError()
+
+    def init_empty_config_content(self) -> None:
+        raise NotImplementedError()

--- a/commitizen/config/base_config.py
+++ b/commitizen/config/base_config.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from commitizen.defaults import DEFAULT_SETTINGS, Settings
+
+if TYPE_CHECKING:
+    import sys
+
+    # Self is Python 3.11+ but backported in typing-extensions
+    if sys.version_info < (3, 11):
+        from typing_extensions import Self
+    else:
+        from typing import Self
 
 
 class BaseConfig:
@@ -28,7 +38,7 @@ class BaseConfig:
         """
         self._path = Path(path)
 
-    def set_key(self, key, value):
+    def set_key(self, key: str, value: Any) -> Self:
         """Set or update a key in the conf.
 
         For now only strings are supported.

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -2,11 +2,21 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from commitizen.exceptions import InvalidConfigurationError
 from commitizen.git import smart_open
 
 from .base_config import BaseConfig
+
+if TYPE_CHECKING:
+    import sys
+
+    # Self is Python 3.11+ but backported in typing-extensions
+    if sys.version_info < (3, 11):
+        from typing_extensions import Self
+    else:
+        from typing import Self
 
 
 class JsonConfig(BaseConfig):
@@ -16,11 +26,11 @@ class JsonConfig(BaseConfig):
         self.path = path
         self._parse_setting(data)
 
-    def init_empty_config_content(self):
+    def init_empty_config_content(self) -> None:
         with smart_open(self.path, "a", encoding=self.encoding) as json_file:
             json.dump({"commitizen": {}}, json_file)
 
-    def set_key(self, key, value):
+    def set_key(self, key: str, value: Any) -> Self:
         """Set or update a key in the conf.
 
         For now only strings are supported.

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 class JsonConfig(BaseConfig):
-    def __init__(self, *, data: bytes | str, path: Path | str):
+    def __init__(self, *, data: bytes | str, path: Path | str) -> None:
         super().__init__()
         self.is_empty_config = False
         self.path = path

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -13,7 +13,7 @@ class JsonConfig(BaseConfig):
     def __init__(self, *, data: bytes | str, path: Path | str):
         super().__init__()
         self.is_empty_config = False
-        self.path = path  # type: ignore
+        self.path = path
         self._parse_setting(data)
 
     def init_empty_config_content(self):

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from tomlkit import exceptions, parse, table
 
 from commitizen.exceptions import InvalidConfigurationError
 
 from .base_config import BaseConfig
+
+if TYPE_CHECKING:
+    import sys
+
+    # Self is Python 3.11+ but backported in typing-extensions
+    if sys.version_info < (3, 11):
+        from typing_extensions import Self
+    else:
+        from typing import Self
 
 
 class TomlConfig(BaseConfig):
@@ -17,7 +27,7 @@ class TomlConfig(BaseConfig):
         self.path = path
         self._parse_setting(data)
 
-    def init_empty_config_content(self):
+    def init_empty_config_content(self) -> None:
         if os.path.isfile(self.path):
             with open(self.path, "rb") as input_toml_file:
                 parser = parse(input_toml_file.read())
@@ -27,10 +37,10 @@ class TomlConfig(BaseConfig):
         with open(self.path, "wb") as output_toml_file:
             if parser.get("tool") is None:
                 parser["tool"] = table()
-            parser["tool"]["commitizen"] = table()
+            parser["tool"]["commitizen"] = table()  # type: ignore
             output_toml_file.write(parser.as_string().encode(self.encoding))
 
-    def set_key(self, key, value):
+    def set_key(self, key: str, value: Any) -> Self:
         """Set or update a key in the conf.
 
         For now only strings are supported.
@@ -39,7 +49,7 @@ class TomlConfig(BaseConfig):
         with open(self.path, "rb") as f:
             parser = parse(f.read())
 
-        parser["tool"]["commitizen"][key] = value
+        parser["tool"]["commitizen"][key] = value  # type: ignore
         with open(self.path, "wb") as f:
             f.write(parser.as_string().encode(self.encoding))
         return self

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -14,7 +14,7 @@ class TomlConfig(BaseConfig):
     def __init__(self, *, data: bytes | str, path: Path | str):
         super().__init__()
         self.is_empty_config = False
-        self.path = path  # type: ignore
+        self.path = path
         self._parse_setting(data)
 
     def init_empty_config_content(self):

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class TomlConfig(BaseConfig):
-    def __init__(self, *, data: bytes | str, path: Path | str):
+    def __init__(self, *, data: bytes | str, path: Path | str) -> None:
         super().__init__()
         self.is_empty_config = False
         self.path = path

--- a/commitizen/config/yaml_config.py
+++ b/commitizen/config/yaml_config.py
@@ -14,7 +14,7 @@ class YAMLConfig(BaseConfig):
     def __init__(self, *, data: bytes | str, path: Path | str):
         super().__init__()
         self.is_empty_config = False
-        self.path = path  # type: ignore
+        self.path = path
         self._parse_setting(data)
 
     def init_empty_config_content(self):

--- a/commitizen/config/yaml_config.py
+++ b/commitizen/config/yaml_config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -8,6 +9,15 @@ from commitizen.exceptions import InvalidConfigurationError
 from commitizen.git import smart_open
 
 from .base_config import BaseConfig
+
+if TYPE_CHECKING:
+    import sys
+
+    # Self is Python 3.11+ but backported in typing-extensions
+    if sys.version_info < (3, 11):
+        from typing_extensions import Self
+    else:
+        from typing import Self
 
 
 class YAMLConfig(BaseConfig):
@@ -17,7 +27,7 @@ class YAMLConfig(BaseConfig):
         self.path = path
         self._parse_setting(data)
 
-    def init_empty_config_content(self):
+    def init_empty_config_content(self) -> None:
         with smart_open(self.path, "a", encoding=self.encoding) as json_file:
             yaml.dump({"commitizen": {}}, json_file, explicit_start=True)
 
@@ -41,7 +51,7 @@ class YAMLConfig(BaseConfig):
         except (KeyError, TypeError):
             self.is_empty_config = True
 
-    def set_key(self, key, value):
+    def set_key(self, key: str, value: Any) -> Self:
         """Set or update a key in the conf.
 
         For now only strings are supported.

--- a/commitizen/config/yaml_config.py
+++ b/commitizen/config/yaml_config.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 class YAMLConfig(BaseConfig):
-    def __init__(self, *, data: bytes | str, path: Path | str):
+    def __init__(self, *, data: bytes | str, path: Path | str) -> None:
         super().__init__()
         self.is_empty_config = False
         self.path = path

--- a/commitizen/cz/base.py
+++ b/commitizen/cz/base.py
@@ -76,13 +76,13 @@ class BaseCommitizen(metaclass=ABCMeta):
         """Format your git message."""
 
     @property
-    def style(self):
+    def style(self) -> Style:
         return merge_styles(
             [
                 Style(BaseCommitizen.default_style_config),
                 Style(self.config.settings["style"]),
             ]
-        )
+        )  # type: ignore[return-value]
 
     def example(self) -> str:
         """Example of the commit message."""

--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -9,22 +9,12 @@ from commitizen.defaults import Questions
 __all__ = ["ConventionalCommitsCz"]
 
 
-def parse_scope(text: str) -> str:
-    if not text:
-        return ""
-
-    scope = text.strip().split()
-    if len(scope) == 1:
-        return scope[0]
-
-    return "-".join(scope)
+def _parse_scope(text: str) -> str:
+    return "-".join(text.strip().split())
 
 
-def parse_subject(text: str) -> str:
-    if isinstance(text, str):
-        text = text.strip(".").strip()
-
-    return required_validator(text, msg="Subject is required.")
+def _parse_subject(text: str) -> str:
+    return required_validator(text.strip(".").strip(), msg="Subject is required.")
 
 
 class ConventionalCommitsCz(BaseCommitizen):
@@ -113,12 +103,12 @@ class ConventionalCommitsCz(BaseCommitizen):
                 "message": (
                     "What is the scope of this change? (class or file name): (press [enter] to skip)\n"
                 ),
-                "filter": parse_scope,
+                "filter": _parse_scope,
             },
             {
                 "type": "input",
                 "name": "subject",
-                "filter": parse_subject,
+                "filter": _parse_subject,
                 "message": (
                     "Write a short and imperative summary of the code changes: (lower case and no period)\n"
                 ),

--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -9,7 +9,7 @@ from commitizen.defaults import Questions
 __all__ = ["ConventionalCommitsCz"]
 
 
-def parse_scope(text):
+def parse_scope(text: str) -> str:
     if not text:
         return ""
 
@@ -20,7 +20,7 @@ def parse_scope(text):
     return "-".join(scope)
 
 
-def parse_subject(text):
+def parse_subject(text: str) -> str:
     if isinstance(text, str):
         text = text.strip(".").strip()
 

--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -21,7 +21,7 @@ class ConventionalCommitsCz(BaseCommitizen):
     bump_pattern = defaults.BUMP_PATTERN
     bump_map = defaults.BUMP_MAP
     bump_map_major_version_zero = defaults.BUMP_MAP_MAJOR_VERSION_ZERO
-    commit_parser = r"^((?P<change_type>feat|fix|refactor|perf|BREAKING CHANGE)(?:\((?P<scope>[^()\r\n]*)\)|\()?(?P<breaking>!)?|\w+!):\s(?P<message>.*)?"  # noqa
+    commit_parser = r"^((?P<change_type>feat|fix|refactor|perf|BREAKING CHANGE)(?:\((?P<scope>[^()\r\n]*)\)|\()?(?P<breaking>!)?|\w+!):\s(?P<message>.*)?"
     change_type_map = {
         "feat": "Feat",
         "fix": "Fix",

--- a/commitizen/cz/customize/customize.py
+++ b/commitizen/cz/customize/customize.py
@@ -26,7 +26,7 @@ class CustomizeCommitsCz(BaseCommitizen):
     bump_map_major_version_zero = defaults.BUMP_MAP_MAJOR_VERSION_ZERO
     change_type_order = defaults.CHANGE_TYPE_ORDER
 
-    def __init__(self, config: BaseConfig):
+    def __init__(self, config: BaseConfig) -> None:
         super().__init__(config)
 
         if "customize" not in self.config.settings:

--- a/commitizen/cz/jira/jira.py
+++ b/commitizen/cz/jira/jira.py
@@ -67,7 +67,7 @@ class JiraSmartCz(BaseCommitizen):
         )
 
     def schema(self) -> str:
-        return "<ignored text> <ISSUE_KEY> <ignored text> #<COMMAND> <optional COMMAND_ARGUMENTS>"  # noqa
+        return "<ignored text> <ISSUE_KEY> <ignored text> #<COMMAND> <optional COMMAND_ARGUMENTS>"
 
     def schema_pattern(self) -> str:
         return r".*[A-Z]{2,}\-[0-9]+( #| .* #).+( #.+)*"

--- a/commitizen/cz/utils.py
+++ b/commitizen/cz/utils.py
@@ -1,7 +1,6 @@
 import os
 import re
 import tempfile
-from typing import Union
 
 from commitizen import git
 from commitizen.cz import exceptions
@@ -9,7 +8,7 @@ from commitizen.cz import exceptions
 _RE_LOCAL_VERSION = re.compile(r"\+.+")
 
 
-def required_validator(answer: str, msg: Union[str, None] = None) -> str:
+def required_validator(answer: str, msg: object = None) -> str:
     if not answer:
         raise exceptions.AnswerRequiredError(msg)
     return answer

--- a/commitizen/cz/utils.py
+++ b/commitizen/cz/utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import tempfile
+from typing import Union
 
 from commitizen import git
 from commitizen.cz import exceptions
@@ -8,13 +9,13 @@ from commitizen.cz import exceptions
 _RE_LOCAL_VERSION = re.compile(r"\+.+")
 
 
-def required_validator(answer, msg=None):
+def required_validator(answer: str, msg: Union[str, None] = None) -> str:
     if not answer:
         raise exceptions.AnswerRequiredError(msg)
     return answer
 
 
-def multiple_line_breaker(answer, sep="|"):
+def multiple_line_breaker(answer: str, sep: str = "|") -> str:
     return "\n".join(line.strip() for line in answer.split(sep) if line)
 
 

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -29,36 +29,36 @@ class CzSettings(TypedDict, total=False):
 
 
 class Settings(TypedDict, total=False):
+    allow_abort: bool
+    allowed_prefixes: list[str]
+    always_signoff: bool
+    bump_message: str | None
+    changelog_file: str
+    changelog_format: str | None
+    changelog_incremental: bool
+    changelog_merge_prerelease: bool
+    changelog_start_rev: str | None
+    customize: CzSettings
+    encoding: str
+    extras: dict[str, Any]
+    ignored_tag_formats: Sequence[str]
+    legacy_tag_formats: Sequence[str]
+    major_version_zero: bool
     name: str
-    version: str | None
+    post_bump_hooks: list[str] | None
+    pre_bump_hooks: list[str] | None
+    prerelease_offset: int
+    retry_after_failure: bool
+    style: list[tuple[str, str]]
+    tag_format: str
+    template: str | None
+    update_changelog_on_bump: bool
+    use_shortcuts: bool
     version_files: list[str]
     version_provider: str | None
     version_scheme: str | None
     version_type: str | None
-    tag_format: str
-    legacy_tag_formats: Sequence[str]
-    ignored_tag_formats: Sequence[str]
-    bump_message: str | None
-    retry_after_failure: bool
-    allow_abort: bool
-    allowed_prefixes: list[str]
-    changelog_file: str
-    changelog_format: str | None
-    changelog_incremental: bool
-    changelog_start_rev: str | None
-    changelog_merge_prerelease: bool
-    update_changelog_on_bump: bool
-    use_shortcuts: bool
-    style: list[tuple[str, str]]
-    customize: CzSettings
-    major_version_zero: bool
-    pre_bump_hooks: list[str] | None
-    post_bump_hooks: list[str] | None
-    prerelease_offset: int
-    encoding: str
-    always_signoff: bool
-    template: str | None
-    extras: dict[str, Any]
+    version: str | None
 
 
 CONFIG_FILES: list[str] = [

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -32,16 +32,18 @@ class Settings(TypedDict, total=False):
     allow_abort: bool
     allowed_prefixes: list[str]
     always_signoff: bool
+    annotated_tag: bool
     bump_message: str | None
+    change_type_map: dict[str, str]
     changelog_file: str
     changelog_format: str | None
     changelog_incremental: bool
     changelog_merge_prerelease: bool
-    change_type_map: dict[str, str]
     changelog_start_rev: str | None
     customize: CzSettings
     encoding: str
     extras: dict[str, Any]
+    gpg_sign: bool
     ignored_tag_formats: Sequence[str]
     legacy_tag_formats: Sequence[str]
     major_version_zero: bool

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -37,6 +37,7 @@ class Settings(TypedDict, total=False):
     changelog_format: str | None
     changelog_incremental: bool
     changelog_merge_prerelease: bool
+    change_type_map: dict[str, str]
     changelog_start_rev: str | None
     customize: CzSettings
     encoding: str

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -1,4 +1,5 @@
 import enum
+from typing import Any
 
 from commitizen import out
 
@@ -40,7 +41,7 @@ class ExitCode(enum.IntEnum):
 
 
 class CommitizenException(Exception):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: str, **kwargs: Any):
         self.output_method = kwargs.get("output_method") or out.error
         self.exit_code: ExitCode = self.__class__.exit_code
         if args:
@@ -50,14 +51,14 @@ class CommitizenException(Exception):
         else:
             self.message = ""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
 
 class ExpectedExit(CommitizenException):
     exit_code = ExitCode.EXPECTED_EXIT
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: str, **kwargs: Any):
         output_method = kwargs.get("output_method") or out.write
         kwargs["output_method"] = output_method
         super().__init__(*args, **kwargs)

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -41,7 +41,7 @@ class ExitCode(enum.IntEnum):
 
 
 class CommitizenException(Exception):
-    def __init__(self, *args: str, **kwargs: Any):
+    def __init__(self, *args: str, **kwargs: Any) -> None:
         self.output_method = kwargs.get("output_method") or out.error
         self.exit_code: ExitCode = self.__class__.exit_code
         if args:
@@ -58,7 +58,7 @@ class CommitizenException(Exception):
 class ExpectedExit(CommitizenException):
     exit_code = ExitCode.EXPECTED_EXIT
 
-    def __init__(self, *args: str, **kwargs: Any):
+    def __init__(self, *args: str, **kwargs: Any) -> None:
         output_method = kwargs.get("output_method") or out.write
         kwargs["output_method"] = output_method
         super().__init__(*args, **kwargs)

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -59,7 +59,7 @@ class GitCommit(GitObject):
         author: str = "",
         author_email: str = "",
         parents: list[str] | None = None,
-    ):
+    ) -> None:
         self.rev = rev.strip()
         self.title = title.strip()
         self.body = body.strip()
@@ -132,7 +132,7 @@ class GitCommit(GitObject):
 
 
 class GitTag(GitObject):
-    def __init__(self, name: str, rev: str, date: str):
+    def __init__(self, name: str, rev: str, date: str) -> None:
         self.rev = rev.strip()
         self.name = name.strip()
         self._date = date.strip()

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -46,15 +46,15 @@ class GitObject:
     name: str
     date: str
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         return hasattr(other, "rev") and self.rev == other.rev
 
 
 class GitCommit(GitObject):
     def __init__(
         self,
-        rev,
-        title,
+        rev: str,
+        title: str,
         body: str = "",
         author: str = "",
         author_email: str = "",
@@ -68,7 +68,7 @@ class GitCommit(GitObject):
         self.parents = parents or []
 
     @property
-    def message(self):
+    def message(self) -> str:
         return f"{self.title}\n\n{self.body}".strip()
 
     @classmethod
@@ -127,22 +127,26 @@ class GitCommit(GitObject):
             parents=[p for p in parents.strip().split(" ") if p],
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.title} ({self.rev})"
 
 
 class GitTag(GitObject):
-    def __init__(self, name, rev, date):
+    def __init__(self, name: str, rev: str, date: str):
         self.rev = rev.strip()
         self.name = name.strip()
         self._date = date.strip()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"GitTag('{self.name}', '{self.rev}', '{self.date}')"
 
     @property
-    def date(self):
+    def date(self) -> str:
         return self._date
+
+    @date.setter
+    def date(self, value: str) -> None:
+        self._date = value
 
     @classmethod
     def from_line(cls, line: str, inner_delimiter: str) -> GitTag:

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -312,7 +312,7 @@ def get_core_editor() -> str | None:
     return None
 
 
-def smart_open(*args, **kwargs):  # type: ignore[no-untyped-def,unused-ignore]
+def smart_open(*args, **kwargs):  # type: ignore[no-untyped-def,unused-ignore] # noqa: ANN201
     """Open a file with the EOL style determined from Git."""
     return open(*args, newline=EOLType.for_open(), **kwargs)
 

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -215,7 +215,7 @@ def get_commits(
     ]
 
 
-def get_filenames_in_commit(git_reference: str = ""):
+def get_filenames_in_commit(git_reference: str = "") -> list[str]:
     """Get the list of files that were committed in the requested git reference.
 
     :param git_reference: a git reference as accepted by `git show`, default: the last commit
@@ -312,7 +312,7 @@ def get_core_editor() -> str | None:
     return None
 
 
-def smart_open(*args, **kwargs):
+def smart_open(*args, **kwargs):  # type: ignore[no-untyped-def,unused-ignore]
     """Open a file with the EOL style determined from Git."""
     return open(*args, newline=EOLType.for_open(), **kwargs)
 

--- a/commitizen/hooks.py
+++ b/commitizen/hooks.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 
 from commitizen import cmd, out
 from commitizen.exceptions import RunHookError
 
 
-def run(hooks, _env_prefix="CZ_", **env):
+def run(hooks: str | list[str], _env_prefix: str = "CZ_", **env: object) -> None:
     if isinstance(hooks, str):
         hooks = [hooks]
 
@@ -24,7 +25,7 @@ def run(hooks, _env_prefix="CZ_", **env):
             raise RunHookError(f"Running hook '{hook}' failed")
 
 
-def _format_env(prefix: str, env: dict[str, str]) -> dict[str, str]:
+def _format_env(prefix: str, env: Mapping[str, object]) -> dict[str, str]:
     """_format_env() prefixes all given environment variables with the given
     prefix so it can be passed directly to cmd.run()."""
     penv = dict(os.environ)

--- a/commitizen/out.py
+++ b/commitizen/out.py
@@ -1,5 +1,6 @@
 import io
 import sys
+from typing import Any
 
 from termcolor import colored
 
@@ -8,12 +9,12 @@ if sys.platform == "win32":
         sys.stdout.reconfigure(encoding="utf-8")
 
 
-def write(value: str, *args) -> None:
+def write(value: str, *args: object) -> None:
     """Intended to be used when value is multiline."""
     print(value, *args)
 
 
-def line(value: str, *args, **kwargs) -> None:
+def line(value: str, *args: object, **kwargs: Any) -> None:
     """Wrapper in case I want to do something different later."""
     print(value, *args, **kwargs)
 
@@ -33,7 +34,7 @@ def info(value: str) -> None:
     line(message)
 
 
-def diagnostic(value: str):
+def diagnostic(value: str) -> None:
     line(value, file=sys.stderr)
 
 

--- a/commitizen/providers/base_provider.py
+++ b/commitizen/providers/base_provider.py
@@ -20,7 +20,7 @@ class VersionProvider(ABC):
 
     config: BaseConfig
 
-    def __init__(self, config: BaseConfig):
+    def __init__(self, config: BaseConfig) -> None:
         self.config = config
 
     @abstractmethod

--- a/commitizen/providers/base_provider.py
+++ b/commitizen/providers/base_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -63,8 +64,8 @@ class JsonProvider(FileProvider):
         self.set(document, version)
         self.file.write_text(json.dumps(document, indent=self.indent) + "\n")
 
-    def get(self, document: dict[str, Any]) -> str:
-        return document["version"]  # type: ignore
+    def get(self, document: Mapping[str, str]) -> str:
+        return document["version"]
 
     def set(self, document: dict[str, Any], version: str) -> None:
         document["version"] = version

--- a/commitizen/providers/base_provider.py
+++ b/commitizen/providers/base_provider.py
@@ -29,7 +29,7 @@ class VersionProvider(ABC):
         """
 
     @abstractmethod
-    def set_version(self, version: str):
+    def set_version(self, version: str) -> None:
         """
         Set the new current version
         """
@@ -58,7 +58,7 @@ class JsonProvider(FileProvider):
         document = json.loads(self.file.read_text())
         return self.get(document)
 
-    def set_version(self, version: str):
+    def set_version(self, version: str) -> None:
         document = json.loads(self.file.read_text())
         self.set(document, version)
         self.file.write_text(json.dumps(document, indent=self.indent) + "\n")
@@ -66,7 +66,7 @@ class JsonProvider(FileProvider):
     def get(self, document: dict[str, Any]) -> str:
         return document["version"]  # type: ignore
 
-    def set(self, document: dict[str, Any], version: str):
+    def set(self, document: dict[str, Any], version: str) -> None:
         document["version"] = version
 
 
@@ -79,7 +79,7 @@ class TomlProvider(FileProvider):
         document = tomlkit.parse(self.file.read_text())
         return self.get(document)
 
-    def set_version(self, version: str):
+    def set_version(self, version: str) -> None:
         document = tomlkit.parse(self.file.read_text())
         self.set(document, version)
         self.file.write_text(tomlkit.dumps(document))
@@ -87,5 +87,5 @@ class TomlProvider(FileProvider):
     def get(self, document: tomlkit.TOMLDocument) -> str:
         return document["project"]["version"]  # type: ignore
 
-    def set(self, document: tomlkit.TOMLDocument, version: str):
+    def set(self, document: tomlkit.TOMLDocument, version: str) -> None:
         document["project"]["version"] = version  # type: ignore

--- a/commitizen/providers/cargo_provider.py
+++ b/commitizen/providers/cargo_provider.py
@@ -28,7 +28,7 @@ class CargoProvider(TomlProvider):
             ...
         return document["workspace"]["package"]["version"]  # type: ignore
 
-    def set(self, document: tomlkit.TOMLDocument, version: str):
+    def set(self, document: tomlkit.TOMLDocument, version: str) -> None:
         try:
             document["workspace"]["package"]["version"] = version  # type: ignore
             return

--- a/commitizen/providers/commitizen_provider.py
+++ b/commitizen/providers/commitizen_provider.py
@@ -11,5 +11,5 @@ class CommitizenProvider(VersionProvider):
     def get_version(self) -> str:
         return self.config.settings["version"]  # type: ignore
 
-    def set_version(self, version: str):
+    def set_version(self, version: str) -> None:
         self.config.set_key("version", version)

--- a/commitizen/providers/npm_provider.py
+++ b/commitizen/providers/npm_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -58,8 +59,8 @@ class NpmProvider(VersionProvider):
                 json.dumps(shrinkwrap_document, indent=self.indent) + "\n"
             )
 
-    def get_package_version(self, document: dict[str, Any]) -> str:
-        return document["version"]  # type: ignore
+    def get_package_version(self, document: Mapping[str, str]) -> str:
+        return document["version"]
 
     def set_package_version(
         self, document: dict[str, Any], version: str

--- a/commitizen/providers/poetry_provider.py
+++ b/commitizen/providers/poetry_provider.py
@@ -15,5 +15,5 @@ class PoetryProvider(TomlProvider):
     def get(self, pyproject: tomlkit.TOMLDocument) -> str:
         return pyproject["tool"]["poetry"]["version"]  # type: ignore
 
-    def set(self, pyproject: tomlkit.TOMLDocument, version: str):
+    def set(self, pyproject: tomlkit.TOMLDocument, version: str) -> None:
         pyproject["tool"]["poetry"]["version"] = version  # type: ignore

--- a/commitizen/providers/scm_provider.py
+++ b/commitizen/providers/scm_provider.py
@@ -23,6 +23,6 @@ class ScmProvider(VersionProvider):
             return "0.0.0"
         return str(versions[-1])
 
-    def set_version(self, version: str):
+    def set_version(self, version: str) -> None:
         # Not necessary
         pass

--- a/commitizen/tags.py
+++ b/commitizen/tags.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 import warnings
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
 from string import Template
@@ -89,14 +89,14 @@ class TagRules:
     merge_prereleases: bool = False
 
     @cached_property
-    def version_regexes(self) -> Sequence[re.Pattern]:
+    def version_regexes(self) -> list[re.Pattern]:
         """Regexes for all legit tag formats, current and legacy"""
         tag_formats = [self.tag_format, *self.legacy_tag_formats]
         regexes = (self._format_regex(p) for p in tag_formats)
         return [re.compile(r) for r in regexes]
 
     @cached_property
-    def ignored_regexes(self) -> Sequence[re.Pattern]:
+    def ignored_regexes(self) -> list[re.Pattern]:
         """Regexes for known but ignored tag formats"""
         regexes = (self._format_regex(p, star=True) for p in self.ignored_tag_formats)
         return [re.compile(r) for r in regexes]
@@ -135,8 +135,8 @@ class TagRules:
         return any(regex.match(tag) for regex in self.ignored_regexes)
 
     def get_version_tags(
-        self, tags: Sequence[GitTag], warn: bool = False
-    ) -> Sequence[GitTag]:
+        self, tags: Iterable[GitTag], warn: bool = False
+    ) -> list[GitTag]:
         """Filter in version tags and warn on unexpected tags"""
         return [tag for tag in tags if self.is_version_tag(tag, warn)]
 
@@ -236,7 +236,7 @@ class TagRules:
         )
 
     def find_tag_for(
-        self, tags: Sequence[GitTag], version: Version | str
+        self, tags: Iterable[GitTag], version: Version | str
     ) -> GitTag | None:
         """Find the first matching tag for a given version."""
         version = self.scheme(version) if isinstance(version, str) else version

--- a/commitizen/tags.py
+++ b/commitizen/tags.py
@@ -240,11 +240,11 @@ class TagRules:
     ) -> GitTag | None:
         """Find the first matching tag for a given version."""
         version = self.scheme(version) if isinstance(version, str) else version
-        possible_tags = [
+        possible_tags = set(
             self.normalize_tag(version, f)
             for f in (self.tag_format, *self.legacy_tag_formats)
-        ]
-        candidates = [t for t in tags if any(t.name == p for p in possible_tags)]
+        )
+        candidates = [t for t in tags if t.name in possible_tags]
         if len(candidates) > 1:
             warnings.warn(
                 UserWarning(

--- a/commitizen/version_schemes.py
+++ b/commitizen/version_schemes.py
@@ -51,7 +51,7 @@ class VersionProtocol(Protocol):
     parser: ClassVar[re.Pattern]
     """Regex capturing this version scheme into a `version` group"""
 
-    def __init__(self, version: str):
+    def __init__(self, version: str) -> None:
         """
         Initialize a version object from its string representation.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2014,4 +2014,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "146cae2abe0cdb8a831b9ece0aa1ee98366e3e4e17ef734f0e7001c4eb7508b3"
+content-hash = "6eea6e061a2ece897c2fb37b0b5116085057e6d97e1f22c0fcd4294fb0ad1dbf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,17 +211,12 @@ convention = "google"
 
 [tool.mypy]
 files = ["commitizen", "tests"]
-disallow_untyped_defs = true
 disallow_untyped_decorators = true
 disallow_subclassing_any = true
 warn_return_any = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unused_configs = true
-
-[[tool.mypy.overrides]]
-module = "tests/*"
-disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = "py.*"               # Legacy pytest dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,9 @@ line-length = 88
 
 [tool.ruff.lint]
 select = [
+    # flake8-annotations
+    "ANN001",
+    "ANN2",
     # pycodestyle
     "E",
     # Pyflakes
@@ -197,6 +200,9 @@ select = [
 ]
 ignore = ["E501", "D1", "D415"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["ANN"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["commitizen", "tests"]
 
@@ -204,13 +210,18 @@ known-first-party = ["commitizen", "tests"]
 convention = "google"
 
 [tool.mypy]
-files = "commitizen"
+files = ["commitizen", "tests"]
+disallow_untyped_defs = true
 disallow_untyped_decorators = true
 disallow_subclassing_any = true
 warn_return_any = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = "tests/*"
+disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
 module = "py.*"               # Legacy pytest dependencies
@@ -228,14 +239,14 @@ poetry_command = ""
 [tool.poe.tasks]
 format.help = "Format the code"
 format.sequence = [
-    { cmd = "ruff check --fix commitizen tests" },
-    { cmd = "ruff format commitizen tests" },
+    { cmd = "ruff check --fix" },
+    { cmd = "ruff format" },
 ]
 
 lint.help = "Lint the code"
 lint.sequence = [
-    { cmd = "ruff check commitizen/ tests/ --fix" },
-    { cmd = "mypy commitizen/ tests/" },
+    { cmd = "ruff check" },
+    { cmd = "mypy" },
 ]
 
 check-commit.help = "Check the commit message"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ deprecated = "^1.2.13"
 [tool.poetry.group.linters.dependencies]
 ruff = ">=0.5.0,<0.10.0"
 pre-commit = ">=2.18,<5.0"
-mypy = "^1.15.0"
+mypy = "^1.16.0"
 types-deprecated = "^1.2.9.2"
 types-python-dateutil = "^2.8.19.13"
 types-PyYAML = ">=5.4.3,<7.0.0"

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1692,7 +1692,7 @@ def test_bump_warn_but_dont_fail_on_invalid_tags(
 
 
 def test_is_initial_tag(mocker: MockFixture, tmp_commitizen_project):
-    """Test the is_initial_tag method behavior."""
+    """Test the _is_initial_tag method behavior."""
     # Create a commit but no tags
     create_file_and_commit("feat: initial commit")
 
@@ -1725,15 +1725,15 @@ def test_is_initial_tag(mocker: MockFixture, tmp_commitizen_project):
 
     # Test case 1: No current tag, not yes mode
     mocker.patch("questionary.confirm", return_value=mocker.Mock(ask=lambda: True))
-    assert bump_cmd.is_initial_tag(None, is_yes=False) is True
+    assert bump_cmd._is_initial_tag(None, is_yes=False) is True
 
     # Test case 2: No current tag, yes mode
-    assert bump_cmd.is_initial_tag(None, is_yes=True) is True
+    assert bump_cmd._is_initial_tag(None, is_yes=True) is True
 
     # Test case 3: Has current tag
     mock_tag = mocker.Mock()
-    assert bump_cmd.is_initial_tag(mock_tag, is_yes=False) is False
+    assert bump_cmd._is_initial_tag(mock_tag, is_yes=False) is False
 
     # Test case 4: No current tag, user denies
     mocker.patch("questionary.confirm", return_value=mocker.Mock(ask=lambda: False))
-    assert bump_cmd.is_initial_tag(None, is_yes=False) is False
+    assert bump_cmd._is_initial_tag(None, is_yes=False) is False

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1721,7 +1721,7 @@ def test_is_initial_tag(mocker: MockFixture, tmp_commitizen_project):
         "extras": None,
     }
 
-    bump_cmd = bump.Bump(config, arguments)
+    bump_cmd = bump.Bump(config, arguments)  # type: ignore
 
     # Test case 1: No current tag, not yes mode
     mocker.patch("questionary.confirm", return_value=mocker.Mock(ask=lambda: True))

--- a/tests/commands/test_version_command.py
+++ b/tests/commands/test_version_command.py
@@ -97,7 +97,6 @@ def test_version_use_version_provider(
         {
             "report": False,
             "project": project,
-            "commitizen": False,
             "verbose": not project,
         },
     )()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,7 @@ class SemverCommitizen(BaseCommitizen):
         "patch": "PATCH",
     }
     changelog_pattern = r"^(patch|minor|major)"
-    commit_parser = r"^(?P<change_type>patch|minor|major)(?:\((?P<scope>[^()\r\n]*)\)|\()?:?\s(?P<message>.+)"  # noqa
+    commit_parser = r"^(?P<change_type>patch|minor|major)(?:\((?P<scope>[^()\r\n]*)\)|\()?:?\s(?P<message>.+)"
     change_type_map = {
         "major": "Breaking Changes",
         "minor": "Features",

--- a/tests/test_bump_find_increment.py
+++ b/tests/test_bump_find_increment.py
@@ -32,14 +32,14 @@ MINOR_INCREMENTS_CC = [
 MAJOR_INCREMENTS_BREAKING_CHANGE_CC = [
     "feat(cli): added version",
     "docs(README): motivation",
-    "BREAKING CHANGE: `extends` key in config file is now used for extending other config files",  # noqa
+    "BREAKING CHANGE: `extends` key in config file is now used for extending other config files",
     "fix(setup.py): future is now required for every python version",
 ]
 
 MAJOR_INCREMENTS_BREAKING_CHANGE_ALT_CC = [
     "feat(cli): added version",
     "docs(README): motivation",
-    "BREAKING-CHANGE: `extends` key in config file is now used for extending other config files",  # noqa
+    "BREAKING-CHANGE: `extends` key in config file is now used for extending other config files",
     "fix(setup.py): future is now required for every python version",
 ]
 

--- a/tests/test_cz_conventional_commits.py
+++ b/tests/test_cz_conventional_commits.py
@@ -2,48 +2,42 @@ import pytest
 
 from commitizen.cz.conventional_commits.conventional_commits import (
     ConventionalCommitsCz,
-    parse_scope,
-    parse_subject,
+    _parse_scope,
+    _parse_subject,
 )
 from commitizen.cz.exceptions import AnswerRequiredError
 
-valid_scopes = ["", "simple", "dash-separated", "camelCaseUPPERCASE"]
 
-scopes_transformations = [["with spaces", "with-spaces"], [None, ""]]
-
-valid_subjects = ["this is a normal text", "aword"]
-
-subjects_transformations = [["with dot.", "with dot"]]
-
-invalid_subjects = ["", "   ", ".", "   .", "", None]
+@pytest.mark.parametrize(
+    "valid_scope", ["", "simple", "dash-separated", "camelCaseUPPERCASE"]
+)
+def test_parse_scope_valid_values(valid_scope):
+    assert valid_scope == _parse_scope(valid_scope)
 
 
-def test_parse_scope_valid_values():
-    for valid_scope in valid_scopes:
-        assert valid_scope == parse_scope(valid_scope)
+@pytest.mark.parametrize(
+    "scopes_transformation", [["with spaces", "with-spaces"], ["", ""]]
+)
+def test_scopes_transformations(scopes_transformation):
+    invalid_scope, transformed_scope = scopes_transformation
+    assert transformed_scope == _parse_scope(invalid_scope)
 
 
-def test_scopes_transformations():
-    for scopes_transformation in scopes_transformations:
-        invalid_scope, transformed_scope = scopes_transformation
-        assert transformed_scope == parse_scope(invalid_scope)
+@pytest.mark.parametrize("valid_subject", ["this is a normal text", "aword"])
+def test_parse_subject_valid_values(valid_subject):
+    assert valid_subject == _parse_subject(valid_subject)
 
 
-def test_parse_subject_valid_values():
-    for valid_subject in valid_subjects:
-        assert valid_subject == parse_subject(valid_subject)
+@pytest.mark.parametrize("invalid_subject", ["", "   ", ".", "   .", "\t\t."])
+def test_parse_subject_invalid_values(invalid_subject):
+    with pytest.raises(AnswerRequiredError):
+        _parse_subject(invalid_subject)
 
 
-def test_parse_subject_invalid_values():
-    for valid_subject in invalid_subjects:
-        with pytest.raises(AnswerRequiredError):
-            parse_subject(valid_subject)
-
-
-def test_subject_transformations():
-    for subject_transformation in subjects_transformations:
-        invalid_subject, transformed_subject = subject_transformation
-        assert transformed_subject == parse_subject(invalid_subject)
+@pytest.mark.parametrize("subject_transformation", [["with dot.", "with dot"]])
+def test_subject_transformations(subject_transformation):
+    invalid_subject, transformed_subject = subject_transformation
+    assert transformed_subject == _parse_subject(invalid_subject)
 
 
 def test_questions(config):

--- a/tests/test_cz_conventional_commits.py
+++ b/tests/test_cz_conventional_commits.py
@@ -83,7 +83,7 @@ def test_long_answer(config):
     message = conventional_commits.message(answers)
     assert (
         message
-        == "fix(users): email pattern corrected\n\ncomplete content\n\ncloses #24"  # noqa
+        == "fix(users): email pattern corrected\n\ncomplete content\n\ncloses #24"
     )
 
 
@@ -101,7 +101,7 @@ def test_breaking_change_in_footer(config):
     print(message)
     assert (
         message
-        == "fix(users): email pattern corrected\n\ncomplete content\n\nBREAKING CHANGE: migrate by renaming user to users"  # noqa
+        == "fix(users): email pattern corrected\n\ncomplete content\n\nBREAKING CHANGE: migrate by renaming user to users"
     )
 
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -18,6 +18,13 @@ from tests.utils import (
 )
 
 
+@pytest.mark.parametrize("date", ["2020-01-21", "1970-01-01"])
+def test_git_tag_date(date: str):
+    git_tag = git.GitTag(rev="sha1-code", name="0.0.1", date="2025-05-30")
+    git_tag.date = date
+    assert git_tag.date == date
+
+
 def test_git_object_eq():
     git_commit = git.GitCommit(
         rev="sha1-code", title="this is title", body="this is body"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

Not sure why the changes of #1466, #1479 and #1480 vanished in the refactors branch. This is redoing it.


## Checklist

- [ ] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `poetry all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes

- [ ] Run `poetry doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external) in the documentation

> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
