### PR TITLE
refactor(BaseConfig): update docstring, extract factory method and remove unnecessary variable assignment

### DIFF
--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+from pathlib import Path
 from typing import Any, NamedTuple
 
 import questionary
@@ -9,7 +10,10 @@ import yaml
 
 from commitizen import cmd, factory, out
 from commitizen.__version__ import __version__
-from commitizen.config import BaseConfig, JsonConfig, TomlConfig, YAMLConfig
+from commitizen.config import (
+    BaseConfig,
+)
+from commitizen.config.factory import create_config
 from commitizen.cz import registry
 from commitizen.defaults import CONFIG_FILES, DEFAULT_SETTINGS
 from commitizen.exceptions import InitFailedError, NoAnswersError
@@ -187,45 +191,33 @@ class Init:
                 )
             out.write("commitizen pre-commit hook is now installed in your '.git'\n")
 
-        # Initialize configuration
-        if "toml" in config_path:
-            self.config = TomlConfig(data="", path=config_path)
-        elif "json" in config_path:
-            self.config = JsonConfig(data="{}", path=config_path)
-        elif "yaml" in config_path:
-            self.config = YAMLConfig(data="", path=config_path)
-
-        # Create and initialize config
-        self.config.init_empty_config_content()
-
-        self.config.set_key("name", cz_name)
-        self.config.set_key("tag_format", tag_format)
-        self.config.set_key("version_scheme", version_scheme)
-        if version_provider == "commitizen":
-            self.config.set_key("version", version.public)
-        else:
-            self.config.set_key("version_provider", version_provider)
-        if update_changelog_on_bump:
-            self.config.set_key("update_changelog_on_bump", update_changelog_on_bump)
-        if major_version_zero:
-            self.config.set_key("major_version_zero", major_version_zero)
+        _write_config_to_file(
+            path=config_path,
+            cz_name=cz_name,
+            version_provider=version_provider,
+            version_scheme=version_scheme,
+            version=version,
+            tag_format=tag_format,
+            update_changelog_on_bump=update_changelog_on_bump,
+            major_version_zero=major_version_zero,
+        )
 
         out.write("\nYou can bump the version running:\n")
         out.info("\tcz bump\n")
         out.success("Configuration complete 🚀")
 
-    def _ask_config_path(self) -> str:
+    def _ask_config_path(self) -> Path:
         default_path = (
             "pyproject.toml" if self.project_info.has_pyproject else ".cz.toml"
         )
 
