### PR TITLE
test: rename the fixture config to mock_config for better code search

### DIFF
--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -7,7 +7,7 @@ from commitizen.config import BaseConfig, JsonConfig
 
 
 @pytest.fixture()
-def config():
+def mock_config():
     _config = BaseConfig()
     _config.settings.update({"name": defaults.DEFAULT_SETTINGS["name"]})
     return _config

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -608,7 +608,7 @@ def test_bump_dry_run(mocker: MockFixture, capsys):
     assert tag_exists is False
 
 
-def test_bump_in_non_git_project(tmpdir, config, mocker: MockFixture):
+def test_bump_in_non_git_project(tmpdir, mock_config, mocker: MockFixture):
     testargs = ["cz", "bump", "--yes"]
     mocker.patch.object(sys, "argv", testargs)
 

--- a/tests/commands/test_changelog_command.py
+++ b/tests/commands/test_changelog_command.py
@@ -279,7 +279,7 @@ def test_changelog_incremental_keep_a_changelog_sample(
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
 @pytest.mark.parametrize("dry_run", [True, False])
-def test_changelog_hook(mocker: MockFixture, config: BaseConfig, dry_run: bool):
+def test_changelog_hook(mocker: MockFixture, mock_config: BaseConfig, dry_run: bool):
     changelog_hook_mock = mocker.Mock()
     changelog_hook_mock.return_value = "cool changelog hook"
 
@@ -287,9 +287,10 @@ def test_changelog_hook(mocker: MockFixture, config: BaseConfig, dry_run: bool):
     create_file_and_commit("refactor: is in changelog")
     create_file_and_commit("Merge into master")
 
-    config.settings["change_type_order"] = ["Refactor", "Feat"]  # type: ignore[typeddict-unknown-key]
+    mock_config.settings["change_type_order"] = ["Refactor", "Feat"]  # type: ignore[typeddict-unknown-key]
     changelog = Changelog(
-        config, {"unreleased_version": None, "incremental": True, "dry_run": dry_run}
+        mock_config,
+        {"unreleased_version": None, "incremental": True, "dry_run": dry_run},
     )
     mocker.patch.object(changelog.cz, "changelog_hook", changelog_hook_mock)
     try:
@@ -330,7 +331,7 @@ def test_changelog_hook_customize(mocker: MockFixture, config_customize):
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
-def test_changelog_release_hook(mocker: MockFixture, config):
+def test_changelog_release_hook(mocker: MockFixture, mock_config):
     def changelog_release_hook(release: dict, tag: git.GitTag) -> dict:
         return release
 
@@ -340,9 +341,9 @@ def test_changelog_release_hook(mocker: MockFixture, config):
         create_file_and_commit("Merge into master")
         git.tag(f"0.{i + 1}.0")
 
-    # changelog = Changelog(config, {})
+    # changelog = Changelog(mock_config, {})
     changelog = Changelog(
-        config, {"unreleased_version": None, "incremental": True, "dry_run": False}
+        mock_config, {"unreleased_version": None, "incremental": True, "dry_run": False}
     )
     mocker.patch.object(changelog.cz, "changelog_release_hook", changelog_release_hook)
     spy = mocker.spy(changelog.cz, "changelog_release_hook")
@@ -529,7 +530,7 @@ def test_changelog_with_different_tag_name_and_changelog_content(
         cli.main()
 
 
-def test_changelog_in_non_git_project(tmpdir, config, mocker: MockFixture):
+def test_changelog_in_non_git_project(tmpdir, mock_config, mocker: MockFixture):
     testargs = ["cz", "changelog", "--incremental"]
     mocker.patch.object(sys, "argv", testargs)
 
@@ -1382,7 +1383,7 @@ def test_changelog_prerelease_rev_with_use_scheme_semver(
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
-def test_changelog_uses_version_tags_for_header(mocker: MockFixture, config):
+def test_changelog_uses_version_tags_for_header(mocker: MockFixture, mock_config):
     """Tests that changelog headers always use version tags even if there are non-version tags
 
     This tests a scenario fixed in this commit:
@@ -1396,7 +1397,7 @@ def test_changelog_uses_version_tags_for_header(mocker: MockFixture, config):
     write_patch = mocker.patch("commitizen.commands.changelog.out.write")
 
     changelog = Changelog(
-        config, {"dry_run": True, "incremental": True, "unreleased_version": None}
+        mock_config, {"dry_run": True, "incremental": True, "unreleased_version": None}
     )
 
     with pytest.raises(DryRunExit):
@@ -1411,7 +1412,7 @@ def test_changelog_uses_version_tags_for_header(mocker: MockFixture, config):
 
 @pytest.mark.usefixtures("tmp_commitizen_project")
 def test_changelog_from_current_version_tag_with_nonversion_tag(
-    mocker: MockFixture, config
+    mocker: MockFixture, mock_config
 ):
     """Tests that changelog generation for a single version works even if
     there is a non-version tag in the list of tags
@@ -1450,7 +1451,7 @@ def test_changelog_from_current_version_tag_with_nonversion_tag(
     write_patch = mocker.patch("commitizen.commands.changelog.out.write")
 
     changelog = Changelog(
-        config,
+        mock_config,
         {
             "dry_run": True,
             "incremental": False,

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -36,7 +36,7 @@ def backup_file(tmp_git_project):
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit(config, mocker: MockFixture):
+def test_commit(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -51,12 +51,12 @@ def test_commit(config, mocker: MockFixture):
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    commands.Commit(config, {})()
+    commands.Commit(mock_config, {})()
     success_mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_backup_on_failure(config, mocker: MockFixture):
+def test_commit_backup_on_failure(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -72,7 +72,7 @@ def test_commit_backup_on_failure(config, mocker: MockFixture):
     error_mock = mocker.patch("commitizen.out.error")
 
     with pytest.raises(CommitError):
-        commit_cmd = commands.Commit(config, {})
+        commit_cmd = commands.Commit(mock_config, {})
         temp_file = commit_cmd.temp_file
         commit_cmd()
 
@@ -82,25 +82,25 @@ def test_commit_backup_on_failure(config, mocker: MockFixture):
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_retry_fails_no_backup(config, mocker: MockFixture):
+def test_commit_retry_fails_no_backup(mock_config, mocker: MockFixture):
     commit_mock = mocker.patch("commitizen.git.commit")
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
 
     with pytest.raises(NoCommitBackupError) as excinfo:
-        commands.Commit(config, {"retry": True})()
+        commands.Commit(mock_config, {"retry": True})()
 
     assert NoCommitBackupError.message in str(excinfo.value)
 
 
 @pytest.mark.usefixtures("staging_is_clean", "backup_file")
-def test_commit_retry_works(config, mocker: MockFixture):
+def test_commit_retry_works(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
 
     commit_mock = mocker.patch("commitizen.git.commit")
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    commit_cmd = commands.Commit(config, {"retry": True})
+    commit_cmd = commands.Commit(mock_config, {"retry": True})
     temp_file = commit_cmd.temp_file
     commit_cmd()
 
@@ -111,7 +111,7 @@ def test_commit_retry_works(config, mocker: MockFixture):
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_retry_after_failure_no_backup(config, mocker: MockFixture):
+def test_commit_retry_after_failure_no_backup(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -126,8 +126,8 @@ def test_commit_retry_after_failure_no_backup(config, mocker: MockFixture):
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    config.settings["retry_after_failure"] = True
-    commands.Commit(config, {})()
+    mock_config.settings["retry_after_failure"] = True
+    commands.Commit(mock_config, {})()
 
     commit_mock.assert_called_with("feat: user created\n\ncloses #21", args="")
     prompt_mock.assert_called_once()
@@ -135,15 +135,15 @@ def test_commit_retry_after_failure_no_backup(config, mocker: MockFixture):
 
 
 @pytest.mark.usefixtures("staging_is_clean", "backup_file")
-def test_commit_retry_after_failure_works(config, mocker: MockFixture):
+def test_commit_retry_after_failure_works(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
 
     commit_mock = mocker.patch("commitizen.git.commit")
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    config.settings["retry_after_failure"] = True
-    commit_cmd = commands.Commit(config, {})
+    mock_config.settings["retry_after_failure"] = True
+    commit_cmd = commands.Commit(mock_config, {})
     temp_file = commit_cmd.temp_file
     commit_cmd()
 
@@ -154,7 +154,9 @@ def test_commit_retry_after_failure_works(config, mocker: MockFixture):
 
 
 @pytest.mark.usefixtures("staging_is_clean", "backup_file")
-def test_commit_retry_after_failure_with_no_retry_works(config, mocker: MockFixture):
+def test_commit_retry_after_failure_with_no_retry_works(
+    mock_config, mocker: MockFixture
+):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -169,8 +171,8 @@ def test_commit_retry_after_failure_with_no_retry_works(config, mocker: MockFixt
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    config.settings["retry_after_failure"] = True
-    commit_cmd = commands.Commit(config, {"no_retry": True})
+    mock_config.settings["retry_after_failure"] = True
+    commit_cmd = commands.Commit(mock_config, {"no_retry": True})
     temp_file = commit_cmd.temp_file
     commit_cmd()
 
@@ -181,7 +183,7 @@ def test_commit_retry_after_failure_with_no_retry_works(config, mocker: MockFixt
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_with_dry_run_option(config, mocker: MockFixture):
+def test_commit_command_with_dry_run_option(mock_config, mocker: MockFixture):
     prompt_mock = mocker = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -193,13 +195,13 @@ def test_commit_command_with_dry_run_option(config, mocker: MockFixture):
     }
 
     with pytest.raises(DryRunExit):
-        commit_cmd = commands.Commit(config, {"dry_run": True})
+        commit_cmd = commands.Commit(mock_config, {"dry_run": True})
         commit_cmd()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
 def test_commit_command_with_write_message_to_file_option(
-    config, tmp_path, mocker: MockFixture
+    mock_config, tmp_path, mocker: MockFixture
 ):
     tmp_file = tmp_path / "message"
 
@@ -217,7 +219,7 @@ def test_commit_command_with_write_message_to_file_option(
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    commands.Commit(config, {"write_message_to_file": tmp_file})()
+    commands.Commit(mock_config, {"write_message_to_file": tmp_file})()
     success_mock.assert_called_once()
     assert tmp_file.exists()
     assert tmp_file.read_text() == "feat: user created"
@@ -225,7 +227,7 @@ def test_commit_command_with_write_message_to_file_option(
 
 @pytest.mark.usefixtures("staging_is_clean")
 def test_commit_command_with_invalid_write_message_to_file_option(
-    config, tmp_path, mocker: MockFixture
+    mock_config, tmp_path, mocker: MockFixture
 ):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
@@ -238,12 +240,12 @@ def test_commit_command_with_invalid_write_message_to_file_option(
     }
 
     with pytest.raises(NotAllowed):
-        commit_cmd = commands.Commit(config, {"write_message_to_file": tmp_path})
+        commit_cmd = commands.Commit(mock_config, {"write_message_to_file": tmp_path})
         commit_cmd()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_with_signoff_option(config, mocker: MockFixture):
+def test_commit_command_with_signoff_option(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -258,14 +260,14 @@ def test_commit_command_with_signoff_option(config, mocker: MockFixture):
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    commands.Commit(config, {"signoff": True})()
+    commands.Commit(mock_config, {"signoff": True})()
 
     commit_mock.assert_called_once_with(ANY, args="-s")
     success_mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_with_always_signoff_enabled(config, mocker: MockFixture):
+def test_commit_command_with_always_signoff_enabled(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -280,8 +282,8 @@ def test_commit_command_with_always_signoff_enabled(config, mocker: MockFixture)
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    config.settings["always_signoff"] = True
-    commands.Commit(config, {})()
+    mock_config.settings["always_signoff"] = True
+    commands.Commit(mock_config, {})()
 
     commit_mock.assert_called_once_with(ANY, args="-s")
     success_mock.assert_called_once()
@@ -289,7 +291,7 @@ def test_commit_command_with_always_signoff_enabled(config, mocker: MockFixture)
 
 @pytest.mark.usefixtures("staging_is_clean")
 def test_commit_command_with_gpgsign_and_always_signoff_enabled(
-    config, mocker: MockFixture
+    mock_config, mocker: MockFixture
 ):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
@@ -305,27 +307,27 @@ def test_commit_command_with_gpgsign_and_always_signoff_enabled(
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    config.settings["always_signoff"] = True
-    commands.Commit(config, {"extra_cli_args": "-S"})()
+    mock_config.settings["always_signoff"] = True
+    commands.Commit(mock_config, {"extra_cli_args": "-S"})()
 
     commit_mock.assert_called_once_with(ANY, args="-S -s")
     success_mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("tmp_git_project")
-def test_commit_when_nothing_to_commit(config, mocker: MockFixture):
+def test_commit_when_nothing_to_commit(mock_config, mocker: MockFixture):
     is_staging_clean_mock = mocker.patch("commitizen.git.is_staging_clean")
     is_staging_clean_mock.return_value = True
 
     with pytest.raises(NothingToCommitError) as excinfo:
-        commit_cmd = commands.Commit(config, {})
+        commit_cmd = commands.Commit(mock_config, {})
         commit_cmd()
 
     assert "No files added to staging!" in str(excinfo.value)
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_with_allow_empty(config, mocker: MockFixture):
+def test_commit_with_allow_empty(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -340,7 +342,7 @@ def test_commit_with_allow_empty(config, mocker: MockFixture):
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    commands.Commit(config, {"extra_cli_args": "--allow-empty"})()
+    commands.Commit(mock_config, {"extra_cli_args": "--allow-empty"})()
 
     commit_mock.assert_called_with(
         "feat: user created\n\ncloses #21", args="--allow-empty"
@@ -349,7 +351,7 @@ def test_commit_with_allow_empty(config, mocker: MockFixture):
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_with_signoff_and_allow_empty(config, mocker: MockFixture):
+def test_commit_with_signoff_and_allow_empty(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -364,8 +366,8 @@ def test_commit_with_signoff_and_allow_empty(config, mocker: MockFixture):
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    config.settings["always_signoff"] = True
-    commands.Commit(config, {"extra_cli_args": "--allow-empty"})()
+    mock_config.settings["always_signoff"] = True
+    commands.Commit(mock_config, {"extra_cli_args": "--allow-empty"})()
 
     commit_mock.assert_called_with(
         "feat: user created\n\ncloses #21", args="--allow-empty -s"
@@ -374,14 +376,16 @@ def test_commit_with_signoff_and_allow_empty(config, mocker: MockFixture):
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_when_customized_expected_raised(config, mocker: MockFixture, capsys):
+def test_commit_when_customized_expected_raised(
+    mock_config, mocker: MockFixture, capsys
+):
     _err = ValueError()
     _err.__context__ = CzException("This is the root custom err")
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.side_effect = _err
 
     with pytest.raises(CustomError) as excinfo:
-        commit_cmd = commands.Commit(config, {})
+        commit_cmd = commands.Commit(mock_config, {})
         commit_cmd()
 
     # Assert only the content in the formatted text
@@ -390,35 +394,35 @@ def test_commit_when_customized_expected_raised(config, mocker: MockFixture, cap
 
 @pytest.mark.usefixtures("staging_is_clean")
 def test_commit_when_non_customized_expected_raised(
-    config, mocker: MockFixture, capsys
+    mock_config, mocker: MockFixture, capsys
 ):
     _err = ValueError()
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.side_effect = _err
 
     with pytest.raises(ValueError):
-        commit_cmd = commands.Commit(config, {})
+        commit_cmd = commands.Commit(mock_config, {})
         commit_cmd()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_when_no_user_answer(config, mocker: MockFixture, capsys):
+def test_commit_when_no_user_answer(mock_config, mocker: MockFixture, capsys):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = None
 
     with pytest.raises(NoAnswersError):
-        commit_cmd = commands.Commit(config, {})
+        commit_cmd = commands.Commit(mock_config, {})
         commit_cmd()
 
 
-def test_commit_in_non_git_project(tmpdir, config):
+def test_commit_in_non_git_project(tmpdir, mock_config):
     with tmpdir.as_cwd():
         with pytest.raises(NotAGitProjectError):
-            commands.Commit(config, {})
+            commands.Commit(mock_config, {})
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_with_all_option(config, mocker: MockFixture):
+def test_commit_command_with_all_option(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -433,13 +437,13 @@ def test_commit_command_with_all_option(config, mocker: MockFixture):
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
     add_mock = mocker.patch("commitizen.git.add")
-    commands.Commit(config, {"all": True})()
+    commands.Commit(mock_config, {"all": True})()
     add_mock.assert_called()
     success_mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_with_extra_args(config, mocker: MockFixture):
+def test_commit_command_with_extra_args(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -453,13 +457,13 @@ def test_commit_command_with_extra_args(config, mocker: MockFixture):
     commit_mock = mocker.patch("commitizen.git.commit")
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
-    commands.Commit(config, {"extra_cli_args": "-- -extra-args1 -extra-arg2"})()
+    commands.Commit(mock_config, {"extra_cli_args": "-- -extra-args1 -extra-arg2"})()
     commit_mock.assert_called_once_with(ANY, args="-- -extra-args1 -extra-arg2")
     success_mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_with_message_length_limit(config, mocker: MockFixture):
+def test_commit_command_with_message_length_limit(mock_config, mocker: MockFixture):
     prompt_mock = mocker.patch("questionary.prompt")
     prefix = "feat"
     subject = "random subject"
@@ -477,16 +481,16 @@ def test_commit_command_with_message_length_limit(config, mocker: MockFixture):
     commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
     success_mock = mocker.patch("commitizen.out.success")
 
-    commands.Commit(config, {"message_length_limit": message_length})()
+    commands.Commit(mock_config, {"message_length_limit": message_length})()
     success_mock.assert_called_once()
 
     with pytest.raises(CommitMessageLengthExceededError):
-        commands.Commit(config, {"message_length_limit": message_length - 1})()
+        commands.Commit(mock_config, {"message_length_limit": message_length - 1})()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
 @pytest.mark.parametrize("editor", ["vim", None])
-def test_manual_edit(editor, config, mocker: MockFixture, tmp_path):
+def test_manual_edit(editor, mock_config, mocker: MockFixture, tmp_path):
     mocker.patch("commitizen.git.get_core_editor", return_value=editor)
     subprocess_mock = mocker.patch("subprocess.call")
 
@@ -499,7 +503,7 @@ def test_manual_edit(editor, config, mocker: MockFixture, tmp_path):
     mock_temp_file = mocker.patch("tempfile.NamedTemporaryFile")
     mock_temp_file.return_value.__enter__.return_value.name = str(temp_file)
 
-    commit_cmd = commands.Commit(config, {"edit": True})
+    commit_cmd = commands.Commit(mock_config, {"edit": True})
 
     if editor is None:
         with pytest.raises(RuntimeError):
@@ -529,7 +533,7 @@ def test_commit_command_shows_description_when_use_help_option(
 @pytest.mark.parametrize(
     "out", ["no changes added to commit", "nothing added to commit"]
 )
-def test_commit_when_nothing_added_to_commit(config, mocker: MockFixture, out):
+def test_commit_when_nothing_added_to_commit(mock_config, mocker: MockFixture, out):
     prompt_mock = mocker.patch("questionary.prompt")
     prompt_mock.return_value = {
         "prefix": "feat",
@@ -550,7 +554,7 @@ def test_commit_when_nothing_added_to_commit(config, mocker: MockFixture, out):
     )
     error_mock = mocker.patch("commitizen.out.error")
 
-    commands.Commit(config, {})()
+    commands.Commit(mock_config, {})()
 
     commit_mock.assert_called_once()
     error_mock.assert_called_once_with(out)

--- a/tests/commands/test_example_command.py
+++ b/tests/commands/test_example_command.py
@@ -7,9 +7,9 @@ from commitizen import cli, commands
 from tests.utils import skip_below_py_3_10
 
 
-def test_example(config, mocker: MockerFixture):
+def test_example(mock_config, mocker: MockerFixture):
     write_mock = mocker.patch("commitizen.out.write")
-    commands.Example(config)()
+    commands.Example(mock_config)()
     write_mock.assert_called_once()
 
 

--- a/tests/commands/test_info_command.py
+++ b/tests/commands/test_info_command.py
@@ -7,9 +7,9 @@ from commitizen import cli, commands
 from tests.utils import skip_below_py_3_10
 
 
-def test_info(config, mocker: MockerFixture):
+def test_info(mock_config, mocker: MockerFixture):
     write_mock = mocker.patch("commitizen.out.write")
-    commands.Info(config)()
+    commands.Info(mock_config)()
     write_mock.assert_called_once()
 
 

--- a/tests/commands/test_ls_command.py
+++ b/tests/commands/test_ls_command.py
@@ -7,9 +7,9 @@ from commitizen import cli, commands
 from tests.utils import skip_below_py_3_10
 
 
-def test_list_cz(config, mocker: MockerFixture):
+def test_list_cz(mock_config, mocker: MockerFixture):
     write_mock = mocker.patch("commitizen.out.write")
-    commands.ListCz(config)()
+    commands.ListCz(mock_config)()
     write_mock.assert_called_once()
 
 

--- a/tests/commands/test_schema_command.py
+++ b/tests/commands/test_schema_command.py
@@ -7,9 +7,9 @@ from commitizen import cli, commands
 from tests.utils import skip_below_py_3_10
 
 
-def test_schema(config, mocker: MockerFixture):
+def test_schema(mock_config, mocker: MockerFixture):
     write_mock = mocker.patch("commitizen.out.write")
-    commands.Schema(config)()
+    commands.Schema(mock_config)()
     write_mock.assert_called_once()
 
 

--- a/tests/commands/test_version_command.py
+++ b/tests/commands/test_version_command.py
@@ -10,27 +10,27 @@ from commitizen.config.base_config import BaseConfig
 from tests.utils import skip_below_py_3_10
 
 
-def test_version_for_showing_project_version(config, capsys):
+def test_version_for_showing_project_version(mock_config, capsys):
     # No version exist
     commands.Version(
-        config,
+        mock_config,
         {"report": False, "project": True, "commitizen": False, "verbose": False},
     )()
     captured = capsys.readouterr()
     assert "No project information in this project." in captured.err
 
-    config.settings["version"] = "v0.0.1"
+    mock_config.settings["version"] = "v0.0.1"
     commands.Version(
-        config,
+        mock_config,
         {"report": False, "project": True, "commitizen": False, "verbose": False},
     )()
     captured = capsys.readouterr()
     assert "v0.0.1" in captured.out
 
 
-def test_version_for_showing_commitizen_version(config, capsys):
+def test_version_for_showing_commitizen_version(mock_config, capsys):
     commands.Version(
-        config,
+        mock_config,
         {"report": False, "project": False, "commitizen": True, "verbose": False},
     )()
     captured = capsys.readouterr()
@@ -38,25 +38,25 @@ def test_version_for_showing_commitizen_version(config, capsys):
 
     # default showing commitizen version
     commands.Version(
-        config,
+        mock_config,
         {"report": False, "project": False, "commitizen": False, "verbose": False},
     )()
     captured = capsys.readouterr()
     assert f"{__version__}" in captured.out
 
 
-def test_version_for_showing_both_versions(config, capsys):
+def test_version_for_showing_both_versions(mock_config, capsys):
     commands.Version(
-        config,
+        mock_config,
         {"report": False, "project": False, "commitizen": False, "verbose": True},
     )()
     captured = capsys.readouterr()
     assert f"Installed Commitizen Version: {__version__}" in captured.out
     assert "No project information in this project." in captured.err
 
-    config.settings["version"] = "v0.0.1"
+    mock_config.settings["version"] = "v0.0.1"
     commands.Version(
-        config,
+        mock_config,
         {"report": False, "project": False, "commitizen": False, "verbose": True},
     )()
     captured = capsys.readouterr()
@@ -66,9 +66,9 @@ def test_version_for_showing_both_versions(config, capsys):
     assert expected_out in captured.out
 
 
-def test_version_for_showing_commitizen_system_info(config, capsys):
+def test_version_for_showing_commitizen_system_info(mock_config, capsys):
     commands.Version(
-        config,
+        mock_config,
         {"report": True, "project": False, "commitizen": False, "verbose": False},
     )()
     captured = capsys.readouterr()
@@ -81,7 +81,7 @@ def test_version_for_showing_commitizen_system_info(config, capsys):
 @pytest.mark.usefixtures("tmp_git_project")
 def test_version_use_version_provider(
     mocker: MockerFixture,
-    config: BaseConfig,
+    mock_config: BaseConfig,
     capsys: pytest.CaptureFixture,
     project: bool,
 ):
@@ -93,7 +93,7 @@ def test_version_use_version_provider(
     )
 
     commands.Version(
-        config,
+        mock_config,
         {
             "report": False,
             "project": project,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,7 +136,7 @@ def tmp_commitizen_project_with_gpg(tmp_commitizen_project):
 
 
 @pytest.fixture()
-def config():
+def mock_config():
     _config = BaseConfig()
     _config.settings.update({"name": defaults.DEFAULT_SETTINGS["name"]})
     return _config
@@ -255,8 +255,8 @@ class MockPlugin(BaseCommitizen):
 
 
 @pytest.fixture
-def mock_plugin(mocker: MockerFixture, config: BaseConfig) -> BaseCommitizen:
-    mock = MockPlugin(config)
+def mock_plugin(mocker: MockerFixture, mock_config: BaseConfig) -> BaseCommitizen:
+    mock = MockPlugin(mock_config)
     mocker.patch("commitizen.factory.committer_factory", return_value=mock)
     return mock
 
@@ -266,20 +266,20 @@ SUPPORTED_FORMATS = ("markdown", "textile", "asciidoc", "restructuredtext")
 
 @pytest.fixture(params=SUPPORTED_FORMATS)
 def changelog_format(
-    config: BaseConfig, request: pytest.FixtureRequest
+    mock_config: BaseConfig, request: pytest.FixtureRequest
 ) -> ChangelogFormat:
     """For tests relying on formats specifics"""
     format: str = request.param
-    config.settings["changelog_format"] = format
+    mock_config.settings["changelog_format"] = format
     if "tmp_commitizen_project" in request.fixturenames:
         tmp_commitizen_project = request.getfixturevalue("tmp_commitizen_project")
         pyproject = tmp_commitizen_project / "pyproject.toml"
         pyproject.write(f'{pyproject.read()}\nchangelog_format = "{format}"\n')
-    return get_changelog_format(config)
+    return get_changelog_format(mock_config)
 
 
 @pytest.fixture
-def any_changelog_format(config: BaseConfig) -> ChangelogFormat:
+def any_changelog_format(mock_config: BaseConfig) -> ChangelogFormat:
     """For test not relying on formats specifics, use the default"""
-    config.settings["changelog_format"] = defaults.CHANGELOG_FORMAT
-    return get_changelog_format(config)
+    mock_config.settings["changelog_format"] = defaults.CHANGELOG_FORMAT
+    return get_changelog_format(mock_config)

--- a/tests/providers/test_base_provider.py
+++ b/tests/providers/test_base_provider.py
@@ -8,13 +8,13 @@ from commitizen.providers import get_provider
 from commitizen.providers.commitizen_provider import CommitizenProvider
 
 
-def test_default_version_provider_is_commitizen_config(config: BaseConfig):
-    provider = get_provider(config)
+def test_default_version_provider_is_commitizen_config(mock_config: BaseConfig):
+    provider = get_provider(mock_config)
 
     assert isinstance(provider, CommitizenProvider)
 
 
-def test_raise_for_unknown_provider(config: BaseConfig):
-    config.settings["version_provider"] = "unknown"
+def test_raise_for_unknown_provider(mock_config: BaseConfig):
+    mock_config.settings["version_provider"] = "unknown"
     with pytest.raises(VersionProviderUnknown):
-        get_provider(config)
+        get_provider(mock_config)

--- a/tests/providers/test_cargo_provider.py
+++ b/tests/providers/test_cargo_provider.py
@@ -233,7 +233,7 @@ dependencies = [
     ),
 )
 def test_cargo_provider(
-    config: BaseConfig,
+    mock_config: BaseConfig,
     chdir: Path,
     content: str,
     expected: str,
@@ -241,9 +241,9 @@ def test_cargo_provider(
     filename = CargoProvider.filename
     file = chdir / filename
     file.write_text(dedent(content))
-    config.settings["version_provider"] = "cargo"
+    mock_config.settings["version_provider"] = "cargo"
 
-    provider = get_provider(config)
+    provider = get_provider(mock_config)
     assert isinstance(provider, CargoProvider)
     assert provider.get_version() == "0.1.0"
 
@@ -269,7 +269,7 @@ def test_cargo_provider(
     ),
 )
 def test_cargo_provider_with_lock(
-    config: BaseConfig,
+    mock_config: BaseConfig,
     chdir: Path,
     toml_content: str,
     lock_content: str,
@@ -292,9 +292,9 @@ def test_cargo_provider_with_lock(
     lock_filename = CargoProvider.lock_filename
     lock_file = chdir / lock_filename
     lock_file.write_text(dedent(lock_content))
-    config.settings["version_provider"] = "cargo"
+    mock_config.settings["version_provider"] = "cargo"
 
-    provider = get_provider(config)
+    provider = get_provider(mock_config)
     assert isinstance(provider, CargoProvider)
     assert provider.get_version() == "0.1.0"
 

--- a/tests/providers/test_commitizen_provider.py
+++ b/tests/providers/test_commitizen_provider.py
@@ -9,11 +9,11 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-def test_commitizen_provider(config: BaseConfig, mocker: MockerFixture):
-    config.settings["version"] = "42"
-    mock = mocker.patch.object(config, "set_key")
+def test_commitizen_provider(mock_config: BaseConfig, mocker: MockerFixture):
+    mock_config.settings["version"] = "42"
+    mock = mocker.patch.object(mock_config, "set_key")
 
-    provider = CommitizenProvider(config)
+    provider = CommitizenProvider(mock_config)
     assert provider.get_version() == "42"
 
     provider.set_version("43.1")

--- a/tests/providers/test_composer_provider.py
+++ b/tests/providers/test_composer_provider.py
@@ -29,7 +29,7 @@ COMPOSER_EXPECTED = """\
     ((COMPOSER_JSON, COMPOSER_EXPECTED),),
 )
 def test_composer_provider(
-    config: BaseConfig,
+    mock_config: BaseConfig,
     chdir: Path,
     content: str,
     expected: str,
@@ -37,9 +37,9 @@ def test_composer_provider(
     filename = ComposerProvider.filename
     file = chdir / filename
     file.write_text(dedent(content))
-    config.settings["version_provider"] = "composer"
+    mock_config.settings["version_provider"] = "composer"
 
-    provider = get_provider(config)
+    provider = get_provider(mock_config)
     assert isinstance(provider, ComposerProvider)
     assert provider.get_version() == "0.1.0"
 

--- a/tests/providers/test_npm_provider.py
+++ b/tests/providers/test_npm_provider.py
@@ -69,7 +69,7 @@ NPM_LOCKFILE_EXPECTED = """\
     ((NPM_LOCKFILE_JSON, NPM_LOCKFILE_EXPECTED), (None, None)),
 )
 def test_npm_provider(
-    config: BaseConfig,
+    mock_config: BaseConfig,
     chdir: Path,
     pkg_lock_content: str,
     pkg_lock_expected: str,
@@ -84,9 +84,9 @@ def test_npm_provider(
     if pkg_shrinkwrap_content:
         pkg_shrinkwrap = chdir / NpmProvider.shrinkwrap_filename
         pkg_shrinkwrap.write_text(dedent(pkg_shrinkwrap_content))
-    config.settings["version_provider"] = "npm"
+    mock_config.settings["version_provider"] = "npm"
 
-    provider = get_provider(config)
+    provider = get_provider(mock_config)
     assert isinstance(provider, NpmProvider)
     assert provider.get_version() == "0.1.0"
 

--- a/tests/providers/test_pep621_provider.py
+++ b/tests/providers/test_pep621_provider.py
@@ -25,7 +25,7 @@ version = "42.1"
     ((PEP621_TOML, PEP621_EXPECTED),),
 )
 def test_cargo_provider(
-    config: BaseConfig,
+    mock_config: BaseConfig,
     chdir: Path,
     content: str,
     expected: str,
@@ -33,9 +33,9 @@ def test_cargo_provider(
     filename = Pep621Provider.filename
     file = chdir / filename
     file.write_text(dedent(content))
-    config.settings["version_provider"] = "pep621"
+    mock_config.settings["version_provider"] = "pep621"
 
-    provider = get_provider(config)
+    provider = get_provider(mock_config)
     assert isinstance(provider, Pep621Provider)
     assert provider.get_version() == "0.1.0"
 

--- a/tests/providers/test_poetry_provider.py
+++ b/tests/providers/test_poetry_provider.py
@@ -25,7 +25,7 @@ version = "42.1"
     ((POETRY_TOML, POETRY_EXPECTED),),
 )
 def test_cargo_provider(
-    config: BaseConfig,
+    mock_config: BaseConfig,
     chdir: Path,
     content: str,
     expected: str,
@@ -33,9 +33,9 @@ def test_cargo_provider(
     filename = PoetryProvider.filename
     file = chdir / filename
     file.write_text(dedent(content))
-    config.settings["version_provider"] = "poetry"
+    mock_config.settings["version_provider"] = "poetry"
 
-    provider = get_provider(config)
+    provider = get_provider(mock_config)
     assert isinstance(provider, PoetryProvider)
     assert provider.get_version() == "0.1.0"
 

--- a/tests/providers/test_scm_provider.py
+++ b/tests/providers/test_scm_provider.py
@@ -42,17 +42,17 @@ from tests.utils import (
 )
 @pytest.mark.usefixtures("tmp_git_project")
 def test_scm_provider(
-    config: BaseConfig, tag_format: str, tag: str, expected_version: str
+    mock_config: BaseConfig, tag_format: str, tag: str, expected_version: str
 ):
     create_file_and_commit("test: fake commit")
     create_tag(tag)
     create_file_and_commit("test: fake commit")
     create_tag("should-not-match")
 
-    config.settings["version_provider"] = "scm"
-    config.settings["tag_format"] = tag_format
+    mock_config.settings["version_provider"] = "scm"
+    mock_config.settings["tag_format"] = tag_format
 
-    provider = get_provider(config)
+    provider = get_provider(mock_config)
     assert isinstance(provider, ScmProvider)
     actual_version = provider.get_version()
     assert actual_version == expected_version
@@ -62,19 +62,19 @@ def test_scm_provider(
 
 
 @pytest.mark.usefixtures("tmp_git_project")
-def test_scm_provider_default_without_commits_and_tags(config: BaseConfig):
-    config.settings["version_provider"] = "scm"
+def test_scm_provider_default_without_commits_and_tags(mock_config: BaseConfig):
+    mock_config.settings["version_provider"] = "scm"
 
-    provider = get_provider(config)
+    provider = get_provider(mock_config)
     assert isinstance(provider, ScmProvider)
     assert provider.get_version() == "0.0.0"
 
 
 @pytest.mark.usefixtures("tmp_git_project")
-def test_scm_provider_default_with_commits_and_tags(config: BaseConfig):
-    config.settings["version_provider"] = "scm"
+def test_scm_provider_default_with_commits_and_tags(mock_config: BaseConfig):
+    mock_config.settings["version_provider"] = "scm"
 
-    provider = get_provider(config)
+    provider = get_provider(mock_config)
     assert isinstance(provider, ScmProvider)
     assert provider.get_version() == "0.0.0"
 
@@ -116,14 +116,14 @@ def test_scm_provider_default_with_commits_and_tags(config: BaseConfig):
 
 
 @pytest.mark.usefixtures("tmp_git_project")
-def test_scm_provider_detect_legacy_tags(config: BaseConfig):
-    config.settings["version_provider"] = "scm"
-    config.settings["tag_format"] = "v${version}"
-    config.settings["legacy_tag_formats"] = [
+def test_scm_provider_detect_legacy_tags(mock_config: BaseConfig):
+    mock_config.settings["version_provider"] = "scm"
+    mock_config.settings["tag_format"] = "v${version}"
+    mock_config.settings["legacy_tag_formats"] = [
         "legacy-${version}",
         "old-${version}",
     ]
-    provider = get_provider(config)
+    provider = get_provider(mock_config)
 
     create_file_and_commit("test: fake commit")
     create_tag("old-0.4.1")

--- a/tests/providers/test_uv_provider.py
+++ b/tests/providers/test_uv_provider.py
@@ -66,7 +66,7 @@ dependencies = [
 
 
 def test_uv_provider(
-    config: BaseConfig, tmpdir, file_regression: FileRegressionFixture
+    mock_config: BaseConfig, tmpdir, file_regression: FileRegressionFixture
 ):
     with tmpdir.as_cwd():
         pyproject_toml_file = tmpdir / UvProvider.filename
@@ -75,9 +75,9 @@ def test_uv_provider(
         uv_lock_file = tmpdir / UvProvider.lock_filename
         uv_lock_file.write_text(UV_LOCK_SIMPLIFIED, encoding="utf-8")
 
-        config.settings["version_provider"] = "uv"
+        mock_config.settings["version_provider"] = "uv"
 
-        provider = get_provider(config)
+        provider = get_provider(mock_config)
         assert isinstance(provider, UvProvider)
         assert provider.get_version() == "4.2.1"
 

--- a/tests/test_changelog_format_asciidoc.py
+++ b/tests/test_changelog_format_asciidoc.py
@@ -99,15 +99,15 @@ EXPECTED_E = Metadata(
 
 
 @pytest.fixture
-def format(config: BaseConfig) -> AsciiDoc:
-    return AsciiDoc(config)
+def format(mock_config: BaseConfig) -> AsciiDoc:
+    return AsciiDoc(mock_config)
 
 
 @pytest.fixture
-def format_with_tags(config: BaseConfig, request) -> AsciiDoc:
-    config.settings["tag_format"] = request.param
-    config.settings["legacy_tag_formats"] = ["legacy-${version}"]
-    return AsciiDoc(config)
+def format_with_tags(mock_config: BaseConfig, request) -> AsciiDoc:
+    mock_config.settings["tag_format"] = request.param
+    mock_config.settings["legacy_tag_formats"] = ["legacy-${version}"]
+    return AsciiDoc(mock_config)
 
 
 VERSIONS_EXAMPLES = [

--- a/tests/test_changelog_format_markdown.py
+++ b/tests/test_changelog_format_markdown.py
@@ -99,15 +99,15 @@ EXPECTED_E = Metadata(
 
 
 @pytest.fixture
-def format(config: BaseConfig) -> Markdown:
-    return Markdown(config)
+def format(mock_config: BaseConfig) -> Markdown:
+    return Markdown(mock_config)
 
 
 @pytest.fixture
-def format_with_tags(config: BaseConfig, request) -> Markdown:
-    config.settings["tag_format"] = request.param
-    config.settings["legacy_tag_formats"] = ["legacy-${version}"]
-    return Markdown(config)
+def format_with_tags(mock_config: BaseConfig, request) -> Markdown:
+    mock_config.settings["tag_format"] = request.param
+    mock_config.settings["legacy_tag_formats"] = ["legacy-${version}"]
+    return Markdown(mock_config)
 
 
 VERSIONS_EXAMPLES = [

--- a/tests/test_changelog_format_restructuredtext.py
+++ b/tests/test_changelog_format_restructuredtext.py
@@ -299,15 +299,15 @@ Changelog
 
 
 @pytest.fixture
-def format(config: BaseConfig) -> RestructuredText:
-    return RestructuredText(config)
+def format(mock_config: BaseConfig) -> RestructuredText:
+    return RestructuredText(mock_config)
 
 
 @pytest.fixture
-def format_with_tags(config: BaseConfig, request) -> RestructuredText:
-    config.settings["tag_format"] = request.param
-    config.settings["legacy_tag_formats"] = ["legacy-${version}"]
-    return RestructuredText(config)
+def format_with_tags(mock_config: BaseConfig, request) -> RestructuredText:
+    mock_config.settings["tag_format"] = request.param
+    mock_config.settings["legacy_tag_formats"] = ["legacy-${version}"]
+    return RestructuredText(mock_config)
 
 
 @pytest.mark.parametrize("content, expected", CASES)

--- a/tests/test_changelog_format_textile.py
+++ b/tests/test_changelog_format_textile.py
@@ -92,15 +92,15 @@ h3. Added
 
 
 @pytest.fixture
-def format(config: BaseConfig) -> Textile:
-    return Textile(config)
+def format(mock_config: BaseConfig) -> Textile:
+    return Textile(mock_config)
 
 
 @pytest.fixture
-def format_with_tags(config: BaseConfig, request) -> Textile:
-    config.settings["tag_format"] = request.param
-    config.settings["legacy_tag_formats"] = ["legacy-${version}"]
-    return Textile(config)
+def format_with_tags(mock_config: BaseConfig, request) -> Textile:
+    mock_config.settings["tag_format"] = request.param
+    mock_config.settings["legacy_tag_formats"] = ["legacy-${version}"]
+    return Textile(mock_config)
 
 
 VERSIONS_EXAMPLES = [

--- a/tests/test_changelog_formats.py
+++ b/tests/test_changelog_formats.py
@@ -32,28 +32,32 @@ def test_guess_format_unknown(filename: str):
         for name, format in KNOWN_CHANGELOG_FORMATS.items()
     ],
 )
-def test_get_format(config: BaseConfig, name: str, expected: type[ChangelogFormat]):
-    config.settings["changelog_format"] = name
-    assert isinstance(get_changelog_format(config), expected)
+def test_get_format(
+    mock_config: BaseConfig, name: str, expected: type[ChangelogFormat]
+):
+    mock_config.settings["changelog_format"] = name
+    assert isinstance(get_changelog_format(mock_config), expected)
 
 
 @pytest.mark.parametrize("filename", (None, ""))
-def test_get_format_empty_filename(config: BaseConfig, filename: str | None):
-    config.settings["changelog_format"] = defaults.CHANGELOG_FORMAT
+def test_get_format_empty_filename(mock_config: BaseConfig, filename: str | None):
+    mock_config.settings["changelog_format"] = defaults.CHANGELOG_FORMAT
     assert isinstance(
-        get_changelog_format(config, filename),
+        get_changelog_format(mock_config, filename),
         KNOWN_CHANGELOG_FORMATS[defaults.CHANGELOG_FORMAT],
     )
 
 
 @pytest.mark.parametrize("filename", (None, ""))
-def test_get_format_empty_filename_no_setting(config: BaseConfig, filename: str | None):
-    config.settings["changelog_format"] = None
+def test_get_format_empty_filename_no_setting(
+    mock_config: BaseConfig, filename: str | None
+):
+    mock_config.settings["changelog_format"] = None
     with pytest.raises(ChangelogFormatUnknown):
-        get_changelog_format(config, filename)
+        get_changelog_format(mock_config, filename)
 
 
 @pytest.mark.parametrize("filename", ("extensionless", "file.unknown"))
-def test_get_format_unknown(config: BaseConfig, filename: str | None):
+def test_get_format_unknown(mock_config: BaseConfig, filename: str | None):
     with pytest.raises(ChangelogFormatUnknown):
-        get_changelog_format(config, filename)
+        get_changelog_format(mock_config, filename)

--- a/tests/test_cz_conventional_commits.py
+++ b/tests/test_cz_conventional_commits.py
@@ -40,15 +40,15 @@ def test_subject_transformations(subject_transformation):
     assert transformed_subject == _parse_subject(invalid_subject)
 
 
-def test_questions(config):
-    conventional_commits = ConventionalCommitsCz(config)
+def test_questions(mock_config):
+    conventional_commits = ConventionalCommitsCz(mock_config)
     questions = conventional_commits.questions()
     assert isinstance(questions, list)
     assert isinstance(questions[0], dict)
 
 
-def test_choices_all_have_keyboard_shortcuts(config):
-    conventional_commits = ConventionalCommitsCz(config)
+def test_choices_all_have_keyboard_shortcuts(mock_config):
+    conventional_commits = ConventionalCommitsCz(mock_config)
     questions = conventional_commits.questions()
 
     list_questions = (q for q in questions if q["type"] == "list")
@@ -56,8 +56,8 @@ def test_choices_all_have_keyboard_shortcuts(config):
         assert all("key" in choice for choice in select["choices"])
 
 
-def test_small_answer(config):
-    conventional_commits = ConventionalCommitsCz(config)
+def test_small_answer(mock_config):
+    conventional_commits = ConventionalCommitsCz(mock_config)
     answers = {
         "prefix": "fix",
         "scope": "users",
@@ -70,8 +70,8 @@ def test_small_answer(config):
     assert message == "fix(users): email pattern corrected"
 
 
-def test_long_answer(config):
-    conventional_commits = ConventionalCommitsCz(config)
+def test_long_answer(mock_config):
+    conventional_commits = ConventionalCommitsCz(mock_config)
     answers = {
         "prefix": "fix",
         "scope": "users",
@@ -87,8 +87,8 @@ def test_long_answer(config):
     )
 
 
-def test_breaking_change_in_footer(config):
-    conventional_commits = ConventionalCommitsCz(config)
+def test_breaking_change_in_footer(mock_config):
+    conventional_commits = ConventionalCommitsCz(mock_config)
     answers = {
         "prefix": "fix",
         "scope": "users",
@@ -105,22 +105,22 @@ def test_breaking_change_in_footer(config):
     )
 
 
-def test_example(config):
+def test_example(mock_config):
     """just testing a string is returned. not the content"""
-    conventional_commits = ConventionalCommitsCz(config)
+    conventional_commits = ConventionalCommitsCz(mock_config)
     example = conventional_commits.example()
     assert isinstance(example, str)
 
 
-def test_schema(config):
+def test_schema(mock_config):
     """just testing a string is returned. not the content"""
-    conventional_commits = ConventionalCommitsCz(config)
+    conventional_commits = ConventionalCommitsCz(mock_config)
     schema = conventional_commits.schema()
     assert isinstance(schema, str)
 
 
-def test_info(config):
+def test_info(mock_config):
     """just testing a string is returned. not the content"""
-    conventional_commits = ConventionalCommitsCz(config)
+    conventional_commits = ConventionalCommitsCz(mock_config)
     info = conventional_commits.info()
     assert isinstance(info, str)

--- a/tests/test_cz_customize.py
+++ b/tests/test_cz_customize.py
@@ -323,7 +323,7 @@ commitizen:
         JsonConfig(data=JSON_STR, path="not_exist.json"),
     ]
 )
-def config(request):
+def mock_config(request):
     """Parametrize the config fixture
 
     This fixture allow to test multiple config formats,
@@ -372,8 +372,8 @@ def test_initialize_cz_customize_failed():
     assert MissingCzCustomizeConfigError.message in str(excinfo.value)
 
 
-def test_bump_pattern(config):
-    cz = CustomizeCommitsCz(config)
+def test_bump_pattern(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     assert cz.bump_pattern == "^(break|new|fix|hotfix)"
 
 
@@ -382,8 +382,8 @@ def test_bump_pattern_unicode(config_with_unicode):
     assert cz.bump_pattern == "^(✨ feat|🐛 bug fix)"
 
 
-def test_bump_map(config):
-    cz = CustomizeCommitsCz(config)
+def test_bump_map(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     assert cz.bump_map == {
         "break": "MAJOR",
         "new": "MINOR",
@@ -401,8 +401,8 @@ def test_bump_map_unicode(config_with_unicode):
     }
 
 
-def test_change_type_order(config):
-    cz = CustomizeCommitsCz(config)
+def test_change_type_order(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     assert cz.change_type_order == [
         "perf",
         "BREAKING CHANGE",
@@ -423,8 +423,8 @@ def test_change_type_order_unicode(config_with_unicode):
     ]
 
 
-def test_questions(config):
-    cz = CustomizeCommitsCz(config)
+def test_questions(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     questions = cz.questions()
     expected_questions = [
         {
@@ -469,8 +469,8 @@ def test_questions_unicode(config_with_unicode):
     assert list(questions) == expected_questions
 
 
-def test_answer(config):
-    cz = CustomizeCommitsCz(config)
+def test_answer(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     answers = {
         "change_type": "feature",
         "message": "this feature enable customize through config file",
@@ -479,7 +479,7 @@ def test_answer(config):
     message = cz.message(answers)
     assert message == "feature: this feature enable customize through config file"
 
-    cz = CustomizeCommitsCz(config)
+    cz = CustomizeCommitsCz(mock_config)
     answers = {
         "change_type": "feature",
         "message": "this feature enable customize through config file",
@@ -512,8 +512,8 @@ def test_answer_unicode(config_with_unicode):
     assert message == "✨ feature:"
 
 
-def test_example(config):
-    cz = CustomizeCommitsCz(config)
+def test_example(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     assert (
         "feature: this feature enables customization through a config file"
         in cz.example()
@@ -528,13 +528,13 @@ def test_example_unicode(config_with_unicode):
     )
 
 
-def test_schema(config):
-    cz = CustomizeCommitsCz(config)
+def test_schema(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     assert "<type>: <body>" in cz.schema()
 
 
-def test_schema_pattern(config):
-    cz = CustomizeCommitsCz(config)
+def test_schema_pattern(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     assert r"(feature|bug fix):(\s.*)" in cz.schema_pattern()
 
 
@@ -543,8 +543,8 @@ def test_schema_pattern_unicode(config_with_unicode):
     assert r"(✨ feature|🐛 bug fix):(\s.*)" in cz.schema_pattern()
 
 
-def test_info(config):
-    cz = CustomizeCommitsCz(config)
+def test_info(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     assert "This is a customized cz." in cz.info()
 
 
@@ -567,8 +567,8 @@ def test_info_without_info(config_without_info):
     assert cz.info() == ""
 
 
-def test_commit_parser(config):
-    cz = CustomizeCommitsCz(config)
+def test_commit_parser(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     assert cz.commit_parser == "^(?P<change_type>feature|bug fix):\\s(?P<message>.*)?"
 
 
@@ -580,8 +580,8 @@ def test_commit_parser_unicode(config_with_unicode):
     )
 
 
-def test_changelog_pattern(config):
-    cz = CustomizeCommitsCz(config)
+def test_changelog_pattern(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     assert cz.changelog_pattern == "^(feature|bug fix)?(!)?"
 
 
@@ -590,8 +590,8 @@ def test_changelog_pattern_unicode(config_with_unicode):
     assert cz.changelog_pattern == "^(✨ feature|🐛 bug fix)?(!)?"
 
 
-def test_change_type_map(config):
-    cz = CustomizeCommitsCz(config)
+def test_change_type_map(mock_config):
+    cz = CustomizeCommitsCz(mock_config)
     assert cz.change_type_map == {"feature": "Feat", "bug fix": "Fix"}
 
 

--- a/tests/test_cz_jira.py
+++ b/tests/test_cz_jira.py
@@ -1,15 +1,15 @@
 from commitizen.cz.jira import JiraSmartCz
 
 
-def test_questions(config):
-    cz = JiraSmartCz(config)
+def test_questions(mock_config):
+    cz = JiraSmartCz(mock_config)
     questions = cz.questions()
     assert isinstance(questions, list)
     assert isinstance(questions[0], dict)
 
 
-def test_answer(config):
-    cz = JiraSmartCz(config)
+def test_answer(mock_config):
+    cz = JiraSmartCz(mock_config)
     answers = {
         "message": "new test",
         "issues": "JRA-34",
@@ -21,18 +21,18 @@ def test_answer(config):
     assert message == "new test JRA-34"
 
 
-def test_example(config):
-    cz = JiraSmartCz(config)
+def test_example(mock_config):
+    cz = JiraSmartCz(mock_config)
     assert "JRA-34 #comment corrected indent issue\n" in cz.example()
 
 
-def test_schema(config):
-    cz = JiraSmartCz(config)
+def test_schema(mock_config):
+    cz = JiraSmartCz(mock_config)
     assert "<ignored text>" in cz.schema()
 
 
-def test_info(config):
-    cz = JiraSmartCz(config)
+def test_info(mock_config):
+    cz = JiraSmartCz(mock_config)
     assert (
         "Smart Commits allow repository committers to perform "
         "actions such as transitioning JIRA Software"

--- a/tests/test_cz_search_filter.py
+++ b/tests/test_cz_search_filter.py
@@ -41,13 +41,13 @@ message = "Write a short and imperative summary of the code changes: (lower case
 
 
 @pytest.fixture
-def config():
+def mock_config():
     return TomlConfig(data=TOML_WITH_SEARCH_FILTER, path="not_exist.toml")
 
 
-def test_questions_with_search_filter(config):
+def test_questions_with_search_filter(mock_config):
     """Test that questions are properly configured with search filter"""
-    cz = CustomizeCommitsCz(config)
+    cz = CustomizeCommitsCz(mock_config)
     questions = cz.questions()
 
     # Test that the first question (change_type) has search filter enabled
@@ -63,9 +63,9 @@ def test_questions_with_search_filter(config):
     assert choices[1]["value"] == "feat"
 
 
-def test_message_template(config):
+def test_message_template(mock_config):
     """Test that the message template is properly configured"""
-    cz = CustomizeCommitsCz(config)
+    cz = CustomizeCommitsCz(mock_config)
     template = cz.message(
         {
             "change_type": "feat",

--- a/tests/test_version_schemes.py
+++ b/tests/test_version_schemes.py
@@ -15,45 +15,45 @@ from commitizen.exceptions import VersionSchemeUnknown
 from commitizen.version_schemes import Pep440, SemVer, get_version_scheme
 
 
-def test_default_version_scheme_is_pep440(config: BaseConfig):
-    scheme = get_version_scheme(config.settings)
+def test_default_version_scheme_is_pep440(mock_config: BaseConfig):
+    scheme = get_version_scheme(mock_config.settings)
     assert scheme is Pep440
 
 
-def test_version_scheme_from_config(config: BaseConfig):
-    config.settings["version_scheme"] = "semver"
-    scheme = get_version_scheme(config.settings)
+def test_version_scheme_from_config(mock_config: BaseConfig):
+    mock_config.settings["version_scheme"] = "semver"
+    scheme = get_version_scheme(mock_config.settings)
     assert scheme is SemVer
 
 
-def test_version_scheme_from_name(config: BaseConfig):
-    config.settings["version_scheme"] = "pep440"
-    scheme = get_version_scheme(config.settings, "semver")
+def test_version_scheme_from_name(mock_config: BaseConfig):
+    mock_config.settings["version_scheme"] = "pep440"
+    scheme = get_version_scheme(mock_config.settings, "semver")
     assert scheme is SemVer
 
 
-def test_raise_for_unknown_version_scheme(config: BaseConfig):
+def test_raise_for_unknown_version_scheme(mock_config: BaseConfig):
     with pytest.raises(VersionSchemeUnknown):
-        get_version_scheme(config.settings, "unknown")
+        get_version_scheme(mock_config.settings, "unknown")
 
 
-def test_version_scheme_from_deprecated_config(config: BaseConfig):
-    config.settings["version_type"] = "semver"
+def test_version_scheme_from_deprecated_config(mock_config: BaseConfig):
+    mock_config.settings["version_type"] = "semver"
     with pytest.warns(DeprecationWarning):
-        scheme = get_version_scheme(config.settings)
+        scheme = get_version_scheme(mock_config.settings)
     assert scheme is SemVer
 
 
-def test_version_scheme_from_config_priority(config: BaseConfig):
-    config.settings["version_scheme"] = "pep440"
-    config.settings["version_type"] = "semver"
+def test_version_scheme_from_config_priority(mock_config: BaseConfig):
+    mock_config.settings["version_scheme"] = "pep440"
+    mock_config.settings["version_type"] = "semver"
     with pytest.warns(DeprecationWarning):
-        scheme = get_version_scheme(config.settings)
+        scheme = get_version_scheme(mock_config.settings)
     assert scheme is Pep440
 
 
 def test_warn_if_version_protocol_not_implemented(
-    config: BaseConfig, mocker: MockerFixture
+    mock_config: BaseConfig, mocker: MockerFixture
 ):
     class NotVersionProtocol:
         pass
@@ -63,4 +63,4 @@ def test_warn_if_version_protocol_not_implemented(
     mocker.patch.object(metadata, "entry_points", return_value=(ep,))
 
     with pytest.warns(match="VersionProtocol"):
-        get_version_scheme(config.settings, "any")
+        get_version_scheme(mock_config.settings, "any")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

There are too many things called `config` in this repo (we have module, parameter key, etc).

Added a prefix `mock_` so we can distinguish them more easily.