### PR TITLE
test: upgrade min pytest to 9 and use native toml configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ dev = [
 base = ["poethepoet>=0.34.0"]
 
 test = [
-    "pytest>=7.2",
+    "pytest>=9",
     "pytest-cov>=4",
     "pytest-mock>=3.10",
     "pytest-regressions>=2.4.0",
@@ -177,8 +177,8 @@ omit = [
 ]
 
 
-[tool.pytest.ini_options]
-addopts = "--strict-markers"
+[tool.pytest]
+addopts = ["--strict-markers"]
 testpaths = ["tests/"]
 filterwarnings = [
     # get_smart_tag_range is deprecated and will be removed in v5

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ dev = [
     { name = "mypy", specifier = ">=1.16.0" },
     { name = "poethepoet", specifier = ">=0.34.0" },
     { name = "pre-commit", specifier = ">=3.2.0" },
-    { name = "pytest", specifier = ">=7.2" },
+    { name = "pytest", specifier = ">=9" },
     { name = "pytest-cov", specifier = ">=4" },
     { name = "pytest-freezer", specifier = ">=0.4.6" },
     { name = "pytest-gitconfig", specifier = ">=0.9.0" },
@@ -329,7 +329,7 @@ linters = [
 ]
 script = [{ name = "rich", specifier = ">=13.7.1" }]
 test = [
-    { name = "pytest", specifier = ">=7.2" },
+    { name = "pytest", specifier = ">=9" },
     { name = "pytest-cov", specifier = ">=4" },
     { name = "pytest-freezer", specifier = ">=0.4.6" },
     { name = "pytest-gitconfig", specifier = ">=0.9.0" },


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

Upgrade the min pytest version to 9 so that we can use native toml configuration (use `[tool.pytest]` instead of `[tool.pytest.ini_options]`)


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- ~~[ ] Add test cases to all the changes you introduce~~
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - ~~[ ] Ensure backward compatibility is maintained~~
  - ~~[ ] Document any manual testing steps performed~~
- ~~[ ] Update the documentation for the changes~~

### Documentation Changes

- ~~[ ] Run `uv run poe doc` locally to ensure the documentation pages renders correctly~~
- ~~[ ] Check and fix any broken links (internal or external) in the documentation~~

> When running `uv run poe doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->
`uv run poe test` runs fine


## Steps to Test This Pull Request
<!-- Steps to reproduce the behavior:
1. ...
2. ...
3. ... -->
1. `uv run poe test`

## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
