### PR TITLE
fix(ExitCode): add from_str in ExitCode and replace parse_no_raise with it, warn if the error code is not in range

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -583,20 +583,19 @@ def parse_no_raise(comma_separated_no_raise: str) -> list[int]:
     Receives digits and strings and outputs the parsed integer which
     represents the exit code found in exceptions.
     """
-    no_raise_items: list[str] = comma_separated_no_raise.split(",")
-    no_raise_codes: list[int] = []
-    for item in no_raise_items:
-        if item.isdecimal():
-            no_raise_codes.append(int(item))
-            continue
+
+    def exit_code_from_str_or_skip(s: str) -> ExitCode | None:
         try:
-            exit_code = ExitCode[item.strip()]
-        except KeyError:
-            out.warn(f"WARN: no_raise key `{item}` does not exist. Skipping.")
-            continue
-        else:
-            no_raise_codes.append(exit_code.value)
-    return no_raise_codes
+            return ExitCode.from_str(s)
+        except (KeyError, ValueError):
+            out.warn(f"WARN: no_raise value `{s}` is not a valid exit code. Skipping.")
+            return None
+
+    return [
+        code.value
+        for s in comma_separated_no_raise.split(",")
+        if (code := exit_code_from_str_or_skip(s)) is not None
+    ]
 
 
 if TYPE_CHECKING:

--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -1,10 +1,12 @@
-import enum
+from __future__ import annotations
+
+from enum import IntEnum
 from typing import Any
 
 from commitizen import out
 
 
-class ExitCode(enum.IntEnum):
+class ExitCode(IntEnum):
     EXPECTED_EXIT = 0
     NO_COMMITIZEN_FOUND = 1
     NOT_A_GIT_PROJECT = 2
@@ -38,6 +40,12 @@ class ExitCode(enum.IntEnum):
     CONFIG_FILE_NOT_FOUND = 30
     CONFIG_FILE_IS_EMPTY = 31
     COMMIT_MESSAGE_LENGTH_LIMIT_EXCEEDED = 32
+
+    @classmethod
+    def from_str(cls, value: str) -> ExitCode:
+        if value.isdecimal():
+            return cls(int(value))
+        return cls[value.strip()]
 
 
 class CommitizenException(Exception):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,38 @@
+import pytest
+
+from commitizen.exceptions import ExitCode
+
+
+def test_from_str_with_decimal():
+    """Test from_str with decimal values."""
+    assert ExitCode.from_str("0") == ExitCode.EXPECTED_EXIT
+    assert ExitCode.from_str("1") == ExitCode.NO_COMMITIZEN_FOUND
+    assert ExitCode.from_str("32") == ExitCode.COMMIT_MESSAGE_LENGTH_LIMIT_EXCEEDED
+
+
+def test_from_str_with_enum_name():
+    """Test from_str with enum names."""
+    assert ExitCode.from_str("EXPECTED_EXIT") == ExitCode.EXPECTED_EXIT
+    assert ExitCode.from_str("NO_COMMITIZEN_FOUND") == ExitCode.NO_COMMITIZEN_FOUND
+    assert (
+        ExitCode.from_str("COMMIT_MESSAGE_LENGTH_LIMIT_EXCEEDED")
+        == ExitCode.COMMIT_MESSAGE_LENGTH_LIMIT_EXCEEDED
+    )
+
+
+def test_from_str_with_whitespace():
+    """Test from_str with whitespace in enum names."""
+    assert ExitCode.from_str("  EXPECTED_EXIT  ") == ExitCode.EXPECTED_EXIT
+    assert ExitCode.from_str("\tNO_COMMITIZEN_FOUND\t") == ExitCode.NO_COMMITIZEN_FOUND
+
+
+def test_from_str_with_invalid_values():
+    """Test from_str with invalid values."""
+    with pytest.raises(KeyError):
+        ExitCode.from_str("invalid_name")
+    with pytest.raises(ValueError):
+        ExitCode.from_str("999")  # Out of range decimal
+    with pytest.raises(KeyError):
+        ExitCode.from_str("")
+    with pytest.raises(KeyError):
+        ExitCode.from_str(" ")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

- Now we validate if the error code exists given a decimal string

## Checklist

- [ ] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `poetry all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes
