### PR TITLE
build(commitizen): use `uv` version provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,13 +122,12 @@ build-backend = "uv_build"
 
 
 [tool.commitizen]
-version = "4.11.1"
 tag_format = "v$version"
 version_files = [
-    "pyproject.toml:version",
     "commitizen/__version__.py",
     ".pre-commit-config.yaml:rev:.+Commitizen",
 ]
+version_provider = "uv"
 version_scheme = "pep440"
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Switch to `uv` version provider.
This should the `uv.lock` part of #1759

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

No code change

### Documentation Changes

None

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->
`uv.lock` is properly updated on bump

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
Bump a release


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
