### PR TITLE
ci(release): using `pypa/gh-action-pypi-publish@release/v1` to release with attestations

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -20,5 +20,5 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - name: Build
         run: uv build
-      - name: Publish
-        run: uv publish
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Use [pypa/gh-action-pypi-publish@release/v1](https://github.com/pypa/gh-action-pypi-publish) to publish to PyPI and have attestation generated.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

No code change

### Documentation Changes

No documentation change

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->
PyPI releases contain attestations to allow checking package authenticity.

## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
Bump a release.


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
