### PR TITLE
fix(bump): remove `NotAllowed` related to `--get-next` option, and other related refactoring

### DIFF
--- a/commitizen/exceptions.py
+++ b/commitizen/exceptions.py
@@ -75,10 +75,6 @@ class DryRunExit(ExpectedExit):
     pass
 
 
-class GetNextExit(ExpectedExit):
-    pass
-
-
 class NoneIncrementExit(CommitizenException):
     exit_code = ExitCode.NO_INCREMENT
 

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -23,7 +23,6 @@ from commitizen.exceptions import (
     DryRunExit,
     ExitCode,
     ExpectedExit,
-    GetNextExit,
     InvalidManualVersion,
     NoCommitsFoundError,
     NoneIncrementExit,
@@ -1456,7 +1455,7 @@ def test_bump_get_next(mocker: MockFixture, capsys):
 
     testargs = ["cz", "bump", "--yes", "--get-next"]
     mocker.patch.object(sys, "argv", testargs)
-    with pytest.raises(GetNextExit):
+    with pytest.raises(DryRunExit):
         cli.main()
 
     out, _ = capsys.readouterr()
@@ -1476,7 +1475,7 @@ def test_bump_get_next_update_changelog_on_bump(
 
     testargs = ["cz", "bump", "--yes", "--get-next"]
     mocker.patch.object(sys, "argv", testargs)
-    with pytest.raises(GetNextExit):
+    with pytest.raises(DryRunExit):
         cli.main()
 
     out, _ = capsys.readouterr()
@@ -1484,39 +1483,6 @@ def test_bump_get_next_update_changelog_on_bump(
 
     tag_exists = git.tag_exist("0.2.0")
     assert tag_exists is False
-
-
-@pytest.mark.usefixtures("tmp_commitizen_project")
-def test_bump_get_next__changelog_is_not_allowed(mocker: MockFixture):
-    create_file_and_commit("feat: new file")
-
-    testargs = ["cz", "bump", "--yes", "--get-next", "--changelog"]
-    mocker.patch.object(sys, "argv", testargs)
-
-    with pytest.raises(NotAllowed):
-        cli.main()
-
-
-@pytest.mark.usefixtures("tmp_commitizen_project")
-def test_bump_get_next__changelog_to_stdout_is_not_allowed(mocker: MockFixture):
-    create_file_and_commit("feat: new file")
-
-    testargs = ["cz", "bump", "--yes", "--get-next", "--changelog-to-stdout"]
-    mocker.patch.object(sys, "argv", testargs)
-
-    with pytest.raises(NotAllowed):
-        cli.main()
-
-
-@pytest.mark.usefixtures("tmp_commitizen_project")
-def test_bump_get_next__manual_version_is_not_allowed(mocker: MockFixture):
-    create_file_and_commit("feat: new file")
-
-    testargs = ["cz", "bump", "--yes", "--get-next", "0.2.1"]
-    mocker.patch.object(sys, "argv", testargs)
-
-    with pytest.raises(NotAllowed):
-        cli.main()
 
 
 @pytest.mark.usefixtures("tmp_commitizen_project")


### PR DESCRIPTION
# Changes

1. Remove unreachable logic, such as setting `dry_run = True` while we already have `get_next = True`. The latter condition raises a `GetNextExit()` exception in the original code, so no effect if we set `dry_run` to `True`. Moreover, the original code is `self.dry_run = True` which is ineffective since we never use the member variable.
2. Simplify things.
3. Rename the variable `get_next` to `next_version_to_stdout`. The variable name `get_next` is very unclear and hard to guess what it will do. I think we can consider renaming the option in the next major release.
4. (relate #1640) Replace `NotAllowed` related to `--get-next` option with warnings.
5. Remove `GetNextExit` exception because we already have `DryRunExit`. `--get-next` is just `--dry-run` but doing less things IMO.
