### PR TITLE
feat(cli): add cz --version back and add cz --report to separate them from cz version

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -119,7 +119,7 @@ data = {
     ],
     "subcommands": {
         "title": "commands",
-        "required": True,
+        "required": False,
         "commands": [
             {
                 "name": ["init"],
@@ -689,18 +689,6 @@ def main() -> None:
         parser.print_help(sys.stderr)
         raise ExpectedExit()
 
-    # TODO(bearomorphism): mark `cz version --commitizen` as deprecated after `cz version` feature is stable
-    if "--version" in sys.argv:
-        out.write(__version__)
-        raise ExpectedExit()
-
-    # TODO(bearomorphism): mark `cz version --report` as deprecated after `cz version` feature is stable
-    if "--report" in sys.argv:
-        out.write(f"Commitizen Version: {__version__}")
-        out.write(f"Python Version: {sys.version}")
-        out.write(f"Operating System: {platform.system()}")
-        raise ExpectedExit()
-
     # This is for the command required constraint in 2.0
     try:
         args, unknown_args = parser.parse_known_args()
@@ -708,6 +696,17 @@ def main() -> None:
         if e.code == 2:
             raise NoCommandFoundError()
         raise e
+
+    if not hasattr(args, "func"):
+        if getattr(args, "version", False):
+            out.write(__version__)
+            raise ExpectedExit()
+        if getattr(args, "report", False):
+            out.write(f"Commitizen Version: {__version__}")
+            out.write(f"Python Version: {sys.version}")
+            out.write(f"Operating System: {platform.system()}")
+            raise ExpectedExit()
+        raise NoCommandFoundError()
 
     arguments = vars(args)
     if unknown_args:

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import platform
 import sys
 from copy import deepcopy
 from functools import partial
@@ -13,6 +14,7 @@ import argcomplete
 from decli import cli
 
 from commitizen import commands, config, out, version_schemes
+from commitizen.__version__ import __version__
 from commitizen.defaults import DEFAULT_SETTINGS
 from commitizen.exceptions import (
     CommitizenException,
@@ -103,6 +105,16 @@ data = {
             "type": str,
             "required": False,
             "help": "Comma-separated error codes that won't raise error, e.g., cz -nr 1,2,3 bump. See codes at https://commitizen-tools.github.io/commitizen/exit_codes/",
+        },
+        {
+            "name": ["-v", "--version"],
+            "action": "store_true",
+            "help": "Show the version of the installed commitizen",
+        },
+        {
+            "name": ["--report"],
+            "action": "store_true",
+            "help": "Show system information for reporting bugs",
         },
     ],
     "subcommands": {
@@ -675,6 +687,18 @@ def main() -> None:
     # Show help if no arg provided
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
+        raise ExpectedExit()
+
+    # TODO(bearomorphism): mark `cz version --commitizen` as deprecated after `cz version` feature is stable
+    if "--version" in sys.argv:
+        out.write(__version__)
+        raise ExpectedExit()
+
+    # TODO(bearomorphism): mark `cz version --report` as deprecated after `cz version` feature is stable
+    if "--report" in sys.argv:
+        out.write(f"Commitizen Version: {__version__}")
+        out.write(f"Python Version: {sys.version}")
+        out.write(f"Operating System: {platform.system()}")
         raise ExpectedExit()
 
     # This is for the command required constraint in 2.0

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -697,15 +697,19 @@ def main() -> None:
             raise NoCommandFoundError()
         raise e
 
+    if getattr(args, "version", False):
+        out.write(__version__)
+        raise ExpectedExit()
+
+    if getattr(args, "report", False) and (
+        not hasattr(args, "func") or args.func is not commands.Version
+    ):
+        out.write(f"Commitizen Version: {__version__}")
+        out.write(f"Python Version: {sys.version}")
+        out.write(f"Operating System: {platform.system()}")
+        raise ExpectedExit()
+
     if not hasattr(args, "func"):
-        if getattr(args, "version", False):
-            out.write(__version__)
-            raise ExpectedExit()
-        if getattr(args, "report", False):
-            out.write(f"Commitizen Version: {__version__}")
-            out.write(f"Python Version: {sys.version}")
-            out.write(f"Operating System: {platform.system()}")
-            raise ExpectedExit()
         raise NoCommandFoundError()
 
     arguments = vars(args)

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -114,6 +114,7 @@ data = {
         {
             "name": ["--report"],
             "action": "store_true",
+            "dest": "global_report",
             "help": "Show system information for reporting bugs",
         },
     ],
@@ -662,6 +663,7 @@ if TYPE_CHECKING:
         name: str | None = None
         no_raise: str | None = None  # comma-separated string, later parsed as list[int]
         report: bool = False
+        global_report: bool = False
         project: bool = False
         commitizen: bool = False
         verbose: bool = False
@@ -701,9 +703,7 @@ def main() -> None:
         out.write(__version__)
         raise ExpectedExit()
 
-    if getattr(args, "report", False) and (
-        not hasattr(args, "func") or args.func is not commands.Version
-    ):
+    if getattr(args, "global_report", False):
         out.write(f"Commitizen Version: {__version__}")
         out.write(f"Python Version: {sys.version}")
         out.write(f"Operating System: {platform.system()}")

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -114,7 +114,6 @@ data = {
         {
             "name": ["--report"],
             "action": "store_true",
-            "dest": "global_report",
             "help": "Show system information for reporting bugs",
         },
     ],
@@ -663,7 +662,6 @@ if TYPE_CHECKING:
         name: str | None = None
         no_raise: str | None = None  # comma-separated string, later parsed as list[int]
         report: bool = False
-        global_report: bool = False
         project: bool = False
         commitizen: bool = False
         verbose: bool = False
@@ -703,13 +701,12 @@ def main() -> None:
         out.write(__version__)
         raise ExpectedExit()
 
-    if getattr(args, "global_report", False):
-        out.write(f"Commitizen Version: {__version__}")
-        out.write(f"Python Version: {sys.version}")
-        out.write(f"Operating System: {platform.system()}")
-        raise ExpectedExit()
-
     if not hasattr(args, "func"):
+        if getattr(args, "report", False):
+            out.write(f"Commitizen Version: {__version__}")
+            out.write(f"Python Version: {sys.version}")
+            out.write(f"Operating System: {platform.system()}")
+            raise ExpectedExit()
         raise NoCommandFoundError()
 
     arguments = vars(args)

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -705,10 +705,8 @@ def main() -> None:
         if unknown_args:
             try:
                 parser.parse_args()
-            except SystemExit as e:
-                if e.code == 2:
-                    raise NoCommandFoundError()
-                raise e
+            except SystemExit:
+                raise NoCommandFoundError()
         if getattr(args, "report", False):
             out.write(f"Commitizen Version: {__version__}")
             out.write(f"Python Version: {sys.version}")

--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -702,6 +702,13 @@ def main() -> None:
         raise ExpectedExit()
 
     if not hasattr(args, "func"):
+        if unknown_args:
+            try:
+                parser.parse_args()
+            except SystemExit as e:
+                if e.code == 2:
+                    raise NoCommandFoundError()
+                raise e
         if getattr(args, "report", False):
             out.write(f"Commitizen Version: {__version__}")
             out.write(f"Python Version: {sys.version}")

--- a/commitizen/commands/version.py
+++ b/commitizen/commands/version.py
@@ -1,5 +1,6 @@
 import platform
 import sys
+import warnings
 from typing import TypedDict
 
 from packaging.version import InvalidVersion
@@ -45,6 +46,12 @@ class Version:
 
     def __call__(self) -> None:
         if self.arguments.get("report"):
+            warnings.warn(
+                "`cz version --report` is deprecated and will be removed in v5. "
+                "Use `cz --report` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             out.write(f"Commitizen Version: {__version__}")
             out.write(f"Python Version: {sys.version}")
             out.write(f"Operating System: {platform.system()}")
@@ -54,6 +61,12 @@ class Version:
             out.write(f"Installed Commitizen Version: {__version__}")
 
         if self.arguments.get("commitizen"):
+            warnings.warn(
+                "`cz version --commitizen` is deprecated and will be removed in v5. "
+                "Use `cz --version` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             out.write(__version__)
             return
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -227,6 +227,8 @@ Commitizen provides a comprehensive CLI with various commands. Here's the comple
 
 | Command | Description | Alias |
 |---------|-------------|-------|
+| `cz --version` | Show installed Commitizen version | `cz -v` |
+| `cz --report` | Show system information for bug reports | - |
 | `cz init` | Initialize Commitizen configuration | - |
 | `cz commit` | Create a new commit | `cz c` |
 | `cz bump` | Bump version and update changelog | - |

--- a/docs/commands/version.md
+++ b/docs/commands/version.md
@@ -1,5 +1,12 @@
 Get the version of the installed Commitizen or the current project (default: installed commitizen).
 
+## Quick version and report
+
+The following top-level flags are available for convenience:
+
+- **`cz --version`** (or **`cz -v`**): print the installed Commitizen version and exit.
+- **`cz --report`**: print system information (Commitizen version, Python version, operating system) useful for bug reports, and exit.
+
 ## Usage
 
 ![cz version --help](../images/cli_help/cz_version___help.svg)
@@ -20,6 +27,8 @@ Get the version of the installed Commitizen or the current project (default: ins
 ## Examples
 
 ```bash
+cz --version              # quick: installed commitizen version
+cz --report               # quick: system info for bug reports
 cz version --project
 cz version 2.0.0 --next MAJOR
 cz version --project --major

--- a/tests/commands/test_version_command.py
+++ b/tests/commands/test_version_command.py
@@ -296,3 +296,23 @@ def test_version_no_arguments_shows_commitizen_version(config, capsys):
     commands.Version(config, {})()
     captured = capsys.readouterr()
     assert captured.out.strip() == __version__
+
+
+def test_version_report_emits_deprecation_warning(config, capsys):
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"`cz version --report` is deprecated.*Use `cz --report` instead",
+    ):
+        commands.Version(config, {"report": True})()
+    captured = capsys.readouterr()
+    assert f"Commitizen Version: {__version__}" in captured.out
+
+
+def test_version_commitizen_emits_deprecation_warning(config, capsys):
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"`cz version --commitizen` is deprecated.*Use `cz --version` instead",
+    ):
+        commands.Version(config, {"commitizen": True})()
+    captured = capsys.readouterr()
+    assert __version__ in captured.out

--- a/tests/commands/test_version_command.py
+++ b/tests/commands/test_version_command.py
@@ -31,10 +31,14 @@ def test_version_for_showing_project_version(config, capsys):
 
 @pytest.mark.parametrize("project", [True, False])
 def test_version_for_showing_commitizen_version(config, capsys, project: bool):
-    commands.Version(
-        config,
-        {"project": project, "commitizen": True},
-    )()
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"`cz version --commitizen` is deprecated.*Use `cz --version` instead",
+    ):
+        commands.Version(
+            config,
+            {"project": project, "commitizen": True},
+        )()
     captured = capsys.readouterr()
     assert f"{__version__}" in captured.out
 
@@ -63,10 +67,14 @@ def test_version_for_showing_both_versions(config, capsys):
 
 
 def test_version_for_showing_commitizen_system_info(config, capsys):
-    commands.Version(
-        config,
-        {"report": True},
-    )()
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"`cz version --report` is deprecated.*Use `cz --report` instead",
+    ):
+        commands.Version(
+            config,
+            {"report": True},
+        )()
     captured = capsys.readouterr()
     assert f"Commitizen Version: {__version__}" in captured.out
     assert f"Python Version: {sys.version}" in captured.out
@@ -296,23 +304,3 @@ def test_version_no_arguments_shows_commitizen_version(config, capsys):
     commands.Version(config, {})()
     captured = capsys.readouterr()
     assert captured.out.strip() == __version__
-
-
-def test_version_report_emits_deprecation_warning(config, capsys):
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"`cz version --report` is deprecated.*Use `cz --report` instead",
-    ):
-        commands.Version(config, {"report": True})()
-    captured = capsys.readouterr()
-    assert f"Commitizen Version: {__version__}" in captured.out
-
-
-def test_version_commitizen_emits_deprecation_warning(config, capsys):
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"`cz version --commitizen` is deprecated.*Use `cz --version` instead",
-    ):
-        commands.Version(config, {"commitizen": True})()
-    captured = capsys.readouterr()
-    assert __version__ in captured.out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_mock import MockFixture
 
 from commitizen import cli
+from commitizen.__version__ import __version__
 from commitizen.exceptions import (
     ConfigFileNotFound,
     ExpectedExit,
@@ -53,6 +54,24 @@ def test_cz_with_arg_but_without_command(util: UtilFixture):
     with pytest.raises(NoCommandFoundError) as excinfo:
         util.run_cli("--name", "cz_jira")
     assert "Command is required" in str(excinfo.value)
+
+
+def test_cz_with_version_arg(util: UtilFixture, capsys):
+    """Test that cz shows the version when --version is used."""
+    with pytest.raises(ExpectedExit):
+        util.run_cli("--version")
+    out, _ = capsys.readouterr()
+    assert __version__ in out
+
+
+def test_cz_with_report_arg(util: UtilFixture, capsys):
+    """Test that cz shows the report when --report is used."""
+    with pytest.raises(ExpectedExit):
+        util.run_cli("--report")
+    out, _ = capsys.readouterr()
+    assert "Commitizen Version:" in out
+    assert "Python Version:" in out
+    assert "Operating System:" in out
 
 
 def test_name(util: UtilFixture, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,6 +72,14 @@ def test_cz_with_version_short_arg(util: UtilFixture, capsys):
     assert __version__ in out
 
 
+def test_cz_version_flag_takes_precedence_over_subcommand(util: UtilFixture, capsys):
+    """Test that --version takes precedence even when a subcommand is given."""
+    with pytest.raises(ExpectedExit):
+        util.run_cli("--version", "bump")
+    out, _ = capsys.readouterr()
+    assert __version__ in out
+
+
 def test_cz_with_report_arg(util: UtilFixture, capsys):
     """Test that cz shows the report when --report is used."""
     with pytest.raises(ExpectedExit):
@@ -80,6 +88,14 @@ def test_cz_with_report_arg(util: UtilFixture, capsys):
     assert "Commitizen Version:" in out
     assert "Python Version:" in out
     assert "Operating System:" in out
+
+
+def test_cz_report_flag_takes_precedence_over_subcommand(util: UtilFixture, capsys):
+    """Test that --report takes precedence over non-version subcommands."""
+    with pytest.raises(ExpectedExit):
+        util.run_cli("--report", "bump")
+    out, _ = capsys.readouterr()
+    assert "Commitizen Version:" in out
 
 
 def test_name(util: UtilFixture, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,14 @@ def test_cz_with_version_arg(util: UtilFixture, capsys):
     assert __version__ in out
 
 
+def test_cz_with_version_short_arg(util: UtilFixture, capsys):
+    """Test that cz shows the version when -v is used."""
+    with pytest.raises(ExpectedExit):
+        util.run_cli("-v")
+    out, _ = capsys.readouterr()
+    assert __version__ in out
+
+
 def test_cz_with_report_arg(util: UtilFixture, capsys):
     """Test that cz shows the report when --report is used."""
     with pytest.raises(ExpectedExit):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,16 @@ def test_cz_report_flag_takes_precedence_over_subcommand(util: UtilFixture, caps
     assert "Commitizen Version:" in out
 
 
+def test_cz_report_flag_takes_precedence_over_version_subcommand(
+    util: UtilFixture, capsys
+):
+    """Test that top-level --report takes precedence over version subcommand."""
+    with pytest.raises(ExpectedExit):
+        util.run_cli("--report", "version")
+    out, _ = capsys.readouterr()
+    assert "Commitizen Version:" in out
+
+
 def test_name(util: UtilFixture, capsys):
     util.run_cli("-n", "cz_jira", "example")
     out, _ = capsys.readouterr()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,24 +90,6 @@ def test_cz_with_report_arg(util: UtilFixture, capsys):
     assert "Operating System:" in out
 
 
-def test_cz_report_flag_takes_precedence_over_subcommand(util: UtilFixture, capsys):
-    """Test that --report takes precedence over non-version subcommands."""
-    with pytest.raises(ExpectedExit):
-        util.run_cli("--report", "bump")
-    out, _ = capsys.readouterr()
-    assert "Commitizen Version:" in out
-
-
-def test_cz_report_flag_takes_precedence_over_version_subcommand(
-    util: UtilFixture, capsys
-):
-    """Test that top-level --report takes precedence over version subcommand."""
-    with pytest.raises(ExpectedExit):
-        util.run_cli("--report", "version")
-    out, _ = capsys.readouterr()
-    assert "Commitizen Version:" in out
-
-
 def test_name(util: UtilFixture, capsys):
     util.run_cli("-n", "cz_jira", "example")
     out, _ = capsys.readouterr()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,26 +56,19 @@ def test_cz_with_arg_but_without_command(util: UtilFixture):
     assert "Command is required" in str(excinfo.value)
 
 
-def test_cz_with_version_arg(util: UtilFixture, capsys):
-    """Test that cz shows the version when --version is used."""
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("--version",),
+        ("-v",),
+        ("--version", "bump"),
+    ],
+    ids=["long-flag", "short-flag", "precedence-over-subcommand"],
+)
+def test_cz_with_version_arg(util: UtilFixture, capsys, args):
+    """Test that cz --version / -v shows the version and takes precedence."""
     with pytest.raises(ExpectedExit):
-        util.run_cli("--version")
-    out, _ = capsys.readouterr()
-    assert __version__ in out
-
-
-def test_cz_with_version_short_arg(util: UtilFixture, capsys):
-    """Test that cz shows the version when -v is used."""
-    with pytest.raises(ExpectedExit):
-        util.run_cli("-v")
-    out, _ = capsys.readouterr()
-    assert __version__ in out
-
-
-def test_cz_version_flag_takes_precedence_over_subcommand(util: UtilFixture, capsys):
-    """Test that --version takes precedence even when a subcommand is given."""
-    with pytest.raises(ExpectedExit):
-        util.run_cli("--version", "bump")
+        util.run_cli(*args)
     out, _ = capsys.readouterr()
     assert __version__ in out
 

--- a/tests/test_cli/test_invalid_command_py_3_10___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_10___invalid_arg_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
 cz: error: the following arguments are required: {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_invalid_command_py_3_10___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_10___invalid_arg_.txt
@@ -1,5 +1,0 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
-          [--report]
-          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
-          ...
-cz: error: the following arguments are required: {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_invalid_command_py_3_10___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_10___invalid_arg_.txt
@@ -1,0 +1,5 @@
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
+          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
+          ...
+cz: error: unrecognized arguments: --invalid-arg

--- a/tests/test_cli/test_invalid_command_py_3_10_invalidCommand_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_10_invalidCommand_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
 cz: error: argument {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}: invalid choice: 'invalidCommand' (choose from 'init', 'commit', 'c', 'ls', 'example', 'info', 'schema', 'bump', 'changelog', 'ch', 'check', 'version')

--- a/tests/test_cli/test_invalid_command_py_3_11___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_11___invalid_arg_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
 cz: error: the following arguments are required: {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_invalid_command_py_3_11___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_11___invalid_arg_.txt
@@ -1,5 +1,0 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
-          [--report]
-          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
-          ...
-cz: error: the following arguments are required: {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_invalid_command_py_3_11___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_11___invalid_arg_.txt
@@ -1,0 +1,5 @@
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
+          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
+          ...
+cz: error: unrecognized arguments: --invalid-arg

--- a/tests/test_cli/test_invalid_command_py_3_11_invalidCommand_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_11_invalidCommand_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
 cz: error: argument {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}: invalid choice: 'invalidCommand' (choose from 'init', 'commit', 'c', 'ls', 'example', 'info', 'schema', 'bump', 'changelog', 'ch', 'check', 'version')

--- a/tests/test_cli/test_invalid_command_py_3_12___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_12___invalid_arg_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
 cz: error: the following arguments are required: {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_invalid_command_py_3_12___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_12___invalid_arg_.txt
@@ -1,5 +1,0 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
-          [--report]
-          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
-          ...
-cz: error: the following arguments are required: {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_invalid_command_py_3_12___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_12___invalid_arg_.txt
@@ -1,0 +1,5 @@
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
+          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
+          ...
+cz: error: unrecognized arguments: --invalid-arg

--- a/tests/test_cli/test_invalid_command_py_3_12_invalidCommand_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_12_invalidCommand_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
 cz: error: argument {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}: invalid choice: 'invalidCommand' (choose from init, commit, c, ls, example, info, schema, bump, changelog, ch, check, version)

--- a/tests/test_cli/test_invalid_command_py_3_13___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_13___invalid_arg_.txt
@@ -1,3 +1,4 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version} ...
 cz: error: the following arguments are required: {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_invalid_command_py_3_13___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_13___invalid_arg_.txt
@@ -1,4 +1,0 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
-          [--report]
-          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version} ...
-cz: error: the following arguments are required: {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_invalid_command_py_3_13___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_13___invalid_arg_.txt
@@ -1,0 +1,4 @@
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
+          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version} ...
+cz: error: unrecognized arguments: --invalid-arg

--- a/tests/test_cli/test_invalid_command_py_3_13_invalidCommand_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_13_invalidCommand_.txt
@@ -1,3 +1,4 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version} ...
 cz: error: argument {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}: invalid choice: 'invalidCommand' (choose from init, commit, c, ls, example, info, schema, bump, changelog, ch, check, version)

--- a/tests/test_cli/test_invalid_command_py_3_14___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_14___invalid_arg_.txt
@@ -1,3 +1,4 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version} ...
 cz: error: the following arguments are required: {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_invalid_command_py_3_14___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_14___invalid_arg_.txt
@@ -1,4 +1,0 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
-          [--report]
-          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version} ...
-cz: error: the following arguments are required: {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_invalid_command_py_3_14___invalid_arg_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_14___invalid_arg_.txt
@@ -1,0 +1,4 @@
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
+          {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version} ...
+cz: error: unrecognized arguments: --invalid-arg

--- a/tests/test_cli/test_invalid_command_py_3_14_invalidCommand_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_14_invalidCommand_.txt
@@ -1,3 +1,4 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version} ...
 cz: error: argument {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}: invalid choice: 'invalidCommand' (choose from init, commit, c, ls, example, info, schema, bump, changelog, ch, check, version)

--- a/tests/test_cli/test_no_argv_py_3_10_.txt
+++ b/tests/test_cli/test_no_argv_py_3_10_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
 
@@ -16,6 +17,8 @@ options:
                         e.g., cz -nr 1,2,3 bump. See codes at
                         https://commitizen-
                         tools.github.io/commitizen/exit_codes/
+  -v, --version         Show the version of the installed commitizen
+  --report              Show system information for reporting bugs
 
 commands:
   {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_no_argv_py_3_11_.txt
+++ b/tests/test_cli/test_no_argv_py_3_11_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
 
@@ -16,6 +17,8 @@ options:
                         e.g., cz -nr 1,2,3 bump. See codes at
                         https://commitizen-
                         tools.github.io/commitizen/exit_codes/
+  -v, --version         Show the version of the installed commitizen
+  --report              Show system information for reporting bugs
 
 commands:
   {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_no_argv_py_3_12_.txt
+++ b/tests/test_cli/test_no_argv_py_3_12_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
 
@@ -16,6 +17,8 @@ options:
                         e.g., cz -nr 1,2,3 bump. See codes at
                         https://commitizen-
                         tools.github.io/commitizen/exit_codes/
+  -v, --version         Show the version of the installed commitizen
+  --report              Show system information for reporting bugs
 
 commands:
   {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_no_argv_py_3_13_.txt
+++ b/tests/test_cli/test_no_argv_py_3_13_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version} ...
 
 Commitizen is a powerful release management tool that helps teams maintain consistent and meaningful commit messages while automating version management.
@@ -15,6 +16,8 @@ options:
                         e.g., cz -nr 1,2,3 bump. See codes at
                         https://commitizen-
                         tools.github.io/commitizen/exit_codes/
+  -v, --version         Show the version of the installed commitizen
+  --report              Show system information for reporting bugs
 
 commands:
   {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}

--- a/tests/test_cli/test_no_argv_py_3_14_.txt
+++ b/tests/test_cli/test_no_argv_py_3_14_.txt
@@ -1,4 +1,5 @@
-usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
+usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE] [-v]
+          [--report]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version} ...
 
 Commitizen is a powerful release management tool that helps teams maintain consistent and meaningful commit messages while automating version management.
@@ -15,6 +16,8 @@ options:
                         e.g., cz -nr 1,2,3 bump. See codes at
                         https://commitizen-
                         tools.github.io/commitizen/exit_codes/
+  -v, --version         Show the version of the installed commitizen
+  --report              Show system information for reporting bugs
 
 commands:
   {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}


### PR DESCRIPTION
## Description

Currently, all of `cz version`, `cz version --commitizen`, and `cz version --report` print the installed Commitizen version / system info. As we extend `cz version` to also report the **project** version (see #1785), it makes sense to extract those two installed-Commitizen / bug-report concerns out of the `version` subcommand and back into top-level flags:

- `cz --version` / `cz -v` — print the installed Commitizen version and exit.
- `cz --report` — print Commitizen version, Python version, and OS, intended for bug reports, and exit.

The corresponding subcommand options are kept and emit a `DeprecationWarning` pointing at the new flags; they will be removed in v5.

Closes part of #1785.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: GitHub Copilot following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained (`cz version --commitizen` / `cz version --report` keep working with deprecation warnings)
  - [x] Document any manual testing steps performed (see below)
- [x] Update the documentation for the changes

### Documentation Changes

- [x] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [x] Check and fix any broken links (internal or external)

## Expected Behavior

| Invocation | Behavior |
| --- | --- |
| `cz --version` / `cz -v` | Print installed Commitizen version. Takes precedence over any subcommand. |
| `cz --report` | Print Commitizen version, Python version, OS. Only takes effect when no subcommand is given. |
| `cz --report version` | Runs the `version` subcommand (top-level `--report` is a "no subcommand" flag — kept simple by design). |
| `cz version --commitizen` | Still works, emits `DeprecationWarning` pointing at `cz --version`. |
| `cz version --report` | Still works, emits `DeprecationWarning` pointing at `cz --report`. |
| `cz --invalid-arg` | Errors with argparse `unrecognized arguments: --invalid-arg` (previously silently fell through). |
| `cz` (no args) | Prints help — unchanged. |
| `cz invalidCommand` | argparse `invalid choice` error — unchanged. |

## Steps to Test This Pull Request

```bash
uv sync --frozen --group base --group test --group linters

# New top-level flags
uv run cz --version
uv run cz -v
uv run cz --report

# Deprecated subcommand flags still work
uv run cz version --commitizen   # emits DeprecationWarning
uv run cz version --report       # emits DeprecationWarning

# Unknown args now error properly
uv run cz --invalid-arg          # exits 13, prints argparse usage + "unrecognized arguments"

# Regression tests
uv run pytest tests/test_cli.py tests/commands/test_version_command.py
uv run poe lint
```

## Additional Context

Related: #1785.

Reviewer feedback addressed in this PR:
- Empty `tests/test_cli/test_invalid_command_py_*___invalid_arg_.txt` baselines were a side effect of changing `subcommands.required` to `False` (needed so the new top-level flags work without a subcommand). `parse_known_args()` then silently swallowed `--invalid-arg`. Fixed by re-running `parser.parse_args()` when there is no subcommand and unknown args are present, so argparse's `unrecognized arguments` error reaches stderr; baselines regenerated for Python 3.10–3.14.
- The earlier suggestion to make `cz --report version` route to the top-level `--report` was intentionally left as-is: `--report` stays a simple "no subcommand" flag (per @woile's note: existing `cz version --*` options are kept until all the new features are out, then removed in v5).
