### PR TITLE
ci(bump): fix the missing permissions for trusted publishing (fix #1759)

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Add the missing permissions for trusted publishing.

> [!NOTE]
> I did not added an environment because I can't see the current settings. If one is required, I'll amend the PR with it


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

No code change

### Documentation Changes

No documentation change

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->

Publish workflow publish on PyPI using trusted publisher


## Steps to Test This Pull Request
Bump a release


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
