### PR TITLE
build: add missing dark mode back

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,9 +2,8 @@ site_name: Commitizen
 site_description: commit rules, semantic version, conventional commits
 
 theme:
-  name: "material"
+  name: material
   palette:
-    - primary: 'deep purple'
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"
       toggle:
@@ -14,6 +13,7 @@ theme:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
+      primary: deep purple
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
@@ -21,6 +21,7 @@ theme:
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
+      primary: deep purple
       toggle:
         icon: material/brightness-4
         name: Switch to system preference


### PR DESCRIPTION
The original config seems to be incorrect. The dark mode toggle button does not show.

Reference: https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/