### PR TITLE
feat(conventional_commits): add ability to overide settings from tool…

### DIFF
--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -1,20 +1,14 @@
 import os
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, TypedDict
+from typing import TypedDict
+
+from jinja2 import Template
 
 from commitizen import defaults
 from commitizen.config import BaseConfig
 from commitizen.cz.base import BaseCommitizen
 from commitizen.cz.utils import multiple_line_breaker, required_validator
 from commitizen.question import CzQuestion
-
-if TYPE_CHECKING:
-    from jinja2 import Template
-else:
-    try:
-        from jinja2 import Template
-    except ImportError:
-        from string import Template
 
 __all__ = ["ConventionalCommitsCz"]
 
@@ -181,10 +175,7 @@ class ConventionalCommitsCz(BaseCommitizen):
 
     def message(self, answers: ConventionalCommitsAnswers) -> str:  # type: ignore[override]
         if _message_template := self.custom_settings.get("message_template"):
-            message_template = Template(_message_template)
-            if getattr(Template, "substitute", None):
-                return message_template.substitute(**answers)  # type: ignore[attr-defined,no-any-return] # pragma: no cover # TODO: check if we can fix this
-            return message_template.render(**answers)
+            return Template(_message_template).render(**answers)
 
         prefix = answers["prefix"]
         scope = answers["scope"]

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -3,17 +3,11 @@ We have two different ways to do so.
 
 ## 1. Customize in configuration file
 
