### PR TITLE
fix(config): include pyproject.toml in multi config file warning

### DIFF
--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -14,7 +14,7 @@ from commitizen.config.toml_config import TomlConfig
 from commitizen.config.yaml_config import YAMLConfig
 from commitizen.exceptions import ConfigFileIsEmpty, InvalidConfigurationError
 
-PYPROJECT = """
+TOML_STR = """
 [tool.commitizen]
 name = "cz_jira"
 version = "1.0.0"
@@ -30,11 +30,16 @@ pre_bump_hooks = [
     "scripts/generate_documentation.sh"
 ]
 post_bump_hooks = ["scripts/slack_notification.sh"]
+"""
+
+PYPROJECT = f"""
+{TOML_STR}
 
 [tool.black]
 line-length = 88
 target-version = ['py36', 'py37', 'py38']
 """
+
 
 DICT_CONFIG = {
     "commitizen": {
@@ -198,7 +203,7 @@ class TestReadCfg:
             p = tmpdir.join("pyproject.toml")
             p.write("")
             p = tmpdir.join(".cz.toml")
-            p.write(PYPROJECT)
+            p.write(TOML_STR)
 
             cfg = config.read_cfg()
             assert cfg.settings == _settings
@@ -240,27 +245,25 @@ class TestReadCfg:
 
 class TestWarnMultipleConfigFiles:
     @pytest.mark.parametrize(
-        "files,expected_path,should_warn",
+        "files,expected_path",
         [
             # Same directory, different file types
-            ([(".cz.toml", PYPROJECT), (".cz.json", JSON_STR)], ".cz.toml", True),
-            ([(".cz.json", JSON_STR), (".cz.yaml", YAML_STR)], ".cz.json", True),
-            ([(".cz.toml", PYPROJECT), (".cz.yaml", YAML_STR)], ".cz.toml", True),
-            # With pyproject.toml (excluded from warning)
+            ([(".cz.toml", TOML_STR), (".cz.json", JSON_STR)], ".cz.toml"),
+            ([(".cz.json", JSON_STR), (".cz.yaml", YAML_STR)], ".cz.json"),
+            ([(".cz.toml", TOML_STR), (".cz.yaml", YAML_STR)], ".cz.toml"),
+            # With pyproject.toml
             (
                 [("pyproject.toml", PYPROJECT), (".cz.json", JSON_STR)],
                 ".cz.json",
-                False,
             ),
             (
-                [("pyproject.toml", PYPROJECT), (".cz.toml", PYPROJECT)],
+                [("pyproject.toml", PYPROJECT), (".cz.toml", TOML_STR)],
                 ".cz.toml",
-                False,
             ),
         ],
     )
     def test_warn_multiple_config_files_same_dir(
-        self, tmpdir, capsys, files, expected_path, should_warn
+        self, tmpdir, capsys, files, expected_path
     ):
         """Test warning when multiple config files exist in same directory."""
         with tmpdir.as_cwd():
@@ -270,27 +273,20 @@ class TestWarnMultipleConfigFiles:
             cfg = config.read_cfg()
             captured = capsys.readouterr()
 
-            if should_warn:
-                assert "Multiple config files detected" in captured.err
-                assert "Using" in captured.err
-                for filename, _ in files:
-                    if filename != "pyproject.toml":
-                        assert filename in captured.err
-            else:
-                assert "Multiple config files detected" not in captured.err
+            assert "Multiple config files detected" in captured.err
+            for filename, _ in files:
+                assert filename in captured.err
+            assert f"Using config file: '{expected_path}'" in captured.err
 
             assert cfg.path == Path(expected_path)
-            # Verify config loaded correctly (name and version match expected)
-            assert cfg.settings["name"] == "cz_jira"
-            assert cfg.settings["version"] == "1.0.0"
 
     @pytest.mark.parametrize(
         "config_file,content",
         [
             (".cz.json", JSON_STR),
-            (".cz.toml", PYPROJECT),
+            (".cz.toml", TOML_STR),
             (".cz.yaml", YAML_STR),
-            ("cz.toml", PYPROJECT),
+            ("cz.toml", TOML_STR),
             ("cz.json", JSON_STR),
             ("cz.yaml", YAML_STR),
         ],
@@ -340,11 +336,11 @@ class TestWarnMultipleConfigFiles:
         [
             (file, content, with_git)
             for file, content in [
-                (".cz.toml", PYPROJECT),
+                (".cz.toml", TOML_STR),
                 (".cz.json", JSON_STR),
                 (".cz.yaml", YAML_STR),
                 ("pyproject.toml", PYPROJECT),
-                ("cz.toml", PYPROJECT),
+                ("cz.toml", TOML_STR),
                 ("cz.json", JSON_STR),
                 ("cz.yaml", YAML_STR),
             ]
@@ -367,6 +363,18 @@ class TestWarnMultipleConfigFiles:
             # No warning should be issued
             assert "Multiple config files detected" not in captured.err
             assert cfg.path == Path(config_file)
+
+    def test_no_warn_with_no_commitizen_section_in_pyproject_toml_and_cz_toml(
+        self, tmpdir, capsys
+    ):
+        with tmpdir.as_cwd():
+            tmpdir.join("pyproject.toml").write("[tool.foo]\nbar = 'baz'")
+            tmpdir.join(".cz.toml").write(TOML_STR)
+
+            cfg = config.read_cfg()
+            captured = capsys.readouterr()
+            assert "Multiple config files detected" not in captured.err
+            assert cfg.path == Path(".cz.toml")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I just remembered that we already have a feature that detects if a configuration file is valid. We can include pyproject.toml in the multi config warning.

Relate #1702 

Also added a test to ensure that no warning when there are both pyproject.toml (without cz settings section) and cz.toml