### PR TITLE
refactor(TomlConfig): minor cleanups for DX

### DIFF
--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from tomlkit import exceptions, parse, table
+from tomlkit import TOMLDocument, exceptions, parse, table
 
 from commitizen.exceptions import InvalidConfigurationError
 
@@ -28,30 +28,31 @@ class TomlConfig(BaseConfig):
         self._parse_setting(data)
 
     def init_empty_config_content(self) -> None:
+        config_doc = TOMLDocument()
         if os.path.isfile(self.path):
             with open(self.path, "rb") as input_toml_file:
-                parser = parse(input_toml_file.read())
-        else:
-            parser = parse("")
+                config_doc = parse(input_toml_file.read())
+
+        if config_doc.get("tool") is None:
+            config_doc["tool"] = table()
+        config_doc["tool"]["commitizen"] = table()  # type: ignore[index]
 
         with open(self.path, "wb") as output_toml_file:
-            if parser.get("tool") is None:
-                parser["tool"] = table()
-            parser["tool"]["commitizen"] = table()  # type: ignore[index]
-            output_toml_file.write(parser.as_string().encode(self.encoding))
+            output_toml_file.write(config_doc.as_string().encode(self.encoding))
 
-    def set_key(self, key: str, value: Any) -> Self:
+    def set_key(self, key: str, value: object) -> Self:
         """Set or update a key in the conf.
 
         For now only strings are supported.
         We use to update the version number.
         """
         with open(self.path, "rb") as f:
-            parser = parse(f.read())
+            config_doc = parse(f.read())
 
-        parser["tool"]["commitizen"][key] = value  # type: ignore[index]
+        config_doc["tool"]["commitizen"][key] = value  # type: ignore[index]
         with open(self.path, "wb") as f:
-            f.write(parser.as_string().encode(self.encoding))
+            f.write(config_doc.as_string().encode(self.encoding))
+
         return self
 
     def _parse_setting(self, data: bytes | str) -> None:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [ ] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `poetry all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes

- [ ] Run `poetry doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external) in the documentation

> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
