### PR TITLE
style(ruff): add `UP` and `TC` fixes to the safe fixes list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,10 @@ select = [
     "TC006",
 ]
 ignore = ["E501", "D1", "D415"]
+extend-safe-fixes = [
+    "TC", # Move imports inside/outside TYPE_CHECKING blocks
+    "UP", # Update syntaxes for current Python version recommendations
+]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["ANN", "S101"]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Adds some lint groups to the safe fixes:
- `UP` to ensure syntaxes are automatically update to the current supported version
- `TC` to properly manage `TYPE_CHECKING` based imports

This way, both the `pre-commit` hook and in-IDE formatting will be able to automatically apply those when formatting.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

No code change

### Documentation Changes

No documentation change

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->
Formatting automatically applies syntax upgrade and move type-checking only imports

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
1. Import something for type checking only but outside a `if TYPE_CHECKING` block
2. Write some code with some legacy syntax (ex: `Optional[str]`)
3. Run `poe format`: 
    - the import is moved in the `if TYPE_CHECKING` block
	- the legacy syntax is updated to the current recommendations (ex: `str | None`)

## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
It might be worth checking the other groups for similar safe fixes, either the entire groups or individual ones.
