### PR TITLE
docs(docs/third-party-commitizen.md): Add cz-path info

### DIFF
--- a/docs/third-party-commitizen.md
+++ b/docs/third-party-commitizen.md
@@ -145,3 +145,56 @@ commitizen:
   version_provider: deno-provider
   version_scheme: semver
 ```
+
+### [cz-path](https://pypi.org/project/cz-path/)
+
+Provides prefix choices for commit messages based on staged files (Git only).
+For example, if the staged files are `component/z/a.ts` and `component/z/b.ts`,
+the path prefix option will be `component/z` and commit message might look like:
+`component/z/: description of changes`. If only one file is staged, the extension
+is removed in the prefix.
+
+#### Installation
+
+```sh
+pip install cz-path
+```
+
+#### Usage
+
+Add `cz-path` to your configuration file.
+
+Example for `.cz.json`:
+
+```json
+{
+  "commitizen": {
+    "name": "cz_path",
+    "remove_path_prefixes": ["src", "module_name"]
+  }
+}
+```
+
+The default value for `remove_path_prefixes` is `["src"]`. Adding `/` to the
+prefixes is not required.
+
+#### Example session
+
+```plain
+ $ git add .vscode/
+ $ cz -n cz_path c
+? Prefix: (Use arrow keys)
+ » .vscode
+   .vscode/
+   project
+   (empty)
+? Prefix: .vscode
+? Commit title: adjust settings
+
+.vscode: adjust settings
+
+[main 0000000] .vscode: adjust settings
+ 2 files changed, 1 insertion(+), 11 deletions(-)
+
+Commit successful!
+```


### PR DESCRIPTION
## Description
I created a new Commitizen plugin called [cz-path](https://pypi.org/project/cz-path/) to make path prefix commit message style easier. Example: `ui/clock: fix dial` when staged files are all in `src/ui/clock` (`src` is by default removed).


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly
- [x] Check and fix any broken links (internal or external) in the documentation
