### PR TITLE
fix: workspace member with fixed version

### DIFF
--- a/tests/providers/test_cargo_provider.py
+++ b/tests/providers/test_cargo_provider.py
@@ -45,7 +45,7 @@ version.workspace = true
         "content": """\
 [package]
 name = "member2"
-version.workspace = "1.1.1"
+version = "1.1.1"
 """,
     },
     {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Fix 2 things with cargo provider : 
- use same order to get / set a version for package or workspace
- there is no `workspace.version = "0.1.0"` in spec to fix the version of a specific workspace member. It must be  `version = "0.1.0"`, even if it is a workspace member

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `poetry all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [x] Update the documentation for the changes

### Documentation Changes

- [x] Run `poetry doc` locally to ensure the documentation pages renders correctly
- [x] Check and fix any broken links (internal or external) in the documentation

> When running `poetry doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```
