### PR TITLE
docs: update version provider install instructions

### DIFF
--- a/docs/config/version_provider.md
+++ b/docs/config/version_provider.md
@@ -267,15 +267,15 @@ setup(
 
     - Once your custom Commitizen provider is packaged and published (for example, to PyPI), install it like any standard Python package:
 
-    ```bash
-    pip install my-commitizen-provider
-    ```
+        ```bash
+        pip install my-commitizen-provider
+        ```
 
     - If you want to use the provider directly from the current project source (during development), install it in editable mode ([See pip documentation](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-e)):
 
-    ```bash
-    pip install -e .
-    ```
+        ```bash
+        pip install -e .
+        ```
 
 2. Configure Commitizen to use your provider:
    ```toml


### PR DESCRIPTION


<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
This change updates the version provider documentation to recommend installing a custom Commitizen provider as a published Python package instead of using editable (pip install -e .) installation.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Documentation Changes

- [x] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external) in the documentation

## Additional Context
Fixes #1707
