### PR TITLE
fix(bump): fix the issue that changelog_merge_prerelease not working on cz bump

### DIFF
--- a/commitizen/changelog_formats/__init__.py
+++ b/commitizen/changelog_formats/__init__.py
@@ -8,7 +8,7 @@ from commitizen.exceptions import ChangelogFormatUnknown
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from commitizen.changelog import Metadata
+    from commitizen.changelog import IncrementalMergeInfo, Metadata
     from commitizen.config.base_config import BaseConfig
 
 CHANGELOG_FORMAT_ENTRYPOINT = "commitizen.changelog_format"
@@ -44,6 +44,12 @@ class ChangelogFormat(Protocol):
     def get_metadata(self, filepath: str) -> Metadata:
         """
         Extract the changelog metadata.
+        """
+        raise NotImplementedError
+
+    def get_latest_full_release(self, filepath: str) -> IncrementalMergeInfo:
+        """
+        Extract metadata for the last non-pre-release.
         """
         raise NotImplementedError
 

--- a/commitizen/changelog_formats/base.py
+++ b/commitizen/changelog_formats/base.py
@@ -4,7 +4,9 @@ import os
 from abc import ABCMeta
 from typing import IO, TYPE_CHECKING, Any, ClassVar
 
-from commitizen.changelog import Metadata
+from commitizen.changelog import IncrementalMergeInfo, Metadata
+from commitizen.config.base_config import BaseConfig
+from commitizen.git import GitTag
 from commitizen.tags import TagRules, VersionTag
 from commitizen.version_schemes import get_version_scheme
 
@@ -60,16 +62,41 @@ class BaseFormat(ChangelogFormat, metaclass=ABCMeta):
                 meta.unreleased_end = index
 
             # Try to find the latest release done
-            parsed = self.parse_version_from_title(line)
-            if parsed:
-                meta.latest_version = parsed.version
-                meta.latest_version_tag = parsed.tag
+            parsed_version = self.parse_version_from_title(line)
+            if parsed_version:
+                meta.latest_version = parsed_version.version
+                meta.latest_version_tag = parsed_version.tag
                 meta.latest_version_position = index
                 break  # there's no need for more info
         if meta.unreleased_start is not None and meta.unreleased_end is None:
             meta.unreleased_end = index
 
         return meta
+
+    def get_latest_full_release(self, filepath: str) -> IncrementalMergeInfo:
+        if not os.path.isfile(filepath):
+            return IncrementalMergeInfo()
+
+        with open(
+            filepath, encoding=self.config.settings["encoding"]
+        ) as changelog_file:
+            return self.get_latest_full_release_from_file(changelog_file)
+
+    def get_latest_full_release_from_file(self, file: IO[Any]) -> IncrementalMergeInfo:
+        latest_version_index: int | None = None
+        for index, line in enumerate(file):
+            latest_version_index = index
+            line = line.strip().lower()
+
+            parsed_version = self.parse_version_from_title(line)
+            if (
+                parsed_version
+                and not self.tag_rules.extract_version(
+                    GitTag(parsed_version.tag, "", "")
+                ).is_prerelease
+            ):
+                return IncrementalMergeInfo(name=parsed_version.tag, index=index)
+        return IncrementalMergeInfo(index=latest_version_index)
 
     def parse_version_from_title(self, line: str) -> VersionTag | None:
         """

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -314,6 +314,8 @@ class Bump:
                 "extras": self.extras,
                 "incremental": True,
                 "dry_run": dry_run,
+                # governs logic for merge_prerelease
+                "during_version_bump": self.arguments["prerelease"] is None,
             }
             if self.changelog_to_stdout:
                 changelog_cmd = Changelog(

--- a/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_alpha_.md
+++ b/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_alpha_.md
@@ -1,0 +1,11 @@
+## 0.2.0 (2025-01-01)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## 0.1.0 (1970-01-01)

--- a/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_beta_.md
+++ b/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_beta_.md
@@ -1,0 +1,11 @@
+## 0.2.0 (2025-01-01)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## 0.1.0 (1970-01-01)

--- a/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_only_prerelease_present_alpha_.md
+++ b/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_only_prerelease_present_alpha_.md
@@ -1,0 +1,10 @@
+## 0.2.0 (2025-01-01)
+
+### Feat
+
+- add new output
+- more relevant commit
+
+### Fix
+
+- output glitch

--- a/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_only_prerelease_present_beta_.md
+++ b/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_only_prerelease_present_beta_.md
@@ -1,0 +1,10 @@
+## 0.2.0 (2025-01-01)
+
+### Feat
+
+- add new output
+- more relevant commit
+
+### Fix
+
+- output glitch

--- a/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_only_prerelease_present_rc_.md
+++ b/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_only_prerelease_present_rc_.md
@@ -1,0 +1,10 @@
+## 0.2.0 (2025-01-01)
+
+### Feat
+
+- add new output
+- more relevant commit
+
+### Fix
+
+- output glitch

--- a/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_rc_.md
+++ b/tests/commands/test_bump_command/test_changelog_config_flag_merge_prerelease_rc_.md
@@ -1,0 +1,11 @@
+## 0.2.0 (2025-01-01)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## 0.1.0 (1970-01-01)

--- a/tests/test_changelog_format_asciidoc.py
+++ b/tests/test_changelog_format_asciidoc.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from commitizen.changelog import Metadata
+from commitizen.changelog import IncrementalMergeInfo, Metadata
 from commitizen.changelog_formats.asciidoc import AsciiDoc
 
 if TYPE_CHECKING:
@@ -171,6 +171,10 @@ def test_get_metadata(
     changelog.write_text(content)
 
     assert format.get_metadata(str(changelog)) == expected
+
+
+def test_get_latest_full_release_no_file(format: AsciiDoc):
+    assert format.get_latest_full_release("/nonexistent") == IncrementalMergeInfo()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
This PR solves issue #1694. 

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and tests (Some error out on mac. I will investigate if they fail in ci)
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions (I thought about breaking changes and starting an empty changelog with prereleases.)
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
~~- [ ] Update the documentation for the changes~~ (I do not think this applies. It works now as documented.)

~~### Documentation Changes~~

~~- [ ] Run `poetry doc` locally to ensure the documentation pages renders correctly~~
~~- [ ] Check and fix any broken links (internal or external) in the documentation~~

> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->
See issue #1694.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
1. build the changes on the branch. `poetry build`.
2. Take the resulting .wheel file from dist/
3. Install the file in a separate python environment: 
- python3 -m venv .venv &&  source .venv/bin/activate
- verify env: which pip
- pip install commitizen-4.10.0-py3-none-any.whl
4. Go through the steps in the issue description and try reproducing the bug.

## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
~~Known issue: When the changelog only contains pre-releases, the old behavior can still be observed.~~ (Fixed)