### PR TITLE
test: remove unreachable code in pytest.raises block, fix some malformed tests, extract fixtures

### DIFF
--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+from pytest_mock import MockerFixture
 
 from commitizen import defaults
 from commitizen.config import BaseConfig
@@ -52,3 +53,8 @@ def changelog_path() -> str:
 @pytest.fixture()
 def config_path() -> str:
     return os.path.join(os.getcwd(), "pyproject.toml")
+
+
+@pytest.fixture()
+def success_mock(mocker: MockerFixture):
+    return mocker.patch("commitizen.out.success")

--- a/tests/test_cz_customize.py
+++ b/tests/test_cz_customize.py
@@ -376,9 +376,9 @@ def config_with_unicode(request):
 
 
 def test_initialize_cz_customize_failed():
+    config = BaseConfig()
     with pytest.raises(MissingCzCustomizeConfigError) as excinfo:
-        config = BaseConfig()
-        _ = CustomizeCommitsCz(config)
+        CustomizeCommitsCz(config)
 
     assert MissingCzCustomizeConfigError.message in str(excinfo.value)
 


### PR DESCRIPTION
# Why

`with pytest.raises` block should contain only one statement which we expect it to throw exceptions.

# Changes made

- Removed unreachable code in tests
- Fixed `test_check_command_cli_overrides_config_message_length_limit`. The last `check_cmd` assignment had no effect.
- Extracted `success_mock` and `commit_mock`