### PR TITLE
ci(coverage): restore builds on `master`, fix Codecov coverage report and adds test analytics (fix #1606)

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,11 @@
 name: Python package
 
-on: [workflow_dispatch, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   python-check:
@@ -29,10 +34,12 @@ jobs:
           poetry ci
         shell: bash
       - name: Upload coverage to Codecov
-        if: runner.os == 'Linux'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
+      - name: Upload test results to Codecov
+        uses: codecov/codecov-action@v5
+        if: ${{ !cancelled() }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache
+junit.xml
 
 # Translations
 *.mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,7 +265,7 @@ test.cmd = "pytest -n 3 --dist=loadfile"
 "test:all".cmd = "tox --parallel"
 
 cover.help = "Run the test suite with coverage"
-cover.ref = "test --cov-report term-missing --cov-report=xml:coverage.xml --cov=commitizen"
+cover.ref = "test --cov-report term-missing --cov-report=xml:coverage.xml --cov=commitizen  --junitxml=junit.xml -o junit_family=legacy"
 
 all.help = "Run all tasks"
 all.sequence = ["format", "lint", "check-commit", "cover"]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Run tests on the `master` branch (@Lee-W @woile not sure why it was not the case, so I'll let you check if this is OK for you).
This should restore the Codecov `master` report and so provide a viable coverage patch diff on pull requests.

It also adds support for Codecov [test analytics](https://about.codecov.io/product/feature/test-analytics/) as it is free for OSS projects and provides a few interesting insights (detailed test duration over time, flaky tests detection) as well as improved feedback on failure.

Coverage report now runs for all platforms (to properly track total number of runs by test 
as well as tests or code only running on a given platform).

Redundant default parameters have been removed.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

No code change.

`junit.xml` output added to `poetry cover` command (and resulting artifact added to `.gitignore`)

### Documentation Changes

No documentation change

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->
Up-to-date coverage report, working patch-diff on pull request.
Benefit of new Codecov features.
The test suite runs on `master` so:
- we detect post-merge failures early
- contributors know that the build is currently 🟢 and in case of failure on their branch, it's most probably their branch
- the coverage badge is updated with the current coverage


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
- For the test analytics part, this PR test runs should just work with it
- For the `master` part, ... it only works on `master` and should be effective after the merge (there should be tests run on `master` and Codecov report should update)


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
Fixes #1606