### PR TITLE
docs: add warning about future removal of cz_customize

### DIFF
--- a/docs/customization/config_file.md
+++ b/docs/customization/config_file.md
@@ -4,6 +4,8 @@ The basic steps are:
 
 1. Define your custom committing or bumping rules in the configuration file.
 2. Declare `name = "cz_customize"` in your configuration file, or add `-n cz_customize` when running Commitizen.
+!!! warning
+    `cz_customize` is likely to be removed or renamed in the next major release.
 
 Example:
 


### PR DESCRIPTION
Closes #1710 

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
Added a warning in the documentation to inform users that `cz_customize` is likely to be removed or renamed in a future major release.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes

- [x] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external) in the documentation


## Expected Behavior
Readers of the documentation are clearly informed that `cz_customize` may be removed or renamed in the next major release.


