### PR TITLE
refactor(BaseFormat): merge ChangelogFormat into BaseFormat

### DIFF
--- a/commitizen/changelog_formats/restructuredtext.py
+++ b/commitizen/changelog_formats/restructuredtext.py
@@ -5,6 +5,7 @@ from itertools import zip_longest
 from typing import IO, TYPE_CHECKING, Any, Union
 
 from commitizen.changelog import Metadata
+from commitizen.tags import VersionTag
 
 from .base import BaseFormat
 
@@ -90,3 +91,9 @@ class RestructuredText(BaseFormat):
             and not second.isalnum()
             and all(char == second[0] for char in second[1:])
         )
+
+    def parse_version_from_title(self, line: str) -> VersionTag | None:
+        raise NotImplementedError("parse_version_from_title is not implemented")
+
+    def parse_title_level(self, line: str) -> int | None:
+        raise NotImplementedError("parse_title_level is not implemented")

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -13,7 +13,7 @@ from pytest_mock import MockFixture
 
 import commitizen.commands.bump as bump
 from commitizen import cli, cmd, defaults, git, hooks
-from commitizen.changelog_formats import ChangelogFormat
+from commitizen.changelog_formats import BaseFormat
 from commitizen.config.base_config import BaseConfig
 from commitizen.cz.base import BaseCommitizen
 from commitizen.exceptions import (
@@ -1289,7 +1289,7 @@ def test_bump_command_version_scheme_priority_over_version_type(mocker: MockFixt
 def test_bump_template_option_precedence(
     mocker: MockFixture,
     tmp_commitizen_project: Path,
-    any_changelog_format: ChangelogFormat,
+    any_changelog_format: BaseFormat,
     arg: str,
     cfg: str,
     expected: str,
@@ -1331,7 +1331,7 @@ def test_bump_template_option_precedence(
 def test_bump_template_extras_precedence(
     mocker: MockFixture,
     tmp_commitizen_project: Path,
-    any_changelog_format: ChangelogFormat,
+    any_changelog_format: BaseFormat,
     mock_plugin: BaseCommitizen,
 ):
     project_root = Path(tmp_commitizen_project)
@@ -1376,7 +1376,7 @@ def test_bump_template_extras_precedence(
 def test_bump_template_extra_quotes(
     mocker: MockFixture,
     tmp_commitizen_project: Path,
-    any_changelog_format: ChangelogFormat,
+    any_changelog_format: BaseFormat,
 ):
     project_root = Path(tmp_commitizen_project)
     changelog_tpl = project_root / any_changelog_format.template

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -12,7 +12,7 @@ from pytest_regressions.file_regression import FileRegressionFixture
 
 from commitizen import __file__ as commitizen_init
 from commitizen import cli, git
-from commitizen.changelog_formats import ChangelogFormat
+from commitizen.changelog_formats import BaseFormat
 from commitizen.commands.changelog import Changelog
 from commitizen.config.base_config import BaseConfig
 from commitizen.cz.base import BaseCommitizen
@@ -77,7 +77,7 @@ def test_changelog_with_different_cz(mocker: MockFixture, capsys, file_regressio
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
 def test_changelog_from_start(
-    mocker: MockFixture, capsys, changelog_format: ChangelogFormat, file_regression
+    mocker: MockFixture, capsys, changelog_format: BaseFormat, file_regression
 ):
     create_file_and_commit("feat: new file")
     create_file_and_commit("refactor: is in changelog")
@@ -103,7 +103,7 @@ def test_changelog_from_start(
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
 def test_changelog_replacing_unreleased_using_incremental(
-    mocker: MockFixture, capsys, changelog_format: ChangelogFormat, file_regression
+    mocker: MockFixture, capsys, changelog_format: BaseFormat, file_regression
 ):
     create_file_and_commit("feat: add new output")
     create_file_and_commit("fix: output glitch")
@@ -1484,7 +1484,7 @@ def test_changelog_from_current_version_tag_with_nonversion_tag(
 def test_changelog_template_option_precedence(
     mocker: MockFixture,
     tmp_commitizen_project: Path,
-    any_changelog_format: ChangelogFormat,
+    any_changelog_format: BaseFormat,
     arg: str,
     cfg: str,
     expected: str,
@@ -1527,7 +1527,7 @@ def test_changelog_template_extras_precedence(
     mocker: MockFixture,
     tmp_commitizen_project: Path,
     mock_plugin: BaseCommitizen,
-    any_changelog_format: ChangelogFormat,
+    any_changelog_format: BaseFormat,
 ):
     project_root = Path(tmp_commitizen_project)
     changelog_tpl = project_root / any_changelog_format.template
@@ -1800,7 +1800,7 @@ def test_changelog_ignored_tags(
 def test_changelog_template_extra_quotes(
     mocker: MockFixture,
     tmp_commitizen_project: Path,
-    any_changelog_format: ChangelogFormat,
+    any_changelog_format: BaseFormat,
 ):
     project_root = Path(tmp_commitizen_project)
     changelog_tpl = project_root / any_changelog_format.template
@@ -1836,7 +1836,7 @@ def test_changelog_template_extra_quotes(
 def test_changelog_template_extra_weird_but_valid(
     mocker: MockFixture,
     tmp_commitizen_project: Path,
-    any_changelog_format: ChangelogFormat,
+    any_changelog_format: BaseFormat,
     extra: str,
     expected,
 ):
@@ -1858,7 +1858,7 @@ def test_changelog_template_extra_weird_but_valid(
 def test_changelog_template_extra_bad_format(
     mocker: MockFixture,
     tmp_commitizen_project: Path,
-    any_changelog_format: ChangelogFormat,
+    any_changelog_format: BaseFormat,
     extra: str,
 ):
     project_root = Path(tmp_commitizen_project)
@@ -1876,7 +1876,7 @@ def test_changelog_template_extra_bad_format(
 def test_export_changelog_template_from_default(
     mocker: MockFixture,
     tmp_commitizen_project: Path,
-    any_changelog_format: ChangelogFormat,
+    any_changelog_format: BaseFormat,
 ):
     project_root = Path(tmp_commitizen_project)
     target = project_root / "changelog.jinja"
@@ -1895,7 +1895,7 @@ def test_export_changelog_template_from_plugin(
     mocker: MockFixture,
     tmp_commitizen_project: Path,
     mock_plugin: BaseCommitizen,
-    changelog_format: ChangelogFormat,
+    changelog_format: BaseFormat,
     tmp_path: Path,
 ):
     project_root = Path(tmp_commitizen_project)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from pytest_mock import MockerFixture
 
 from commitizen import cmd, defaults
 from commitizen.changelog_formats import (
-    ChangelogFormat,
+    BaseFormat,
     get_changelog_format,
 )
 from commitizen.config import BaseConfig
@@ -265,9 +265,7 @@ SUPPORTED_FORMATS = ("markdown", "textile", "asciidoc", "restructuredtext")
 
 
 @pytest.fixture(params=SUPPORTED_FORMATS)
-def changelog_format(
-    config: BaseConfig, request: pytest.FixtureRequest
-) -> ChangelogFormat:
+def changelog_format(config: BaseConfig, request: pytest.FixtureRequest) -> BaseFormat:
     """For tests relying on formats specifics"""
     format: str = request.param
     config.settings["changelog_format"] = format
@@ -279,7 +277,7 @@ def changelog_format(
 
 
 @pytest.fixture
-def any_changelog_format(config: BaseConfig) -> ChangelogFormat:
+def any_changelog_format(config: BaseConfig) -> BaseFormat:
     """For test not relying on formats specifics, use the default"""
     config.settings["changelog_format"] = defaults.CHANGELOG_FORMAT
     return get_changelog_format(config)

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -11,7 +11,7 @@ import pytest
 from jinja2 import FileSystemLoader
 
 from commitizen import changelog, git
-from commitizen.changelog_formats import ChangelogFormat
+from commitizen.changelog_formats import BaseFormat
 from commitizen.commands.changelog import Changelog
 from commitizen.config import BaseConfig
 from commitizen.cz.conventional_commits.conventional_commits import (
@@ -1240,7 +1240,7 @@ def test_generate_ordered_changelog_tree_raises():
 
 
 def test_render_changelog(
-    gitcommits, tags, changelog_content, any_changelog_format: ChangelogFormat
+    gitcommits, tags, changelog_content, any_changelog_format: BaseFormat
 ):
     parser = ConventionalCommitsCz.commit_parser
     changelog_pattern = ConventionalCommitsCz.changelog_pattern
@@ -1254,7 +1254,7 @@ def test_render_changelog(
 
 
 def test_render_changelog_from_default_plugin_values(
-    gitcommits, tags, changelog_content, any_changelog_format: ChangelogFormat
+    gitcommits, tags, changelog_content, any_changelog_format: BaseFormat
 ):
     parser = ConventionalCommitsCz.commit_parser
     changelog_pattern = ConventionalCommitsCz.changelog_pattern
@@ -1282,7 +1282,7 @@ def test_render_changelog_override_loader(gitcommits, tags, tmp_path: Path):
 
 
 def test_render_changelog_override_template_from_cwd(
-    gitcommits, tags, chdir: Path, any_changelog_format: ChangelogFormat
+    gitcommits, tags, chdir: Path, any_changelog_format: BaseFormat
 ):
     tpl = "overridden from cwd"
     template = any_changelog_format.template
@@ -1342,7 +1342,7 @@ def test_render_changelog_support_arbitrary_kwargs(gitcommits, tags, tmp_path: P
     assert result == "value"
 
 
-def test_render_changelog_unreleased(gitcommits, any_changelog_format: ChangelogFormat):
+def test_render_changelog_unreleased(gitcommits, any_changelog_format: BaseFormat):
     some_commits = gitcommits[:7]
     parser = ConventionalCommitsCz.commit_parser
     changelog_pattern = ConventionalCommitsCz.changelog_pattern
@@ -1356,7 +1356,7 @@ def test_render_changelog_unreleased(gitcommits, any_changelog_format: Changelog
 
 
 def test_render_changelog_tag_and_unreleased(
-    gitcommits, tags, any_changelog_format: ChangelogFormat
+    gitcommits, tags, any_changelog_format: BaseFormat
 ):
     some_commits = gitcommits[:7]
     single_tag = [
@@ -1377,7 +1377,7 @@ def test_render_changelog_tag_and_unreleased(
 
 
 def test_render_changelog_with_change_type(
-    gitcommits, tags, any_changelog_format: ChangelogFormat
+    gitcommits, tags, any_changelog_format: BaseFormat
 ):
     new_title = ":some-emoji: feature"
     change_type_map = {"feat": new_title}
@@ -1393,7 +1393,7 @@ def test_render_changelog_with_change_type(
 
 
 def test_render_changelog_with_changelog_message_builder_hook(
-    gitcommits, tags, any_changelog_format: ChangelogFormat
+    gitcommits, tags, any_changelog_format: BaseFormat
 ):
     def changelog_message_builder_hook(message: dict, commit: git.GitCommit) -> dict:
         message["message"] = (
@@ -1418,7 +1418,7 @@ def test_render_changelog_with_changelog_message_builder_hook(
 
 
 def test_changelog_message_builder_hook_can_remove_commits(
-    gitcommits, tags, any_changelog_format: ChangelogFormat
+    gitcommits, tags, any_changelog_format: BaseFormat
 ):
     def changelog_message_builder_hook(message: dict, commit: git.GitCommit):
         return None
@@ -1444,7 +1444,7 @@ def test_changelog_message_builder_hook_can_remove_commits(
 
 
 def test_render_changelog_with_changelog_message_builder_hook_multiple_entries(
-    gitcommits, tags, any_changelog_format: ChangelogFormat
+    gitcommits, tags, any_changelog_format: BaseFormat
 ):
     def changelog_message_builder_hook(message: dict, commit: git.GitCommit):
         messages = [message.copy(), message.copy(), message.copy()]
@@ -1470,7 +1470,7 @@ def test_render_changelog_with_changelog_message_builder_hook_multiple_entries(
 
 
 def test_changelog_message_builder_hook_can_access_and_modify_change_type(
-    gitcommits, tags, any_changelog_format: ChangelogFormat
+    gitcommits, tags, any_changelog_format: BaseFormat
 ):
     def changelog_message_builder_hook(message: dict, commit: git.GitCommit):
         assert "change_type" in message
@@ -1501,7 +1501,7 @@ def test_changelog_message_builder_hook_can_access_and_modify_change_type(
 
 
 def test_render_changelog_with_changelog_release_hook(
-    gitcommits, tags, any_changelog_format: ChangelogFormat
+    gitcommits, tags, any_changelog_format: BaseFormat
 ):
     def changelog_release_hook(release: dict, tag: git.GitTag | None) -> dict:
         release["extra"] = "whatever"

--- a/tests/test_changelog_formats.py
+++ b/tests/test_changelog_formats.py
@@ -5,7 +5,7 @@ import pytest
 from commitizen import defaults
 from commitizen.changelog_formats import (
     KNOWN_CHANGELOG_FORMATS,
-    ChangelogFormat,
+    BaseFormat,
     _guess_changelog_format,
     get_changelog_format,
 )
@@ -14,7 +14,7 @@ from commitizen.exceptions import ChangelogFormatUnknown
 
 
 @pytest.mark.parametrize("format", KNOWN_CHANGELOG_FORMATS.values())
-def test_guess_format(format: type[ChangelogFormat]):
+def test_guess_format(format: type[BaseFormat]):
     assert _guess_changelog_format(f"CHANGELOG.{format.extension}") is format
     for ext in format.alternative_extensions:
         assert _guess_changelog_format(f"CHANGELOG.{ext}") is format
@@ -32,7 +32,7 @@ def test_guess_format_unknown(filename: str):
         for name, format in KNOWN_CHANGELOG_FORMATS.items()
     ],
 )
-def test_get_format(config: BaseConfig, name: str, expected: type[ChangelogFormat]):
+def test_get_format(config: BaseConfig, name: str, expected: type[BaseFormat]):
     config.settings["changelog_format"] = name
     assert isinstance(get_changelog_format(config), expected)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

`BaseFormat` already looks like a base class for changelog format, but it has a parent class protocol `ChangelogFormat`. It is confusing to me.

Additionally, the protocol `ChangelogFormat` declares implementations of methods. I consider it confusing too.

This change addresses the unnecessary complexity and remove `ChangelogFormat` completely from the codebase. The alternative now is `BaseFormat`.

I am not sure if this is a breaking change. Please help to review.