### PR TITLE
docs: fix typo in bump command hooks description

### DIFF
--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -589,7 +589,7 @@ execution of the script, some environment variables are available:
 | `CZ_PRE_NEW_VERSION`         | New version, after the bump                                |
 | `CZ_PRE_NEW_TAG_VERSION`     | New version tag, after the bump                            |
 | `CZ_PRE_MESSAGE`             | Commit message of the bump                                 |
-| `CZ_PRE_INCREMENT`           | Whether this is a `MAJOR`, `MINOR` or `PATH` release       |
+| `CZ_PRE_INCREMENT`           | Whether this is a `MAJOR`, `MINOR` or `PATCH` release       |
 | `CZ_PRE_CHANGELOG_FILE_NAME` | Path to the changelog file, if available                   |
 
 ```toml title="pyproject.toml"
@@ -616,7 +616,7 @@ release. During execution of the script, some environment variables are availabl
 | `CZ_POST_CURRENT_VERSION`      | Current version, after the bump                             |
 | `CZ_POST_CURRENT_TAG_VERSION`  | Current version tag, after the bump                         |
 | `CZ_POST_MESSAGE`              | Commit message of the bump                                  |
-| `CZ_POST_INCREMENT`            | Whether this was a `MAJOR`, `MINOR` or `PATH` release      |
+| `CZ_POST_INCREMENT`            | Whether this was a `MAJOR`, `MINOR` or `PATCH` release      |
 | `CZ_POST_CHANGELOG_FILE_NAME`  | Path to the changelog file, if available                    |
 
 ```toml title="pyproject.toml"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
`CZ_PRE_INCREMENT` and `CZ_POST_INCREMENT` environment variables should say `PATCH` not `PATH`

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly
- [x] Check and fix any broken links (internal or external) in the documentation

<!--
> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```
-->
