### PR TITLE
docs(bump): general documentation update

### DIFF
--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -2,9 +2,18 @@
 
 ## About
 
-`cz bump` is a powerful command that **automatically** determines and increases your project's version number based on your commit history. It analyzes your commits to determine the appropriate version increment according to semantic versioning principles.
+`cz bump` is a powerful command that **automatically** determines and increases your project's version number based on your commit history.
 
-### Key Features
+It analyzes your commits to determine the appropriate version increment according to semantic versioning principles.
+
+!!! note
+    In the following documentation, the term "configuration file" refers to `pyproject.toml`, `.cz.toml` or other configuration files.
+
+    We will use `pyproject.toml` as the configuration file throughout the documentation.
+
+    See [Configuration file](../config.md#configuration-file) for more details.
+
+## Key Features
 
 - **Automatic Version Detection**: Analyzes commit history to determine the appropriate version bump
 - **Manual Version Control**: Supports manual version specification when needed
@@ -21,7 +30,7 @@ The version follows the `MAJOR.MINOR.PATCH` format, with increments determined b
 | `MINOR`   | New features                | `feat`                  |
 | `PATCH`   | Fixes and improvements      | `fix`, `perf`, `refactor`|
 
-### Version Schemes
+### Version Schemes (`--version-scheme`)
 
 By default, Commitizen uses [PEP 440][pep440] for version formatting. You can switch to semantic versioning using either:
 
@@ -35,6 +44,26 @@ cz bump --version-scheme semver
 [tool.commitizen]
 version_scheme = "semver"
 ```
+
+Available options are:
+
+- `pep440`: [PEP 440][pep440] (**default** and recommended for Python projects)
+- `semver`: [Semantic Versioning][semver] (recommended for non-Python projects)
+
+You can also set this in the [configuration](#version_scheme) with `version_scheme = "semver"`.
+
+!!! note
+    [pep440][pep440] and [semver][semver] are quite similar, although their difference lies in
+    how the prereleases look. For example, `0.3.1a0` in pep440 is equivalent to `0.3.1-a0` in semver.
+
+    The following table illustrates the difference between the two schemes:
+
+    | Version Type | pep440         | semver          |
+    |--------------|----------------|-----------------|
+    | Non-prerelease | `0.1.0`        | `0.1.0`         |
+    | Prerelease     | `0.3.1a0`      | `0.3.1-a0`      |
+    | Devrelease     | `0.1.1.dev1`   | `0.1.1-dev1`    |
+    | Dev and pre    | `1.0.0a3.dev1` | `1.0.0-a3-dev1` |
 
 ### PEP440 Version Examples
 
@@ -76,13 +105,13 @@ Commitizen supports the [PEP 440][pep440] version format, which includes several
 
 > **Note**: `post` releases (e.g., `1.0.0.post1`) are not currently supported.
 
-## Usage
+## Command line options
 
 ![cz bump --help](../images/cli_help/cz_bump___help.svg)
 
 ### `--files-only`
 
-Bumps the version in the files defined in `version_files` without creating a commit and tag on the git repository,
+Bumps the version in the files defined in [`version_files`](#version_files) without creating a commit and tag on the git repository,
 
 ```bash
 cz bump --files-only
@@ -90,7 +119,7 @@ cz bump --files-only
 
 ### `--changelog`
 
-Generate a **changelog** along with the new version and tag when bumping.
+Generate a **changelog** along with the new version and tag when bumping. See [changelog](./changelog.md) for more details.
 
 ```bash
 cz bump --changelog
@@ -122,16 +151,21 @@ by their precedence and showcase how a release might flow through a development 
 
 ### `--increment-mode`
 
-By default, `--increment-mode` is set to `linear`, which ensures that bumping pre-releases _maintains linearity_:
-bumping of a pre-release with lower precedence than the current pre-release phase maintains the current phase of
-higher precedence. For example, if the current version is `1.0.0b1` then bumping with `--prerelease alpha` will
-continue to bump the "beta" phase.
+#### `--increment-mode=linear` (default)
 
-Setting `--increment-mode` to `exact` instructs `cz bump` to instead apply the
-exact changes that have been specified with `--increment` or determined from the commit log. For example,
-`--prerelease beta` will always result in a `b` tag, and `--increment PATCH` will always increase the patch component.
+Ensures that bumping pre-releases **maintains linearity**.
 
-Below are some examples that illustrate the difference in behavior:
+Bumping a pre-release with lower precedence than the current pre-release phase maintains the current phase of higher precedence.
+For example, if the current version is `1.0.0b1` then bumping with `--prerelease alpha` will continue to bump the *beta* phase.
+
+#### `--increment-mode=exact`
+
+Applies the exact changes that have been specified with `--increment` or determined from the commit log.
+For example, `--prerelease beta` will always result in a `b` tag, and `--increment PATCH` will always increase the patch component.
+
+#### Examples
+
+The following table illustrates the difference in behavior between the two modes:
 
 | Increment | Pre-release | Start Version | `--increment-mode=linear` | `--increment-mode=exact` |
 |-----------|-------------|---------------|---------------------------|--------------------------|
@@ -144,14 +178,13 @@ Below are some examples that illustrate the difference in behavior:
 
 ### `--check-consistency`
 
-Check whether the versions defined in `version_files` and the version in Commitizen
-configuration are consistent before bumping version.
+Check whether the versions defined in [`version_files`](#version_files) and the version in Commitizen configuration are consistent before bumping version.
 
 ```bash
 cz bump --check-consistency
 ```
 
-For example, if we have `pyproject.toml`
+For example, if we have the following configuration file `pyproject.toml`:
 
 ```toml title="pyproject.toml"
 [tool.commitizen]
@@ -162,14 +195,11 @@ version_files = [
 ]
 ```
 
-`src/__version__.py`
-
+and the following version files `src/__version__.py` and `setup.py`:
 
 ```python title="src/__version__.py"
 __version__ = "1.21.0"
 ```
-
-and `setup.py`
 
 ```python title="setup.py"
 from setuptools import setup
@@ -177,52 +207,82 @@ from setuptools import setup
 setup(..., version="1.0.5", ...)
 ```
 
-If `--check-consistency` is used, Commitizen will check whether the current version in `pyproject.toml`
-exists in all version_files and find out it does not exist in `setup.py` and fails.
-However, it will still update `pyproject.toml` and `src/__version__.py`.
+When you run `cz bump --check-consistency`, Commitizen will verify that the current version in `pyproject.toml` (`1.21.0`) exists in all files listed in [`version_files`](#version_files).
+In this example, it will detect that `setup.py` contains `1.0.5` instead of `1.21.0`, causing the bump to fail.
 
-To fix it, you'll first `git checkout .` to reset to the status before trying to bump and update
-the version in `setup.py` to `1.21.0`
+!!! warning "Partial updates on failure"
+    If the consistency check fails, Commitizen may have already updated some files (like `pyproject.toml` and `src/__version__.py`) before detecting the inconsistency.
+    In this case, you'll need to restore the files to their previous state.
+
+    To resolve this issue:
+
+    1. Restore the modified files to their previous state:
+      ```bash
+      git checkout .
+      ```
+
+    2. Manually update the version in `setup.py` to match the version in `pyproject.toml`:
+      ```python title="setup.py"
+      from setuptools import setup
+
+      setup(..., version="1.21.0", ...)
+      ```
+
+    3. Run the bump command again:
+      ```bash
+      cz bump --check-consistency
+      ```
 
 ### `--local-version`
 
 Bump the local portion of the version.
 
-```bash
-cz bump --local-version
-```
-
-For example, if we have `pyproject.toml`
+For example, if we have the following configuration file `pyproject.toml`:
 
 ```toml title="pyproject.toml"
 [tool.commitizen]
 version = "5.3.5+0.1.0"
 ```
 
-If `--local-version` is used, it will bump only the local version `0.1.0` and keep the public version `5.3.5` intact, bumping to the version `5.3.5+0.2.0`.
+When you run `cz bump --local-version`, it will bump only the local version `0.1.0` and keep the public version `5.3.5` intact, bumping to the version `5.3.5+0.2.0`.
 
 ### `--annotated-tag`
 
-If `--annotated-tag` is used, Commitizen will create annotated tags. It is also available via configuration, in `pyproject.toml` or `.cz.toml`.
+Create annotated tags.
+
+It is also available via configuration files.
+
+For example, in `pyproject.toml`:
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+annotated_tag = true
+```
 
 ### `--annotated-tag-message`
 
-If `--annotated-tag-message` is used, Commitizen will create annotated tags with the given message.
+Create annotated tags with the given message.
+
+It is also available via configuration files.
+
+For example, in `pyproject.toml`:
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+annotated_tag_message = "Annotated tag message"
+```
 
 ### `--changelog-to-stdout`
 
-If `--changelog-to-stdout` is used, the incremental changelog generated by the bump
-will be sent to the stdout, and any other message generated by the bump will be
-sent to stderr.
+Send the incremental changelog generated by `cz bump` to `stdout`.
+Any other messages generated by `cz bump` will be sent to `stderr`.
 
-If `--changelog` is not used with this command, it is still smart enough to
-understand that the user wants to create a changelog. It is recommended to be
-explicit and use `--changelog` (or the setting `update_changelog_on_bump`).
+When this flag is used, `--changelog` is implied.
+However, it is recommended to set `--changelog` (or the setting `update_changelog_on_bump`) explicitly when the option `--changelog-to-stdout` is used.
 
-This command is useful to "transport" the newly created changelog.
-It can be sent to an auditing system, or to create a GitHub Release.
+#### Useful scenarios
 
-Example:
+This is useful to pipe the newly created changelog to another tool. For example, it can be sent to an auditing system, or to create a GitHub Release, etc.
 
 ```bash
 cz bump --changelog --changelog-to-stdout > body.md
@@ -230,55 +290,64 @@ cz bump --changelog --changelog-to-stdout > body.md
 
 ### `--git-output-to-stderr`
 
-If `--git-output-to-stderr` is used, git commands output is redirected to stderr.
+If `--git-output-to-stderr` is used, git commands output is redirected to `stderr`.
 
-This command is useful when used with `--changelog-to-stdout` and piping the output to a file,
-and you don't want the `git commit` output polluting  the stdout.
+Useful when used with `--changelog-to-stdout` and piping the output to a file,
+
+For example, `git commit` output may pollute `stdout`, so it is recommended to use this flag when piping the output to a file.
 
 ### `--retry`
 
-If you use tools like [pre-commit](https://pre-commit.com/), add this flag.
-It will retry the commit if it fails the 1st time.
+If you use tools like [pre-commit](https://pre-commit.com/), you can add this flag.
+It will retry the commit if it fails the first time.
 
 Useful to combine with code formatters, like [Prettier](https://prettier.io/).
 
 ### `--major-version-zero`
 
-A project in its initial development should have a major version zero, and even breaking changes
-should not bump that major version from zero. This command ensures that behavior.
+Breaking changes does not bump the major version number.
 
-If `--major-version-zero` is used for projects that have a version number greater than zero it fails.
-If used together with a manual version the command also fails.
+Say you have a project with the version `0.1.x` and you commit a breaking change like this:
 
-We recommend setting `major_version_zero = true` in your configuration file while a project
-is in its initial development. Remove that configuration using a breaking-change commit to bump
-your project's major version to `v1.0.0` once your project has reached maturity.
+```text
+fix(magic)!: fully deprecate whatever
+```
 
-### `--version-scheme`
+and you run
 
-Choose the version format, options: `pep440`, `semver`.
+```bash
+cz bump --major-version-zero
+```
 
-Default: `pep440`
+Then the version of your project will be bumped to `0.2.0` instead of `1.0.0`.
 
-Recommended for python: `pep440`
+!!! note
+    A project in its initial development should have a major version zero,
+    and even breaking changes should not bump that major version from zero. This command ensures that behavior.
 
-Recommended for other: `semver`
+    We recommend setting `major_version_zero = true` in your configuration file while a project
+    is in its initial development. Remove that configuration using a breaking-change commit to bump
+    your project's major version to `v1.0.0` once your project has reached maturity.
 
-You can also set this in the [configuration](#version_scheme) with `version_scheme = "semver"`.
+!!! warning
+    This option is only compatible with projects that have major version number zero, `0.x.x` for example.
 
-[pep440][pep440] and [semver][semver] are quite similar, their difference lies in
-how the prereleases look.
+    It fails when used with projects that have a version number greater than zero like `1.x.x`.
 
-| schemes        | pep440         | semver          |
-| -------------- | -------------- | --------------- |
-| non-prerelease | `0.1.0`        | `0.1.0`         |
-| prerelease     | `0.3.1a0`      | `0.3.1-a0`      |
-| devrelease     | `0.1.1.dev1`   | `0.1.1-dev1`    |
-| dev and pre    | `1.0.0a3.dev1` | `1.0.0-a3-dev1` |
+    If used together with a manual version, the command also fails.
 
-Can I transition from one to the other?
+    ```bash
+    # This fails
+    cz bump 0.1.0 --major-version-zero
+    ```
 
-Yes, you shouldn't have any issues.
+### `--gpg-sign`
+
+Create gpg signed tags.
+
+```bash
+cz bump --gpg-sign
+```
 
 ### `--template`
 
@@ -304,15 +373,23 @@ cz bump --build-metadata yourmetadata
 ```
 
 Will create a version like `1.1.2+yourmetadata`.
+
 This can be useful for multiple things
+
 - Git hash in version
 - Labeling the version with additional metadata.
 
-Note that Commitizen ignores everything after `+` when it bumps the version. It is therefore safe to write different build-metadata between versions.
+!!! note
+    Commitizen ignores everything after `+` when it bumps the version.
 
-You should normally not use this functionality, but if you decide to do, keep in mind that
-- Version `1.2.3+a`, and `1.2.3+b` are the same version! Tools should not use the string after `+` for version calculation. This is probably not a guarantee (example in helm) even tho it is in the spec.
-- It might be problematic having the metadata in place when doing upgrades depending on what tool you use.
+    It is therefore safe to write different build-metadata between versions.
+
+
+!!! warning
+    Normally, you should not use this functionality, but if you decide to do so, keep in mind that:
+
+    - Version `1.2.3+a`, and `1.2.3+b` are the same version! Tools should not use the string after `+` for version calculation. This is probably not a guarantee (example in helm) even tho it is in the spec.
+    - It might be problematic having the metadata in place when doing upgrades depending on what tool you use.
 
 ### `--get-next`
 
@@ -323,33 +400,33 @@ and `manual version`.
 cz bump --get-next
 ```
 
-Will output the next version, e.g., `1.2.3`. This can be useful for determining the next version based on CI for non
-production environments/builds.
+Will only output the next version, e.g., `1.2.3`. This can be useful for determining the next version based on CI for non-production environments/builds.
 
-This behavior differs from the `--dry-run` flag. The `--dry-run` flag provides a more detailed output and can also show
-the changes as they would appear in the changelog file.
+!!! note "Compare with `--dry-run`"
+    `--dry-run` provides a more detailed output including the changes as they would appear in the changelog file, while `--get-next` only outputs the next version.
 
-The following output is the result of `cz bump --dry-run`:
+    The following is the output of `cz bump --dry-run`:
 
-```
-bump: version 3.28.0 → 3.29.0
-tag to create: v3.29.0
-increment detected: MINOR
-```
+    ```text
+    bump: version 3.28.0 → 3.29.0
+    tag to create: v3.29.0
+    increment detected: MINOR
+    ```
 
-The following output is the result of `cz bump --get-next`:
+    The following is the output of `cz bump --get-next`:
 
-```
-3.29.0
-```
+    ```text
+    3.29.0
+    ```
 
-The `--get-next` flag will raise a `NoneIncrementExit` if the found commits are not eligible for a version bump.
+!!! warning
+    The `--get-next` flag will raise a `NoneIncrementExit` if the found commits are not eligible for a version bump.
 
-For information on how to suppress this exit, see [avoid raising errors](#avoid-raising-errors).
+    For information on how to suppress this exit, see [avoid raising errors](#avoid-raising-errors).
 
 ### `--allow-no-commit`
 
-Allow the project version to be bumped even when there's no eligible version. This is most useful when used with `--increment {MAJOR,MINOR,PATCH}` or `[MANUL_VERSION]`
+Allow the project version to be bumped even when there's no eligible version. This is most useful when used with `--increment {MAJOR,MINOR,PATCH}` or `[MANUAL_VERSION]`
 
 ```sh
 # bump a minor version even when there's only bug fixes, documentation changes or even no commits
@@ -358,6 +435,250 @@ cz bump --incremental MINOR --allow-no-commit
 # bump version to 2.0.0 even when there's no breaking changes changes or even no commits
 cz bump --allow-no-commit 2.0.0
 ```
+
+### `--version-scheme`
+
+See [Version Schemes](#version-schemes-version-scheme).
+
+## Configuration file options
+
+### `tag_format`
+
+`tag_format` and [`version_scheme`](#version-schemes-version-scheme) are combined to make Git tag names from versions.
+
+These are used in:
+
+- `cz bump`: Find previous release tag (exact match) and generate new tag.
+- Find previous release tags in `cz changelog`.
+  - If `--incremental`: Using the latest version found in the changelog, scan existing Git tags with 89\% similarity match.
+  - `--rev-range` is converted to Git tag names with `tag_format` before searching Git history.
+- If the `scm` `version_provider` is used, it uses different regexes to find the previous version tags:
+  - If `tag_format` is set to `$version` (default): `VersionProtocol.parser` (allows `v` prefix)
+  - If `tag_format` is set: Custom regex similar to SemVer (not as lenient as PEP440 e.g. on dev-releases)
+
+Commitizen supports two types of formats, a simple and a more complex.
+
+```bash
+cz bump --tag-format="v$version"
+```
+
+```bash
+cz bump --tag-format="v$minor.$major.$patch$prerelease.$devrelease"
+```
+
+In your configuration file:
+
+```toml
+[tool.commitizen]
+tag_format = "v$major.$minor.$patch$prerelease"
+```
+
+The variables must be preceded by a `$` sign and optionally can be wrapped in `{}`. The default is `$version`.
+
+Supported variables:
+
+| Variable                       | Description                                 |
+|--------------------------------|---------------------------------------------|
+| `$version`, `${version}`       | fully generated version                      |
+| `$major`, `${major}`           | MAJOR increment                             |
+| `$minor`, `${minor}`           | MINOR increment                             |
+| `$patch`, `${patch}`           | PATCH increment                             |
+| `$prerelease`, `${prerelease}` | Prerelease (alpha, beta, release candidate) |
+| `$devrelease`, ${devrelease}`  | Development release                         |
+
+### `version_files`
+
+Identify the files or glob patterns which should be updated with the new version.
+
+Commitizen will update its configuration file automatically when bumping,
+regarding if the file is present or not in `version_files`.
+
+You may specify the `version_files` in your configuration file.
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+version_files = [
+    "src/__version__.py",
+]
+```
+
+It is also possible to provide a pattern for each file, separated by a colon (e.g. `file:pattern`). See the below example for more details.
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+version_files = [
+    "packages/*/pyproject.toml:version",
+    "setup.json:version",
+]
+```
+
+#### Example scenario
+
+We have a project with the following configuration file `pyproject.toml`:
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+version_files = [
+    "src/__version__.py",
+    "packages/*/pyproject.toml:version",
+    "setup.json:version",
+]
+```
+
+For the reference `"setup.json:version"`, it means that it will look for a file `setup.json` and will only change the lines that contain the substring `"version"`.
+
+For example, if the content of `setup.json` is:
+
+<!-- DEPENDENCY: repeated_version_number.json -->
+
+```json title="setup.json"
+{
+  "name": "magictool",
+  "version": "1.2.3",
+  "dependencies": {
+      "lodash": "1.2.3"
+  }
+}
+```
+
+After running `cz bump 2.0.0`, its content will be updated to:
+
+```diff title="setup.json"
+{
+  "name": "magictool",
+- "version": "1.2.3",
++ "version": "2.0.0",
+  "dependencies": {
+      "lodash": "1.2.3"
+  }
+}
+```
+
+!!! note
+    Files can be specified using relative (to the execution) paths, absolute paths, or glob patterns.
+
+!!! note "Historical note"
+    This option was renamed from `files` to `version_files`.
+
+### `bump_message`
+
+Template used to specify the commit message generated when bumping.
+
+Defaults to: `bump: version $current_version → $new_version`
+
+| Variable           | Description                         |
+| ------------------ | ----------------------------------- |
+| `$current_version` | the version existing before bumping |
+| `$new_version`     | version generated after bumping     |
+
+#### Example configuration
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+bump_message = "release $current_version → $new_version [skip-ci]"
+```
+
+### `update_changelog_on_bump`
+
+When set to `true`, `cz bump` is equivalent to `cz bump --changelog`.
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+update_changelog_on_bump = true
+```
+
+### `annotated_tag`
+
+When set to `true`, `cz bump` is equivalent to `cz bump --annotated-tag`.
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+annotated_tag = true
+```
+
+### `gpg_sign`
+
+When set to `true`, `cz bump` is equivalent to `cz bump --gpg-sign`. See [--gpg-sign](#-gpg-sign).
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+gpg_sign = true
+```
+
+### `major_version_zero`
+
+When set to `true`, `cz bump` is equivalent to `cz bump --major-version-zero`. See [--major-version-zero](#-major-version-zero).
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+major_version_zero = true
+```
+
+### `pre_bump_hooks`
+
+A list of optional commands that will run right _after_ updating [`version_files`](#version_files)
+and _before_ actual committing and tagging the release.
+
+Useful when you need to generate documentation based on the new version. During
+execution of the script, some environment variables are available:
+
+| Variable                     | Description                                                |
+| ---------------------------- | ---------------------------------------------------------- |
+| `CZ_PRE_IS_INITIAL`          | `True` when this is the initial release, `False` otherwise |
+| `CZ_PRE_CURRENT_VERSION`     | Current version, before the bump                           |
+| `CZ_PRE_CURRENT_TAG_VERSION` | Current version tag, before the bump                       |
+| `CZ_PRE_NEW_VERSION`         | New version, after the bump                                |
+| `CZ_PRE_NEW_TAG_VERSION`     | New version tag, after the bump                            |
+| `CZ_PRE_MESSAGE`             | Commit message of the bump                                 |
+| `CZ_PRE_INCREMENT`           | Whether this is a `MAJOR`, `MINOR` or `PATCH` release       |
+| `CZ_PRE_CHANGELOG_FILE_NAME` | Path to the changelog file, if available                   |
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+pre_bump_hooks = [
+  "scripts/generate_documentation.sh"
+]
+```
+
+### `post_bump_hooks`
+
+A list of optional commands that will run right _after_ committing and tagging the release.
+
+Useful when you need to send notifications about a release, or further automate deploying the
+release. During execution of the script, some environment variables are available:
+
+| Variable                       | Description                                                 |
+| ------------------------------ | ----------------------------------------------------------- |
+| `CZ_POST_WAS_INITIAL`          | `True` when this was the initial release, `False` otherwise |
+| `CZ_POST_PREVIOUS_VERSION`     | Previous version, before the bump                           |
+| `CZ_POST_PREVIOUS_TAG_VERSION` | Previous version tag, before the bump                       |
+| `CZ_POST_CURRENT_VERSION`      | Current version, after the bump                             |
+| `CZ_POST_CURRENT_TAG_VERSION`  | Current version tag, after the bump                         |
+| `CZ_POST_MESSAGE`              | Commit message of the bump                                  |
+| `CZ_POST_INCREMENT`            | Whether this was a `MAJOR`, `MINOR` or `PATCH` release      |
+| `CZ_POST_CHANGELOG_FILE_NAME`  | Path to the changelog file, if available                    |
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+post_bump_hooks = [
+  "scripts/slack_notification.sh"
+]
+```
+
+### `prerelease_offset`
+
+Offset with which to start counting prereleases.
+
+Defaults to: `0`
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+prerelease_offset = 1
+```
+
+### `version_scheme`
+
+See [Version Schemes](#version-schemes-version-scheme).
 
 ## Avoid raising errors
 
@@ -420,270 +741,6 @@ on the list, and then you can use the exit code:
 
 ```sh
 cz -nr 21 bump
-```
-
-## Configuration
-
-### `tag_format`
-
-`tag_format` and `version_scheme` are combined to make Git tag names from versions.
-
-These are used in:
-
-- `cz bump`: Find previous release tag (exact match) and generate new tag.
-- Find previous release tags in `cz changelog`.
-  - If `--incremental`: Using the latest version found in the changelog, scan existing Git tags with 89\% similarity match.
-  - `--rev-range` is converted to Git tag names with `tag_format` before searching Git history.
-- If the `scm` `version_provider` is used, it uses different regexes to find the previous version tags:
-  - If `tag_format` is set to `$version` (default): `VersionProtocol.parser` (allows `v` prefix)
-  - If `tag_format` is set: Custom regex similar to SemVer (not as lenient as PEP440 e.g. on dev-releases)
-
-Commitizen supports 2 types of formats, a simple and a more complex.
-
-```bash
-cz bump --tag-format="v$version"
-```
-
-```bash
-cz bump --tag-format="v$minor.$major.$patch$prerelease.$devrelease"
-```
-
-In your `pyproject.toml` or `.cz.toml`
-
-```toml
-[tool.commitizen]
-tag_format = "v$major.$minor.$patch$prerelease"
-```
-
-The variables must be preceded by a `$` sign and optionally can be wrapped in `{}`. The default is `$version`.
-
-Supported variables:
-
-| Variable                       | Description                                 |
-|--------------------------------|---------------------------------------------|
-| `$version`, `${version}`       | full generated version                      |
-| `$major`, `${major}`           | MAJOR increment                             |
-| `$minor`, `${minor}`           | MINOR increment                             |
-| `$patch`, `${patch}`           | PATCH increment                             |
-| `$prerelease`, `${prerelease}` | Prerelease (alpha, beta, release candidate) |
-| `$devrelease`, ${devrelease}`  | Development release                         |
-
----
-
-### `version_files`
-
-It is used to identify the files or glob patterns which should be updated with the new version.
-
-Commitizen will update its configuration file automatically (`pyproject.toml`, `.cz`) when bumping,
-regarding if the file is present or not in `version_files`.
-
-You may specify the `version_files` in your `pyproject.toml`, `.cz.toml` or `cz.toml` configuration file.
-
-It is also possible to provide a pattern for each file, separated by a colon (e.g. `file:pattern`). See the below example for more details.
-
-#### Example Configuration
-
-```toml title="pyproject.toml"
-[tool.commitizen]
-version_files = [
-    "src/__version__.py",
-    "packages/*/pyproject.toml:version",
-    "setup.json:version",
-]
-```
-
-In the example configuration above, we can see the reference `"setup.json:version"`.
-
-This means that it will find a file `setup.json` and will only change the lines that contain the substring `"version"`.
-
-For example, if we have a file `setup.json` with the following content:
-
-<!-- DEPENDENCY: repeated_version_number.json -->
-
-```json title="setup.json"
-{
-  "name": "magictool",
-  "version": "1.2.3",
-  "dependencies": {
-      "lodash": "1.2.3"
-  }
-}
-```
-
-After running `cz bump 2.0.0`, the file will be updated to:
-
-```diff title="setup.json"
-{
-  "name": "magictool",
-- "version": "1.2.3",
-+ "version": "2.0.0",
-  "dependencies": {
-      "lodash": "1.2.3"
-  }
-}
-```
-
-!!! note
-    Files can be specified using relative (to the execution) paths, absolute paths, or glob patterns.
-
-!!! note
-    (Historical note) This option was renamed from `files` to `version_files`.
-
----
-
-### `bump_message`
-
-Template used to specify the commit message generated when bumping.
-
-Defaults to: `bump: version $current_version → $new_version`
-
-| Variable           | Description                         |
-| ------------------ | ----------------------------------- |
-| `$current_version` | the version existing before bumping |
-| `$new_version`     | version generated after bumping     |
-
-Some examples
-
-`pyproject.toml`, `.cz.toml` or `cz.toml`
-
-```toml title="pyproject.toml"
-[tool.commitizen]
-bump_message = "release $current_version → $new_version [skip-ci]"
-```
-
----
-
-### `update_changelog_on_bump`
-
-When set to `true` the changelog is always updated incrementally when running `cz bump`, so the user does not have to provide the `--changelog` flag every time.
-
-Defaults to: `false`
-
-```toml title="pyproject.toml"
-[tool.commitizen]
-update_changelog_on_bump = true
-```
-
----
-
-### `annotated_tag`
-
-When set to `true`, Commitizen will create annotated tags.
-
-```toml title="pyproject.toml"
-[tool.commitizen]
-annotated_tag = true
-```
-
----
-
-### `gpg_sign`
-
-When set to `true`, Commitizen will create gpg signed tags.
-
-```toml title="pyproject.toml"
-[tool.commitizen]
-gpg_sign = true
-```
-
----
-
-### `major_version_zero`
-
-When set to `true`, Commitizen will keep the major version at zero.
-Useful during the initial development stage of your project.
-
-Defaults to: `false`
-
-```toml title="pyproject.toml"
-[tool.commitizen]
-major_version_zero = true
-```
-
----
-
-### `pre_bump_hooks`
-
-A list of optional commands that will run right _after_ updating `version_files`
-and _before_ actual committing and tagging the release.
-
-Useful when you need to generate documentation based on the new version. During
-execution of the script, some environment variables are available:
-
-| Variable                     | Description                                                |
-| ---------------------------- | ---------------------------------------------------------- |
-| `CZ_PRE_IS_INITIAL`          | `True` when this is the initial release, `False` otherwise |
-| `CZ_PRE_CURRENT_VERSION`     | Current version, before the bump                           |
-| `CZ_PRE_CURRENT_TAG_VERSION` | Current version tag, before the bump                       |
-| `CZ_PRE_NEW_VERSION`         | New version, after the bump                                |
-| `CZ_PRE_NEW_TAG_VERSION`     | New version tag, after the bump                            |
-| `CZ_PRE_MESSAGE`             | Commit message of the bump                                 |
-| `CZ_PRE_INCREMENT`           | Whether this is a `MAJOR`, `MINOR` or `PATCH` release       |
-| `CZ_PRE_CHANGELOG_FILE_NAME` | Path to the changelog file, if available                   |
-
-```toml title="pyproject.toml"
-[tool.commitizen]
-pre_bump_hooks = [
-  "scripts/generate_documentation.sh"
-]
-```
-
----
-
-### `post_bump_hooks`
-
-A list of optional commands that will run right _after_ committing and tagging the release.
-
-Useful when you need to send notifications about a release, or further automate deploying the
-release. During execution of the script, some environment variables are available:
-
-| Variable                       | Description                                                 |
-| ------------------------------ | ----------------------------------------------------------- |
-| `CZ_POST_WAS_INITIAL`          | `True` when this was the initial release, `False` otherwise |
-| `CZ_POST_PREVIOUS_VERSION`     | Previous version, before the bump                           |
-| `CZ_POST_PREVIOUS_TAG_VERSION` | Previous version tag, before the bump                       |
-| `CZ_POST_CURRENT_VERSION`      | Current version, after the bump                             |
-| `CZ_POST_CURRENT_TAG_VERSION`  | Current version tag, after the bump                         |
-| `CZ_POST_MESSAGE`              | Commit message of the bump                                  |
-| `CZ_POST_INCREMENT`            | Whether this was a `MAJOR`, `MINOR` or `PATCH` release      |
-| `CZ_POST_CHANGELOG_FILE_NAME`  | Path to the changelog file, if available                    |
-
-```toml title="pyproject.toml"
-[tool.commitizen]
-post_bump_hooks = [
-  "scripts/slack_notification.sh"
-]
-```
-
-### `prerelease_offset`
-
-Offset with which to start counting prereleases.
-
-Defaults to: `0`
-
-```toml title="pyproject.toml"
-[tool.commitizen]
-prerelease_offset = 1
-```
-
-### `version_scheme`
-
-Choose version scheme
-
-| schemes        | pep440         | semver          | semver2               |
-| -------------- | -------------- | --------------- | --------------------- |
-| non-prerelease | `0.1.0`        | `0.1.0`         | `0.1.0`               |
-| prerelease     | `0.3.1a0`      | `0.3.1-a0`      | `0.3.1-alpha.0`       |
-| devrelease     | `0.1.1.dev1`   | `0.1.1-dev1`    | `0.1.1-dev.1`         |
-| dev and pre    | `1.0.0a3.dev1` | `1.0.0-a3-dev1` | `1.0.0-alpha.3.dev.1` |
-
-Options: `pep440`, `semver`, `semver2`
-
-Defaults to: `pep440`
-
-```toml title="pyproject.toml"
-[tool.commitizen]
-version_scheme = "semver"
 ```
 
 ## Custom bump

--- a/docs/config.md
+++ b/docs/config.md
@@ -408,7 +408,7 @@ setup(
 [prerelease-offset]: commands/bump.md#prerelease_offset
 [retry_after_failure]: commands/commit.md#retry
 [allow_abort]: commands/check.md#allow-abort
-[version-scheme]: commands/bump.md#-version-scheme
+[version-scheme]: commands/bump.md#version-schemes-version-scheme
 [pre_bump_hooks]: commands/bump.md#pre_bump_hooks
 [post_bump_hooks]: commands/bump.md#post_bump_hooks
 [allowed_prefixes]: commands/check.md#allowed-prefixes


### PR DESCRIPTION
Just noticed the documentation of `cz bump` read a bit awkward.

Added some anchors, rewording, make notes `!!! note`, warnings `!!! warning`, etc.

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly
- [x] Check and fix any broken links (internal or external) in the documentation
