### PR TITLE
fix(cli): `debug` and `no_raise` can be used together in `sys.excepthook`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -186,10 +186,10 @@ def test_unknown_args_before_double_dash_raises(mocker: MockFixture):
 
 
 def test_commitizen_excepthook_non_commitizen_exception(mocker: MockFixture):
-    """Test that commitizen_excepthook delegates to original_excepthook for non-CommitizenException."""
+    """Test that commitizen_excepthook delegates to sys.__excepthook__ for non-CommitizenException."""
     # Mock the original excepthook
     mock_original_excepthook = mocker.Mock()
-    mocker.patch("commitizen.cli.original_excepthook", mock_original_excepthook)
+    mocker.patch("commitizen.cli.sys.__excepthook__", mock_original_excepthook)
 
     # Create a regular exception
     test_exception = ValueError("test error")
@@ -197,7 +197,7 @@ def test_commitizen_excepthook_non_commitizen_exception(mocker: MockFixture):
     # Call commitizen_excepthook with the regular exception
     cli.commitizen_excepthook(ValueError, test_exception, None)
 
-    # Verify original_excepthook was called with correct arguments
+    # Verify sys.__excepthook__ was called with correct arguments
     mock_original_excepthook.assert_called_once_with(ValueError, test_exception, None)
 
 
@@ -207,7 +207,7 @@ def test_commitizen_excepthook_non_commitizen_exception_with_traceback(
     """Test that commitizen_excepthook handles traceback correctly for non-CommitizenException."""
     # Mock the original excepthook
     mock_original_excepthook = mocker.Mock()
-    mocker.patch("commitizen.cli.original_excepthook", mock_original_excepthook)
+    mocker.patch("commitizen.cli.sys.__excepthook__", mock_original_excepthook)
 
     # Create a regular exception with a traceback
     test_exception = ValueError("test error")
@@ -216,7 +216,7 @@ def test_commitizen_excepthook_non_commitizen_exception_with_traceback(
     # Call commitizen_excepthook with the regular exception and traceback
     cli.commitizen_excepthook(ValueError, test_exception, test_traceback)
 
-    # Verify original_excepthook was called with correct arguments including traceback
+    # Verify sys.__excepthook__ was called with correct arguments including traceback
     mock_original_excepthook.assert_called_once_with(
         ValueError, test_exception, test_traceback
     )
@@ -228,7 +228,7 @@ def test_commitizen_excepthook_non_commitizen_exception_with_invalid_traceback(
     """Test that commitizen_excepthook handles invalid traceback correctly for non-CommitizenException."""
     # Mock the original excepthook
     mock_original_excepthook = mocker.Mock()
-    mocker.patch("commitizen.cli.original_excepthook", mock_original_excepthook)
+    mocker.patch("commitizen.cli.sys.__excepthook__", mock_original_excepthook)
 
     # Create a regular exception with an invalid traceback
     test_exception = ValueError("test error")
@@ -237,5 +237,5 @@ def test_commitizen_excepthook_non_commitizen_exception_with_invalid_traceback(
     # Call commitizen_excepthook with the regular exception and invalid traceback
     cli.commitizen_excepthook(ValueError, test_exception, test_traceback)
 
-    # Verify original_excepthook was called with None as traceback
+    # Verify sys.__excepthook__ was called with None as traceback
     mock_original_excepthook.assert_called_once_with(ValueError, test_exception, None)


### PR DESCRIPTION
Closes #1294 