### PR TITLE
docs: update contribution guide related to uv

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,7 +40,7 @@ If you're a first-time contributor, please check out issues labeled [good first 
     ```
 4. Set up the development environment:
     ```bash
-    uv sync --dev
+    uv sync --all-groups
     ```
 5. Set up pre-commit hooks:
     ```bash

--- a/docs/contributing_tldr.md
+++ b/docs/contributing_tldr.md
@@ -13,7 +13,7 @@ Please check the [pyproject.toml](https://github.com/commitizen-tools/commitizen
 
 ```bash
 # Ensure you have the correct dependencies
-uv sync --dev
+uv sync --all-groups
 
 # Make ruff happy
 uv run poe format


### PR DESCRIPTION
It seems that `uv sync --dev` is not enough. I need to run `uv sync --all-groups` to have correct environment on my machine.