-The basic steps are:
-
-1. Define your custom committing or bumping rules in the configuration file.
-2. Declare `name = "cz_customize"` in your configuration file, or add `-n cz_customize` when running Commitizen.
+Define your custom committing or bumping rules in the configuration file, changing behaviour of the default cz_conventional_commits commitizen.
 
 Example:
 
 ```toml title="pyproject.toml"
-[tool.commitizen]
-name = "cz_customize"
-
 [tool.commitizen.customize]
 message_template = "{{change_type}}:{% if show_message %} {{message}}{% endif %}"
 example = "feature: this feature enable customize through config file"
@@ -53,7 +47,6 @@ The equivalent example for a json config file:
 ```json title=".cz.json"
 {
     "commitizen": {
-        "name": "cz_customize",
         "customize": {
             "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
             "example": "feature: this feature enable customize through config file",
@@ -108,7 +101,6 @@ And the correspondent example for a yaml file:
 
 ```yaml title=".cz.yaml"
 commitizen:
-  name: cz_customize
   customize:
     message_template: "{{change_type}}:{% if show_message %} {{message}}{% endif %}"
     example: 'feature: this feature enable customize through config file'

--- a/tests/test_customized_cz_conventional_commits.py
+++ b/tests/test_customized_cz_conventional_commits.py
@@ -1,0 +1,562 @@
+import pytest
+
+from commitizen.config import JsonConfig, TomlConfig, YAMLConfig
+from commitizen.cz.conventional_commits import ConventionalCommitsCz
+
+TOML_STR = r"""
+    [tool.commitizen.customize]
+    message_template = "{{change_type}}:{% if show_message %} {{message}}{% endif %}"
+    example = "feature: this feature enables customization through a config file"
+    schema = "<type>: <body>"
+    schema_pattern = "(feature|bug fix):(\\s.*)"
+    commit_parser = "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?"
+    changelog_pattern = "^(feature|bug fix)?(!)?"
+    change_type_map = {"feature" = "Feat", "bug fix" = "Fix"}
+
+    bump_pattern = "^(break|new|fix|hotfix)"
+    bump_map = {"break" = "MAJOR", "new" = "MINOR", "fix" = "PATCH", "hotfix" = "PATCH"}
+    change_type_order = ["perf", "BREAKING CHANGE", "feat", "fix", "refactor"]
+    info = "This is a customized cz."
+
+    [[tool.commitizen.customize.questions]]
+    type = "list"
+    name = "change_type"
+    choices = [
+        {value = "feature", name = "feature: A new feature."},
+        {value = "bug fix", name = "bug fix: A bug fix."}
+    ]
+    message = "Select the type of change you are committing"
+
+    [[tool.commitizen.customize.questions]]
+    type = "input"
+    name = "message"
+    message = "Body."
+
+    [[tool.commitizen.customize.questions]]
+    type = "confirm"
+    name = "show_message"
+    message = "Do you want to add body message in commit?"
+"""
+
+JSON_STR = r"""
+    {
+        "commitizen": {
+            "version": "1.0.0",
+            "version_files": [
+                "commitizen/__version__.py",
+                "pyproject.toml"
+            ],
+            "customize": {
+                "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
+                "example": "feature: this feature enables customization through a config file",
+                "schema": "<type>: <body>",
+                "schema_pattern": "(feature|bug fix):(\\s.*)",
+                "bump_pattern": "^(break|new|fix|hotfix)",
+                "bump_map": {
+                    "break": "MAJOR",
+                    "new": "MINOR",
+                    "fix": "PATCH",
+                    "hotfix": "PATCH"
+                },
+                "commit_parser": "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?",
+                "changelog_pattern": "^(feature|bug fix)?(!)?",
+                "change_type_map": {"feature": "Feat", "bug fix": "Fix"},
+                "change_type_order": ["perf", "BREAKING CHANGE", "feat", "fix", "refactor"],
+                "info": "This is a customized cz.",
+                "questions": [
+                    {
+                        "type": "list",
+                        "name": "change_type",
+                        "choices": [
+                            {
+                                "value": "feature",
+                                "name": "feature: A new feature."
+                            },
+                            {
+                                "value": "bug fix",
+                                "name": "bug fix: A bug fix."
+                            }
+                        ],
+                        "message": "Select the type of change you are committing"
+                    },
+                    {
+                        "type": "input",
+                        "name": "message",
+                        "message": "Body."
+                    },
+                    {
+                        "type": "confirm",
+                        "name": "show_message",
+                        "message": "Do you want to add body message in commit?"
+                    }
+                ]
+            }
+        }
+    }
+"""
+
+YAML_STR = """
+commitizen:
+  version: 1.0.0
+  version_files:
+  - commitizen/__version__.py
+  - pyproject.toml
+  customize:
+    message_template: "{{change_type}}:{% if show_message %} {{message}}{% endif %}"
+    example: 'feature: this feature enables customization through a config file'
+    schema: "<type>: <body>"
+    schema_pattern: "(feature|bug fix):(\\s.*)"
+    bump_pattern: "^(break|new|fix|hotfix)"
+    bump_map:
+      break: MAJOR
+      new: MINOR
+      fix: PATCH
+      hotfix: PATCH
+    change_type_order: ["perf", "BREAKING CHANGE", "feat", "fix", "refactor"]
+    info: This is a customized cz.
+    questions:
+    - type: list
+      name: change_type
+      choices:
+      - value: feature
+        name: 'feature: A new feature.'
+      - value: bug fix
+        name: 'bug fix: A bug fix.'
+      message: Select the type of change you are committing
+    - type: input
+      name: message
+      message: Body.
+    - type: confirm
+      name: show_message
+      message: Do you want to add body message in commit?
+"""
+
+TOML_WITH_UNICODE = r"""
+    [tool.commitizen]
+    version = "1.0.0"
+    version_files = [
+        "commitizen/__version__.py",
+        "pyproject.toml:version"
+    ]
+    [tool.commitizen.customize]
+    message_template = "{{change_type}}:{% if show_message %} {{message}}{% endif %}"
+    example = "✨ feature: this feature enables customization through a config file"
+    schema = "<type>: <body>"
+    schema_pattern = "(✨ feature|🐛 bug fix):(\\s.*)"
+    commit_parser = "^(?P<change_type>✨ feature|🐛 bug fix):\\s(?P<message>.*)?"
+    changelog_pattern = "^(✨ feature|🐛 bug fix)?(!)?"
+    change_type_map = {"✨ feature" = "Feat", "🐛 bug fix" = "Fix"}
+    bump_pattern = "^(✨ feat|🐛 bug fix)"
+    bump_map = {"break" = "MAJOR", "✨ feat" = "MINOR", "🐛 bug fix" = "MINOR"}
+    change_type_order = ["perf", "BREAKING CHANGE", "feat", "fix", "refactor"]
+    info = "This is a customized cz with emojis 🎉!"
+    [[tool.commitizen.customize.questions]]
+    type = "list"
+    name = "change_type"
+    choices = [
+        {value = "✨ feature", name = "✨ feature: A new feature."},
+        {value = "🐛 bug fix", name = "🐛 bug fix: A bug fix."}
+    ]
+    message = "Select the type of change you are committing"
+    [[tool.commitizen.customize.questions]]
+    type = "input"
+    name = "message"
+    message = "Body."
+    [[tool.commitizen.customize.questions]]
+    type = "confirm"
+    name = "show_message"
+    message = "Do you want to add body message in commit?"
+"""
+
+JSON_WITH_UNICODE = r"""
+    {
+        "commitizen": {
+            "version": "1.0.0",
+            "version_files": [
+                "commitizen/__version__.py",
+                "pyproject.toml:version"
+            ],
+            "customize": {
+                "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
+                "example": "✨ feature: this feature enables customization through a config file",
+                "schema": "<type>: <body>",
+                "schema_pattern": "(✨ feature|🐛 bug fix):(\\s.*)",
+                "bump_pattern": "^(✨ feat|🐛 bug fix)",
+                "bump_map": {
+                    "break": "MAJOR",
+                    "✨ feat": "MINOR",
+                    "🐛 bug fix": "MINOR"
+                },
+                "commit_parser": "^(?P<change_type>✨ feature|🐛 bug fix):\\s(?P<message>.*)?",
+                "changelog_pattern": "^(✨ feature|🐛 bug fix)?(!)?",
+                "change_type_map": {"✨ feature": "Feat", "🐛 bug fix": "Fix"},
+                "change_type_order": ["perf", "BREAKING CHANGE", "feat", "fix", "refactor"],
+                "info": "This is a customized cz with emojis 🎉!",
+                "questions": [
+                    {
+                        "type": "list",
+                        "name": "change_type",
+                        "choices": [
+                            {
+                                "value": "✨ feature",
+                                "name": "✨ feature: A new feature."
+                            },
+                            {
+                                "value": "🐛 bug fix",
+                                "name": "🐛 bug fix: A bug fix."
+                            }
+                        ],
+                        "message": "Select the type of change you are committing"
+                    },
+                    {
+                        "type": "input",
+                        "name": "message",
+                        "message": "Body."
+                    },
+                    {
+                        "type": "confirm",
+                        "name": "show_message",
+                        "message": "Do you want to add body message in commit?"
+                    }
+                ]
+            }
+        }
+    }
+"""
+
+TOML_STR_INFO_PATH = """
+    [tool.commitizen.customize]
+    message_template = "{{change_type}}:{% if show_message %} {{message}}{% endif %}"
+    example = "feature: this feature enables customization through a config file"
+    schema = "<type>: <body>"
+    bump_pattern = "^(break|new|fix|hotfix)"
+    bump_map = {"break" = "MAJOR", "new" = "MINOR", "fix" = "PATCH", "hotfix" = "PATCH"}
+    info_path = "info.txt"
+"""
+
+JSON_STR_INFO_PATH = r"""
+    {
+        "commitizen": {
+            "customize": {
+                "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
+                "example": "feature: this feature enables customization through a config file",
+                "schema": "<type>: <body>",
+                "bump_pattern": "^(break|new|fix|hotfix)",
+                "bump_map": {
+                    "break": "MAJOR",
+                    "new": "MINOR",
+                    "fix": "PATCH",
+                    "hotfix": "PATCH"
+                },
+                "info_path": "info.txt"
+            }
+        }
+    }
+"""
+
+YAML_STR_INFO_PATH = """
+commitizen:
+  customize:
+    message_template: "{{change_type}}:{% if show_message %} {{message}}{% endif %}"
+    example: 'feature: this feature enables customization through a config file'
+    schema: "<type>: <body>"
+    bump_pattern: "^(break|new|fix|hotfix)"
+    bump_map:
+      break: MAJOR
+      new: MINOR
+      fix: PATCH
+      hotfix: PATCH
+    info_path: info.txt
+"""
+
+JSON_STR_WITHOUT_PATH = r"""
+    {
+        "commitizen": {
+            "customize": {
+                "message_template": "{{change_type}}:{% if show_message %} {{message}}{% endif %}",
+                "example": "feature: this feature enables customization through a config file",
+                "schema": "<type>: <body>",
+                "bump_pattern": "^(break|new|fix|hotfix)",
+                "bump_map": {
+                    "break": "MAJOR",
+                    "new": "MINOR",
+                    "fix": "PATCH",
+                    "hotfix": "PATCH"
+                }
+            }
+        }
+    }
+"""
+
+YAML_STR_WITHOUT_PATH = """
+commitizen:
+  customize:
+    message_template: "{{change_type}}:{% if show_message %} {{message}}{% endif %}"
+    example: 'feature: this feature enables customization through a config file'
+    schema: "<type>: <body>"
+    bump_pattern: "^(break|new|fix|hotfix)"
+    bump_map:
+      break: MAJOR
+      new: MINOR
+      fix: PATCH
+      hotfix: PATCH
+"""
+
+
+@pytest.fixture(
+    params=[
+        TomlConfig(data=TOML_STR, path="not_exist.toml"),
+        JsonConfig(data=JSON_STR, path="not_exist.json"),
+    ]
+)
+def config(request):
+    """Parametrize the config fixture
+
+    This fixture allow to test multiple config formats,
+    without add the builtin parametrize decorator
+    """
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        TomlConfig(data=TOML_STR_INFO_PATH, path="not_exist.toml"),
+        JsonConfig(data=JSON_STR_INFO_PATH, path="not_exist.json"),
+        YAMLConfig(data=YAML_STR_INFO_PATH, path="not_exist.yaml"),
+    ]
+)
+def config_info(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        TomlConfig(data=TOML_WITH_UNICODE, path="not_exist.toml"),
+        JsonConfig(data=JSON_WITH_UNICODE, path="not_exist.json"),
+    ]
+)
+def config_with_unicode(request):
+    return request.param
+
+
+def test_bump_pattern(config):
+    cz = ConventionalCommitsCz(config)
+    assert cz.bump_pattern == "^(break|new|fix|hotfix)"
+
+
+def test_bump_pattern_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    assert cz.bump_pattern == "^(✨ feat|🐛 bug fix)"
+
+
+def test_bump_map(config):
+    cz = ConventionalCommitsCz(config)
+    assert cz.bump_map == {
+        "break": "MAJOR",
+        "new": "MINOR",
+        "fix": "PATCH",
+        "hotfix": "PATCH",
+    }
+
+
+def test_bump_map_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    assert cz.bump_map == {
+        "break": "MAJOR",
+        "✨ feat": "MINOR",
+        "🐛 bug fix": "MINOR",
+    }
+
+
+def test_change_type_order(config):
+    cz = ConventionalCommitsCz(config)
+    assert cz.change_type_order == [
+        "perf",
+        "BREAKING CHANGE",
+        "feat",
+        "fix",
+        "refactor",
+    ]
+
+
+def test_change_type_order_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    assert cz.change_type_order == [
+        "perf",
+        "BREAKING CHANGE",
+        "feat",
+        "fix",
+        "refactor",
+    ]
+
+
+def test_questions(config):
+    cz = ConventionalCommitsCz(config)
+    questions = cz.questions()
+    expected_questions = [
+        {
+            "type": "list",
+            "name": "change_type",
+            "choices": [
+                {"value": "feature", "name": "feature: A new feature."},
+                {"value": "bug fix", "name": "bug fix: A bug fix."},
+            ],
+            "message": "Select the type of change you are committing",
+        },
+        {"type": "input", "name": "message", "message": "Body."},
+        {
+            "type": "confirm",
+            "name": "show_message",
+            "message": "Do you want to add body message in commit?",
+        },
+    ]
+    assert list(questions) == expected_questions
+
+
+def test_questions_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    questions = cz.questions()
+    expected_questions = [
+        {
+            "type": "list",
+            "name": "change_type",
+            "choices": [
+                {"value": "✨ feature", "name": "✨ feature: A new feature."},
+                {"value": "🐛 bug fix", "name": "🐛 bug fix: A bug fix."},
+            ],
+            "message": "Select the type of change you are committing",
+        },
+        {"type": "input", "name": "message", "message": "Body."},
+        {
+            "type": "confirm",
+            "name": "show_message",
+            "message": "Do you want to add body message in commit?",
+        },
+    ]
+    assert list(questions) == expected_questions
+
+
+def test_answer(config):
+    cz = ConventionalCommitsCz(config)
+    answers = {
+        "change_type": "feature",
+        "message": "this feature enable customize through config file",
+        "show_message": True,
+    }
+    message = cz.message(answers)
+    assert message == "feature: this feature enable customize through config file"
+
+    cz = ConventionalCommitsCz(config)
+    answers = {
+        "change_type": "feature",
+        "message": "this feature enable customize through config file",
+        "show_message": False,
+    }
+    message = cz.message(answers)
+    assert message == "feature:"
+
+
+def test_answer_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    answers = {
+        "change_type": "✨ feature",
+        "message": "this feature enables customization through a config file",
+        "show_message": True,
+    }
+    message = cz.message(answers)
+    assert (
+        message
+        == "✨ feature: this feature enables customization through a config file"
+    )
+
+    cz = ConventionalCommitsCz(config_with_unicode)
+    answers = {
+        "change_type": "✨ feature",
+        "message": "this feature enables customization through a config file",
+        "show_message": False,
+    }
+    message = cz.message(answers)
+    assert message == "✨ feature:"
+
+
+def test_example(config):
+    cz = ConventionalCommitsCz(config)
+    assert (
+        "feature: this feature enables customization through a config file"
+        in cz.example()
+    )
+
+
+def test_example_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    assert (
+        "✨ feature: this feature enables customization through a config file"
+        in cz.example()
+    )
+
+
+def test_schema(config):
+    cz = ConventionalCommitsCz(config)
+    assert "<type>: <body>" in cz.schema()
+
+
+def test_schema_pattern(config):
+    cz = ConventionalCommitsCz(config)
+    assert r"(feature|bug fix):(\s.*)" in cz.schema_pattern()
+
+
+def test_schema_pattern_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    assert r"(✨ feature|🐛 bug fix):(\s.*)" in cz.schema_pattern()
+
+
+def test_info(config):
+    cz = ConventionalCommitsCz(config)
+    assert "This is a customized cz." in cz.info()
+
+
+def test_info_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    assert "This is a customized cz with emojis 🎉!" in cz.info()
+
+
+def test_info_with_info_path(tmpdir, config_info):
+    with tmpdir.as_cwd():
+        tmpfile = tmpdir.join("info.txt")
+        tmpfile.write("Test info")
+
+        cz = ConventionalCommitsCz(config_info)
+        assert "Test info" in cz.info()
+
+
+def test_commit_parser(config):
+    cz = ConventionalCommitsCz(config)
+    assert cz.commit_parser == "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?"
+
+
+def test_commit_parser_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    assert (
+        cz.commit_parser
+        == "^(?P<change_type>✨ feature|🐛 bug fix):\\s(?P<message>.*)?"
+    )
+
+
+def test_changelog_pattern(config):
+    cz = ConventionalCommitsCz(config)
+    assert cz.changelog_pattern == "^(feature|bug fix)?(!)?"
+
+
+def test_changelog_pattern_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    assert cz.changelog_pattern == "^(✨ feature|🐛 bug fix)?(!)?"
+
+
+def test_change_type_map(config):
+    cz = ConventionalCommitsCz(config)
+    assert cz.change_type_map == {"feature": "Feat", "bug fix": "Fix"}
+
+
+def test_change_type_map_unicode(config_with_unicode):
+    cz = ConventionalCommitsCz(config_with_unicode)
+    assert cz.change_type_map == {"✨ feature": "Feat", "🐛 bug fix": "Fix"}


### PR DESCRIPTION
….commitizen.customize

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Adds ability to override settings using [tool.commitizen.customize] in the cz_conventional_commits


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [x] Update the documentation for the changes

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly
- [x] Check and fix any broken links (internal or external) in the documentation


## Expected Behavior
You use `conventional_commits` commitizen, and using  [tool.commitizen.customize] config section you override selected settings

## Steps to Test This Pull Request
Add this to pyproject.tomp in existing project using conventional_commits and update_changelog_on_bump = true:
```
[tool.commitizen.customize]
change_type_map = {"feat" = "✨ Feat", "fix" = "🐛 Bug Fix", "refactor" = "♻️  Refactor", "perf" = "⚡️ Perf"}
```
do `cz  bump --dry-run` and observe that changelog headers have gitmoji. 
Test that other behavior is identical to unpatched version
test that 
`bump_map = {"^.+!$" = "MAJOR", "^feat" = "MAJOR", "^fix" = "MINOR", "^refactor" = "MINOR", "^perf" = "MINOR"}` bumps MINOR not PATCH part on fix commit, test that other things are unchanged. 
Test other settings.

## Additional Context
This is starting shot at #1385 
To test this I copied tests for cz_customize, removed name=... from all configs there and removed the tests that don't make
sense, for example exception for missing customize section.