### PR TITLE
docs: add url to contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,4 +3,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Contact
+    url: https://github.com/woile
     about: Please report security vulnerabilities to santiwilly@gmail.com


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

1. **(Will do in a separate PR)** Sometimes I still need a blank issue form... for example, the idea might be a performance improvement or test coverage improvement, which is neither documentation change, feature request or bug
2. There should be a url field for each entry in `contact_links`. I added @woile 's github profile link.

<img width="965" height="282" alt="image" src="https://github.com/user-attachments/assets/589b8e42-ac52-40b5-98c3-21b3f5141e92" />

