### PR TITLE
refactor(BaseCommitizen): construct Style object directly to get rid …

### DIFF
--- a/commitizen/cz/base.py
+++ b/commitizen/cz/base.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Mapping
 from typing import Any, Callable, Protocol
 
 from jinja2 import BaseLoader, PackageLoader
-from prompt_toolkit.styles import Style, merge_styles
+from prompt_toolkit.styles import Style
 
 from commitizen import git
 from commitizen.config.base_config import BaseConfig
@@ -77,12 +77,12 @@ class BaseCommitizen(metaclass=ABCMeta):
 
     @property
     def style(self) -> Style:
-        return merge_styles(
+        return Style(
             [
-                Style(BaseCommitizen.default_style_config),
-                Style(self.config.settings["style"]),
+                *BaseCommitizen.default_style_config,
+                *self.config.settings["style"],
             ]
-        )  # type: ignore[return-value]
+        )
 
     def example(self) -> str:
         """Example of the commit message."""


### PR DESCRIPTION
…of potential type error

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

Remove the use of `merge_styles`.

## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->

See the implementation of `_MergedStyle` here. They are equivalent.

https://github.com/prompt-toolkit/python-prompt-toolkit/blob/d8adbe9bfcf5f7e95b015d8ab12e2985b9a7822b/src/prompt_toolkit/styles/style.py#L365