-        name: str = questionary.select(
+        filename: str = questionary.select(
             "Please choose a supported config file: ",
             choices=CONFIG_FILES,
             default=default_path,
             style=self.cz.style,
         ).unsafe_ask()
-        return name
+        return Path(filename)
 
     def _ask_name(self) -> str:
         name: str = questionary.select(
@@ -369,3 +361,30 @@ class Init:
         else:
             repos.append(CZ_HOOK_CONFIG)
         return config_data
+
+
+def _write_config_to_file(
+    *,
+    path: Path,
+    cz_name: str,
+    version_provider: str,
+    version_scheme: str,
+    version: Version,
+    tag_format: str,
+    update_changelog_on_bump: bool,
+    major_version_zero: bool,
+) -> None:
+    out_config = create_config(path=path)
+    out_config.init_empty_config_content()
+
+    out_config.set_key("name", cz_name)
+    out_config.set_key("tag_format", tag_format)
+    out_config.set_key("version_scheme", version_scheme)
+    if version_provider == "commitizen":
+        out_config.set_key("version", version.public)
+    else:
+        out_config.set_key("version_provider", version_provider)
+    if update_changelog_on_bump:
+        out_config.set_key("update_changelog_on_bump", update_changelog_on_bump)
+    if major_version_zero:
+        out_config.set_key("major_version_zero", major_version_zero)

--- a/commitizen/config/__init__.py
+++ b/commitizen/config/__init__.py
@@ -1,58 +1,46 @@
 from __future__ import annotations
 
+from collections.abc import Generator
 from pathlib import Path
 
 from commitizen import defaults, git
+from commitizen.config.factory import create_config
 from commitizen.exceptions import ConfigFileIsEmpty, ConfigFileNotFound
 
 from .base_config import BaseConfig
-from .json_config import JsonConfig
-from .toml_config import TomlConfig
-from .yaml_config import YAMLConfig
+
+
+def _resolve_config_paths(filepath: str | None = None) -> Generator[Path, None, None]:
+    if filepath is not None:
+        out_path = Path(filepath)
+        if not out_path.exists():
+            raise ConfigFileNotFound()
+
+        yield out_path
+        return
+
+    git_project_root = git.find_git_project_root()
+    cfg_search_paths = [Path(".")]
+    if git_project_root:
+        cfg_search_paths.append(git_project_root)
+
+    for path in cfg_search_paths:
+        for filename in defaults.CONFIG_FILES:
+            out_path = path / Path(filename)
+            if out_path.exists():
+                yield out_path
 
 
 def read_cfg(filepath: str | None = None) -> BaseConfig:
-    conf = BaseConfig()
-
-    if filepath is not None:
-        if not Path(filepath).exists():
-            raise ConfigFileNotFound()
-
-        cfg_paths = (path for path in (Path(filepath),))
-    else:
-        git_project_root = git.find_git_project_root()
-        cfg_search_paths = [Path(".")]
-        if git_project_root:
-            cfg_search_paths.append(git_project_root)
-
-        cfg_paths = (
-            path / Path(filename)
-            for path in cfg_search_paths
-            for filename in defaults.CONFIG_FILES
-        )
-
-    for filename in cfg_paths:
-        if not filename.exists():
-            continue
-
-        _conf: TomlConfig | JsonConfig | YAMLConfig
-
+    for filename in _resolve_config_paths(filepath):
         with open(filename, "rb") as f:
             data: bytes = f.read()
 
-        if "toml" in filename.suffix:
-            _conf = TomlConfig(data=data, path=filename)
-        elif "json" in filename.suffix:
-            _conf = JsonConfig(data=data, path=filename)
-        elif "yaml" in filename.suffix:
-            _conf = YAMLConfig(data=data, path=filename)
+        conf = create_config(data=data, path=filename)
+        if not conf.is_empty_config:
+            return conf
 
-        if filepath is not None and _conf.is_empty_config:
+        if filepath is not None:
             raise ConfigFileIsEmpty()
-        elif _conf.is_empty_config:
-            continue
-        else:
-            conf = _conf
-            break
 
-    return conf
+    return BaseConfig()

--- a/commitizen/config/base_config.py
+++ b/commitizen/config/base_config.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 
 class BaseConfig:
     def __init__(self) -> None:
+        self.is_empty_config = False
         self._settings: Settings = DEFAULT_SETTINGS.copy()
-        self.encoding = self.settings["encoding"]
         self._path: Path | None = None
 
     @property
@@ -30,7 +30,7 @@ class BaseConfig:
         return self._path  # type: ignore[return-value]
 
     @path.setter
-    def path(self, path: str | Path) -> None:
+    def path(self, path: Path) -> None:
         self._path = Path(path)
 
     def set_key(self, key: str, value: Any) -> Self:
@@ -48,4 +48,8 @@ class BaseConfig:
         raise NotImplementedError()
 
     def init_empty_config_content(self) -> None:
+        """Create a config file with the empty config content.
+
+        The implementation is different for each config file type.
+        """
         raise NotImplementedError()

--- a/commitizen/config/factory.py
+++ b/commitizen/config/factory.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from commitizen.config.base_config import BaseConfig
+from commitizen.config.json_config import JsonConfig
+from commitizen.config.toml_config import TomlConfig
+from commitizen.config.yaml_config import YAMLConfig
+
+
+def create_config(*, data: bytes | str | None = None, path: Path) -> BaseConfig:
+    if "toml" in path.suffix:
+        return TomlConfig(data=data or "", path=path)
+    if "json" in path.suffix:
+        return JsonConfig(data=data or "{}", path=path)
+    if "yaml" in path.suffix:
+        return YAMLConfig(data=data or "", path=path)
+
+    # Should be unreachable. See the constant CONFIG_FILES.
+    raise ValueError(
+        f"Unsupported config file: {path.name} due to unknown file extension"
+    )

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -20,14 +20,15 @@ if TYPE_CHECKING:
 
 
 class JsonConfig(BaseConfig):
-    def __init__(self, *, data: bytes | str, path: Path | str) -> None:
+    def __init__(self, *, data: bytes | str, path: Path) -> None:
         super().__init__()
-        self.is_empty_config = False
         self.path = path
         self._parse_setting(data)
 
     def init_empty_config_content(self) -> None:
-        with smart_open(self.path, "a", encoding=self.encoding) as json_file:
+        with smart_open(
+            self.path, "a", encoding=self._settings["encoding"]
+        ) as json_file:
             json.dump({"commitizen": {}}, json_file)
 
     def set_key(self, key: str, value: Any) -> Self:
@@ -40,7 +41,7 @@ class JsonConfig(BaseConfig):
             parser = json.load(f)
 
         parser["commitizen"][key] = value
-        with smart_open(self.path, "w", encoding=self.encoding) as f:
+        with smart_open(self.path, "w", encoding=self._settings["encoding"]) as f:
             json.dump(parser, f, indent=2)
         return self
 

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -21,9 +21,8 @@ if TYPE_CHECKING:
 
 
 class TomlConfig(BaseConfig):
-    def __init__(self, *, data: bytes | str, path: Path | str) -> None:
+    def __init__(self, *, data: bytes | str, path: Path) -> None:
         super().__init__()
-        self.is_empty_config = False
         self.path = path
         self._parse_setting(data)
 
@@ -38,7 +37,9 @@ class TomlConfig(BaseConfig):
             if parser.get("tool") is None:
                 parser["tool"] = table()
             parser["tool"]["commitizen"] = table()  # type: ignore[index]
-            output_toml_file.write(parser.as_string().encode(self.encoding))
+            output_toml_file.write(
+                parser.as_string().encode(self._settings["encoding"])
+            )
 
     def set_key(self, key: str, value: Any) -> Self:
         """Set or update a key in the conf.
@@ -51,7 +52,7 @@ class TomlConfig(BaseConfig):
 
         parser["tool"]["commitizen"][key] = value  # type: ignore[index]
         with open(self.path, "wb") as f:
-            f.write(parser.as_string().encode(self.encoding))
+            f.write(parser.as_string().encode(self._settings["encoding"]))
         return self
 
     def _parse_setting(self, data: bytes | str) -> None:

--- a/commitizen/config/yaml_config.py
+++ b/commitizen/config/yaml_config.py
@@ -21,14 +21,15 @@ if TYPE_CHECKING:
 
 
 class YAMLConfig(BaseConfig):
-    def __init__(self, *, data: bytes | str, path: Path | str) -> None:
+    def __init__(self, *, data: bytes | str, path: Path) -> None:
         super().__init__()
-        self.is_empty_config = False
         self.path = path
         self._parse_setting(data)
 
     def init_empty_config_content(self) -> None:
-        with smart_open(self.path, "a", encoding=self.encoding) as json_file:
+        with smart_open(
+            self.path, "a", encoding=self._settings["encoding"]
+        ) as json_file:
             yaml.dump({"commitizen": {}}, json_file, explicit_start=True)
 
     def _parse_setting(self, data: bytes | str) -> None:
@@ -61,7 +62,9 @@ class YAMLConfig(BaseConfig):
             parser = yaml.load(yaml_file, Loader=yaml.FullLoader)
 
         parser["commitizen"][key] = value
-        with smart_open(self.path, "w", encoding=self.encoding) as yaml_file:
+        with smart_open(
+            self.path, "w", encoding=self._settings["encoding"]
+        ) as yaml_file:
             yaml.dump(parser, yaml_file, explicit_start=True)
 
         return self

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -3,7 +3,8 @@ import os
 import pytest
 
 from commitizen import defaults
-from commitizen.config import BaseConfig, JsonConfig
+from commitizen.config import BaseConfig
+from commitizen.config.json_config import JsonConfig
 
 
 @pytest.fixture()

--- a/tests/commands/test_init_command.py
+++ b/tests/commands/test_init_command.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -87,7 +88,7 @@ def test_init_without_setup_pre_commit_hook(
 
 def test_init_when_config_already_exists(config: BaseConfig, capsys):
     # Set config path
-    path = os.sep.join(["tests", "pyproject.toml"])
+    path = Path(os.sep.join(["tests", "pyproject.toml"]))
     config.path = path
 
     commands.Init(config)()

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -9,6 +9,9 @@ import pytest
 import yaml
 
 from commitizen import config, defaults, git
+from commitizen.config.json_config import JsonConfig
+from commitizen.config.toml_config import TomlConfig
+from commitizen.config.yaml_config import YAMLConfig
 from commitizen.exceptions import ConfigFileIsEmpty, InvalidConfigurationError
 
 PYPROJECT = """
@@ -211,7 +214,7 @@ class TestReadCfg:
             _not_root_path.write(JSON_STR)
 
             cfg = config.read_cfg(filepath="./not_in_root/.cz.json")
-            json_cfg_by_class = config.JsonConfig(data=JSON_STR, path=_not_root_path)
+            json_cfg_by_class = JsonConfig(data=JSON_STR, path=_not_root_path)
             assert cfg.settings == json_cfg_by_class.settings
 
     def test_load_cz_yaml_not_from_config_argument(_, tmpdir):
@@ -220,7 +223,7 @@ class TestReadCfg:
             _not_root_path.write(YAML_STR)
 
             cfg = config.read_cfg(filepath="./not_in_root/.cz.yaml")
-            yaml_cfg_by_class = config.YAMLConfig(data=YAML_STR, path=_not_root_path)
+            yaml_cfg_by_class = YAMLConfig(data=YAML_STR, path=_not_root_path)
             assert cfg.settings == yaml_cfg_by_class._settings
 
     def test_load_empty_pyproject_toml_from_config_argument(_, tmpdir):
@@ -244,7 +247,7 @@ class TestReadCfg:
 class TestTomlConfig:
     def test_init_empty_config_content(self, tmpdir, config_file, exception_string):
         path = tmpdir.mkdir("commitizen").join(config_file)
-        toml_config = config.TomlConfig(data="", path=path)
+        toml_config = TomlConfig(data="", path=path)
         toml_config.init_empty_config_content()
 
         with open(path, encoding="utf-8") as toml_file:
@@ -257,7 +260,7 @@ class TestTomlConfig:
 
         path = tmpdir.mkdir("commitizen").join(config_file)
         path.write(existing_content)
-        toml_config = config.TomlConfig(data="", path=path)
+        toml_config = TomlConfig(data="", path=path)
         toml_config.init_empty_config_content()
 
         with open(path, encoding="utf-8") as toml_file:
@@ -270,7 +273,7 @@ class TestTomlConfig:
         path = tmpdir.mkdir("commitizen").join(config_file)
 
         with pytest.raises(InvalidConfigurationError, match=exception_string):
-            config.TomlConfig(data=existing_content, path=path)
+            TomlConfig(data=existing_content, path=path)
 
 
 @pytest.mark.parametrize(
@@ -284,7 +287,7 @@ class TestTomlConfig:
 class TestJsonConfig:
     def test_init_empty_config_content(self, tmpdir, config_file, exception_string):
         path = tmpdir.mkdir("commitizen").join(config_file)
-        json_config = config.JsonConfig(data="{}", path=path)
+        json_config = JsonConfig(data="{}", path=path)
         json_config.init_empty_config_content()
 
         with open(path, encoding="utf-8") as json_file:
@@ -297,7 +300,7 @@ class TestJsonConfig:
         path = tmpdir.mkdir("commitizen").join(config_file)
 
         with pytest.raises(InvalidConfigurationError, match=exception_string):
-            config.JsonConfig(data=existing_content, path=path)
+            JsonConfig(data=existing_content, path=path)
 
 
 @pytest.mark.parametrize(
@@ -311,7 +314,7 @@ class TestJsonConfig:
 class TestYamlConfig:
     def test_init_empty_config_content(self, tmpdir, config_file, exception_string):
         path = tmpdir.mkdir("commitizen").join(config_file)
-        yaml_config = config.YAMLConfig(data="{}", path=path)
+        yaml_config = YAMLConfig(data="{}", path=path)
         yaml_config.init_empty_config_content()
 
         with open(path) as yaml_file:
@@ -322,4 +325,4 @@ class TestYamlConfig:
         path = tmpdir.mkdir("commitizen").join(config_file)
 
         with pytest.raises(InvalidConfigurationError, match=exception_string):
-            config.YAMLConfig(data=existing_content, path=path)
+            YAMLConfig(data=existing_content, path=path)

--- a/tests/test_cz_customize.py
+++ b/tests/test_cz_customize.py
@@ -1,6 +1,11 @@
+from pathlib import Path
+
 import pytest
 
-from commitizen.config import BaseConfig, JsonConfig, TomlConfig, YAMLConfig
+from commitizen.config import BaseConfig
+from commitizen.config.json_config import JsonConfig
+from commitizen.config.toml_config import TomlConfig
+from commitizen.config.yaml_config import YAMLConfig
 from commitizen.cz.customize import CustomizeCommitsCz
 from commitizen.exceptions import MissingCzCustomizeConfigError
 
@@ -319,8 +324,8 @@ commitizen:
 
 @pytest.fixture(
     params=[
-        TomlConfig(data=TOML_STR, path="not_exist.toml"),
-        JsonConfig(data=JSON_STR, path="not_exist.json"),
+        TomlConfig(data=TOML_STR, path=Path("not_exist.toml")),
+        JsonConfig(data=JSON_STR, path=Path("not_exist.json")),
     ]
 )
 def config(request):
@@ -334,9 +339,9 @@ def config(request):
 
 @pytest.fixture(
     params=[
-        TomlConfig(data=TOML_STR_INFO_PATH, path="not_exist.toml"),
-        JsonConfig(data=JSON_STR_INFO_PATH, path="not_exist.json"),
-        YAMLConfig(data=YAML_STR_INFO_PATH, path="not_exist.yaml"),
+        TomlConfig(data=TOML_STR_INFO_PATH, path=Path("not_exist.toml")),
+        JsonConfig(data=JSON_STR_INFO_PATH, path=Path("not_exist.json")),
+        YAMLConfig(data=YAML_STR_INFO_PATH, path=Path("not_exist.yaml")),
     ]
 )
 def config_info(request):
@@ -345,9 +350,9 @@ def config_info(request):
 
 @pytest.fixture(
     params=[
-        TomlConfig(data=TOML_STR_WITHOUT_INFO, path="not_exist.toml"),
-        JsonConfig(data=JSON_STR_WITHOUT_PATH, path="not_exist.json"),
-        YAMLConfig(data=YAML_STR_WITHOUT_PATH, path="not_exist.yaml"),
+        TomlConfig(data=TOML_STR_WITHOUT_INFO, path=Path("not_exist.toml")),
+        JsonConfig(data=JSON_STR_WITHOUT_PATH, path=Path("not_exist.json")),
+        YAMLConfig(data=YAML_STR_WITHOUT_PATH, path=Path("not_exist.yaml")),
     ]
 )
 def config_without_info(request):
@@ -356,8 +361,8 @@ def config_without_info(request):
 
 @pytest.fixture(
     params=[
-        TomlConfig(data=TOML_WITH_UNICODE, path="not_exist.toml"),
-        JsonConfig(data=JSON_WITH_UNICODE, path="not_exist.json"),
+        TomlConfig(data=TOML_WITH_UNICODE, path=Path("not_exist.toml")),
+        JsonConfig(data=JSON_WITH_UNICODE, path=Path("not_exist.json")),
     ]
 )
 def config_with_unicode(request):

--- a/tests/test_cz_search_filter.py
+++ b/tests/test_cz_search_filter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from commitizen.config import TomlConfig
+from commitizen.config.toml_config import TomlConfig
 from commitizen.cz.customize import CustomizeCommitsCz
 
 TOML_WITH_SEARCH_FILTER = r"""


### PR DESCRIPTION


<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [ ] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `poetry all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes

- [ ] Run `poetry doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external) in the documentation

> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
