### PR TITLE
refactor(Init): fix unbounded variable in _ask_tag_format

### DIFF
--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -208,23 +208,20 @@ class Init:
         return latest_tag
 
     def _ask_tag_format(self, latest_tag: str) -> str:
-        is_correct_format = False
         if latest_tag.startswith("v"):
-            tag_format = r"v$version"
-            is_correct_format = questionary.confirm(
-                f'Is "{tag_format}" the correct tag format?', style=self.cz.style
-            ).unsafe_ask()
+            v_tag_format = r"v$version"
+            if questionary.confirm(
+                f'Is "{v_tag_format}" the correct tag format?', style=self.cz.style
+            ).unsafe_ask():
+                return v_tag_format
 
         default_format = DEFAULT_SETTINGS["tag_format"]
-        if not is_correct_format:
-            tag_format = questionary.text(
-                f'Please enter the correct version format: (default: "{default_format}")',
-                style=self.cz.style,
-            ).unsafe_ask()
+        tag_format: str = questionary.text(
+            f'Please enter the correct version format: (default: "{default_format}")',
+            style=self.cz.style,
+        ).unsafe_ask()
 
-            if not tag_format:
-                tag_format = default_format
-        return tag_format
+        return tag_format or default_format
 
     def _ask_version_provider(self) -> str:
         """Ask for setting: version_provider"""

--- a/tests/commands/test_init_command.py
+++ b/tests/commands/test_init_command.py
@@ -255,6 +255,38 @@ class TestNoPreCommitInstalled:
                 commands.Init(config)()
 
 
+class TestAskTagFormat:
+    def test_confirm_v_tag_format(self, mocker: MockFixture, config):
+        init = commands.Init(config)
+        mocker.patch("questionary.confirm", return_value=FakeQuestion(True))
+
+        result = init._ask_tag_format("v1.0.0")
+        assert result == r"v$version"
+
+    def test_reject_v_tag_format(self, mocker: MockFixture, config):
+        init = commands.Init(config)
+        mocker.patch("questionary.confirm", return_value=FakeQuestion(False))
+        mocker.patch("questionary.text", return_value=FakeQuestion("custom-$version"))
+
+        result = init._ask_tag_format("v1.0.0")
+        assert result == "custom-$version"
+
+    def test_non_v_tag_format(self, mocker: MockFixture, config):
+        init = commands.Init(config)
+        mocker.patch("questionary.text", return_value=FakeQuestion("custom-$version"))
+
+        result = init._ask_tag_format("1.0.0")
+        assert result == "custom-$version"
+
+    def test_empty_input_returns_default(self, mocker: MockFixture, config):
+        init = commands.Init(config)
+        mocker.patch("questionary.confirm", return_value=FakeQuestion(False))
+        mocker.patch("questionary.text", return_value=FakeQuestion(""))
+
+        result = init._ask_tag_format("v1.0.0")
+        assert result == "$version"  # This is the default format from DEFAULT_SETTINGS
+
+
 @skip_below_py_3_10
 def test_init_command_shows_description_when_use_help_option(
     mocker: MockFixture, capsys, file_regression


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

Before this change, the type of `tag_format` is `Any | Unbounded | str` at the end of the function. Actually `tag_format` is defined for all code paths.

- If `is_correct_format` is `True`, then `tag_format` is assigned `"v$version"`  and the function returns it.
- If `is_correct_format` is `False`, then `tag_format` is initialized in the if-block.

The function logic should be easier to understand after this change.


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)
