### PR TITLE
docs(commands/bump.md): document --yes option for cz bump

### DIFF
--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -504,10 +504,6 @@ Supported variables:
 | `$prerelease`, `${prerelease}` | Prerelease (alpha, beta, release candidate) |
 | `$devrelease`, `${devrelease}` | Development release                         |
 
-[pep440]: https://www.python.org/dev/peps/pep-0440/
-[semver]: https://semver.org/
-[version_files]: ../config/bump.md#version_files
-
 ### `--yes`
 
 Automatically answers “yes” to all interactive prompts during the bump process, allowing the command to run without manual confirmation.
@@ -515,3 +511,7 @@ Automatically answers “yes” to all interactive prompts during the bump proce
 ```bash
 cz bump --yes
 ```
+
+[pep440]: https://www.python.org/dev/peps/pep-0440/
+[semver]: https://semver.org/
+[version_files]: ../config/bump.md#version_files


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
This PR documents the --yes option for the cz bump command, which is currently shown in the CLI help output but not explained in the documentation. The new section clarifies its usage.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [x] Update the documentation for the changes

### Documentation Changes

- [x] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external) in the documentation

## Expected Behavior
Users can clearly understand what the --yes option does when running cz bump.


## Additional Context
Fixes #1698
