### PR TITLE
test(commit): extract fixtures to dedup logic in tests

### DIFF
--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -22,15 +22,29 @@ from commitizen.exceptions import (
 
 @pytest.fixture
 def commit_mock(mocker: MockFixture):
-    commit_mock = mocker.patch("commitizen.git.commit")
-    commit_mock.return_value = cmd.Command("success", "", b"", b"", 0)
-    return commit_mock
+    return mocker.patch(
+        "commitizen.git.commit", return_value=cmd.Command("success", "", b"", b"", 0)
+    )
+
+
+@pytest.fixture
+def prompt_mock_feat(mocker: MockFixture):
+    return mocker.patch(
+        "questionary.prompt",
+        return_value={
+            "prefix": "feat",
+            "subject": "user created",
+            "scope": "",
+            "is_breaking_change": False,
+            "body": "closes #21",
+            "footer": "",
+        },
+    )
 
 
 @pytest.fixture
 def staging_is_clean(mocker: MockFixture, tmp_git_project):
-    is_staging_clean_mock = mocker.patch("commitizen.git.is_staging_clean")
-    is_staging_clean_mock.return_value = False
+    mocker.patch("commitizen.git.is_staging_clean", return_value=False)
     return tmp_git_project
 
 
@@ -40,36 +54,18 @@ def backup_file(tmp_git_project):
         backup_file.write("backup commit")
 
 
-@pytest.mark.usefixtures("staging_is_clean", "commit_mock")
-def test_commit(config, success_mock: MockType, mocker: MockFixture):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "",
-        "footer": "",
-    }
-
+@pytest.mark.usefixtures("staging_is_clean", "commit_mock", "prompt_mock_feat")
+def test_commit(config, success_mock: MockType):
     commands.Commit(config, {})()
     success_mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_backup_on_failure(config, mocker: MockFixture):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "closes #21",
-        "footer": "",
-    }
-
-    mocker.patch("commitizen.git.commit").return_value = cmd.Command(
-        "", "error", b"", b"", 9
+def test_commit_backup_on_failure(
+    config, mocker: MockFixture, prompt_mock_feat: MockType
+):
+    mocker.patch(
+        "commitizen.git.commit", return_value=cmd.Command("", "error", b"", b"", 9)
     )
     error_mock = mocker.patch("commitizen.out.error")
 
@@ -78,7 +74,7 @@ def test_commit_backup_on_failure(config, mocker: MockFixture):
     with pytest.raises(CommitError):
         commit_cmd()
 
-    prompt_mock.assert_called_once()
+    prompt_mock_feat.assert_called_once()
     error_mock.assert_called_once()
     assert os.path.isfile(temp_file)
 
@@ -109,23 +105,13 @@ def test_commit_retry_works(
 
 @pytest.mark.usefixtures("staging_is_clean")
 def test_commit_retry_after_failure_no_backup(
-    config, success_mock: MockType, mocker: MockFixture, commit_mock: MockType
+    config, success_mock: MockType, commit_mock: MockType, prompt_mock_feat: MockType
 ):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "closes #21",
-        "footer": "",
-    }
-
     config.settings["retry_after_failure"] = True
     commands.Commit(config, {})()
 
     commit_mock.assert_called_with("feat: user created\n\ncloses #21", args="")
-    prompt_mock.assert_called_once()
+    prompt_mock_feat.assert_called_once()
     success_mock.assert_called_once()
 
 
@@ -148,119 +134,56 @@ def test_commit_retry_after_failure_works(
 
 @pytest.mark.usefixtures("staging_is_clean", "backup_file")
 def test_commit_retry_after_failure_with_no_retry_works(
-    config, success_mock: MockType, mocker: MockFixture, commit_mock: MockType
+    config, success_mock: MockType, commit_mock: MockType, prompt_mock_feat: MockType
 ):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "closes #21",
-        "footer": "",
-    }
-
     config.settings["retry_after_failure"] = True
     commit_cmd = commands.Commit(config, {"no_retry": True})
     temp_file = commit_cmd.backup_file_path
     commit_cmd()
 
     commit_mock.assert_called_with("feat: user created\n\ncloses #21", args="")
-    prompt_mock.assert_called_once()
+    prompt_mock_feat.assert_called_once()
     success_mock.assert_called_once()
     assert not os.path.isfile(temp_file)
 
 
-@pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_with_dry_run_option(config, mocker: MockFixture):
-    prompt_mock = mocker = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "closes #57",
-        "footer": "",
-    }
-
+@pytest.mark.usefixtures("staging_is_clean", "prompt_mock_feat")
+def test_commit_command_with_dry_run_option(config):
     with pytest.raises(DryRunExit):
         commands.Commit(config, {"dry_run": True})()
 
 
-@pytest.mark.usefixtures("staging_is_clean", "commit_mock")
+@pytest.mark.usefixtures("staging_is_clean", "commit_mock", "prompt_mock_feat")
 def test_commit_command_with_write_message_to_file_option(
-    config, tmp_path, success_mock: MockType, mocker: MockFixture
+    config, tmp_path, success_mock: MockType
 ):
     tmp_file = tmp_path / "message"
-
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "",
-        "footer": "",
-    }
-
     commands.Commit(config, {"write_message_to_file": tmp_file})()
     success_mock.assert_called_once()
     assert tmp_file.exists()
-    assert tmp_file.read_text() == "feat: user created"
+    assert "feat: user created" in tmp_file.read_text()
 
 
-@pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_with_invalid_write_message_to_file_option(
-    config, tmp_path, mocker: MockFixture
-):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "",
-        "footer": "",
-    }
-
+@pytest.mark.usefixtures("staging_is_clean", "prompt_mock_feat")
+def test_commit_command_with_invalid_write_message_to_file_option(config, tmp_path):
     with pytest.raises(NotAllowed):
         commands.Commit(config, {"write_message_to_file": tmp_path})()
 
 
-@pytest.mark.usefixtures("staging_is_clean")
+@pytest.mark.usefixtures("staging_is_clean", "prompt_mock_feat")
 def test_commit_command_with_signoff_option(
-    config, success_mock: MockType, mocker: MockFixture, commit_mock: MockType
+    config, success_mock: MockType, commit_mock: MockType
 ):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "",
-        "footer": "",
-    }
-
     commands.Commit(config, {"signoff": True})()
 
     commit_mock.assert_called_once_with(ANY, args="-s")
     success_mock.assert_called_once()
 
 
-@pytest.mark.usefixtures("staging_is_clean")
+@pytest.mark.usefixtures("staging_is_clean", "prompt_mock_feat")
 def test_commit_command_with_always_signoff_enabled(
-    config, success_mock: MockType, mocker: MockFixture, commit_mock: MockType
+    config, success_mock: MockType, commit_mock: MockType
 ):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "",
-        "footer": "",
-    }
-
     config.settings["always_signoff"] = True
     commands.Commit(config, {})()
 
@@ -268,20 +191,10 @@ def test_commit_command_with_always_signoff_enabled(
     success_mock.assert_called_once()
 
 
-@pytest.mark.usefixtures("staging_is_clean")
+@pytest.mark.usefixtures("staging_is_clean", "prompt_mock_feat")
 def test_commit_command_with_gpgsign_and_always_signoff_enabled(
-    config, success_mock: MockType, mocker: MockFixture, commit_mock: MockType
+    config, success_mock: MockType, commit_mock: MockType
 ):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "",
-        "footer": "",
-    }
-
     config.settings["always_signoff"] = True
     commands.Commit(config, {"extra_cli_args": "-S"})()
 
@@ -291,8 +204,7 @@ def test_commit_command_with_gpgsign_and_always_signoff_enabled(
 
 @pytest.mark.usefixtures("tmp_git_project")
 def test_commit_when_nothing_to_commit(config, mocker: MockFixture):
-    is_staging_clean_mock = mocker.patch("commitizen.git.is_staging_clean")
-    is_staging_clean_mock.return_value = True
+    mocker.patch("commitizen.git.is_staging_clean", return_value=True)
 
     with pytest.raises(NothingToCommitError) as excinfo:
         commands.Commit(config, {})()
@@ -300,42 +212,19 @@ def test_commit_when_nothing_to_commit(config, mocker: MockFixture):
     assert "No files added to staging!" in str(excinfo.value)
 
 
-@pytest.mark.usefixtures("staging_is_clean")
-def test_commit_with_allow_empty(
-    config, success_mock: MockType, mocker: MockFixture, commit_mock: MockType
-):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "closes #21",
-        "footer": "",
-    }
-
+@pytest.mark.usefixtures("staging_is_clean", "prompt_mock_feat")
+def test_commit_with_allow_empty(config, success_mock: MockType, commit_mock: MockType):
     commands.Commit(config, {"extra_cli_args": "--allow-empty"})()
-
     commit_mock.assert_called_with(
         "feat: user created\n\ncloses #21", args="--allow-empty"
     )
     success_mock.assert_called_once()
 
 
-@pytest.mark.usefixtures("staging_is_clean")
+@pytest.mark.usefixtures("staging_is_clean", "prompt_mock_feat")
 def test_commit_with_signoff_and_allow_empty(
-    config, success_mock: MockType, mocker: MockFixture, commit_mock: MockType
+    config, success_mock: MockType, commit_mock: MockType
 ):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "closes #21",
-        "footer": "",
-    }
-
     config.settings["always_signoff"] = True
     commands.Commit(config, {"extra_cli_args": "--allow-empty"})()
 
@@ -346,12 +235,10 @@ def test_commit_with_signoff_and_allow_empty(
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_when_customized_expected_raised(config, mocker: MockFixture, capsys):
+def test_commit_when_customized_expected_raised(config, mocker: MockFixture):
     _err = ValueError()
     _err.__context__ = CzException("This is the root custom err")
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.side_effect = _err
-
+    mocker.patch("questionary.prompt", side_effect=_err)
     with pytest.raises(CustomError) as excinfo:
         commands.Commit(config, {})()
 
@@ -360,22 +247,15 @@ def test_commit_when_customized_expected_raised(config, mocker: MockFixture, cap
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_when_non_customized_expected_raised(
-    config, mocker: MockFixture, capsys
-):
-    _err = ValueError()
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.side_effect = _err
-
+def test_commit_when_non_customized_expected_raised(config, mocker: MockFixture):
+    mocker.patch("questionary.prompt", side_effect=ValueError())
     with pytest.raises(ValueError):
         commands.Commit(config, {})()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
-def test_commit_when_no_user_answer(config, mocker: MockFixture, capsys):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = None
-
+def test_commit_when_no_user_answer(config, mocker: MockFixture):
+    mocker.patch("questionary.prompt", return_value=None)
     with pytest.raises(NoAnswersError):
         commands.Commit(config, {})()
 
@@ -386,67 +266,23 @@ def test_commit_in_non_git_project(tmpdir, config):
             commands.Commit(config, {})
 
 
-@pytest.mark.usefixtures("staging_is_clean", "commit_mock")
+@pytest.mark.usefixtures("staging_is_clean", "commit_mock", "prompt_mock_feat")
 def test_commit_command_with_all_option(
     config, success_mock: MockType, mocker: MockFixture
 ):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "",
-        "footer": "",
-    }
-
     add_mock = mocker.patch("commitizen.git.add")
     commands.Commit(config, {"all": True})()
     add_mock.assert_called()
     success_mock.assert_called_once()
 
 
-@pytest.mark.usefixtures("staging_is_clean")
+@pytest.mark.usefixtures("staging_is_clean", "prompt_mock_feat")
 def test_commit_command_with_extra_args(
-    config, success_mock: MockType, mocker: MockFixture, commit_mock: MockType
+    config, success_mock: MockType, commit_mock: MockType
 ):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "",
-        "footer": "",
-    }
-
     commands.Commit(config, {"extra_cli_args": "-- -extra-args1 -extra-arg2"})()
     commit_mock.assert_called_once_with(ANY, args="-- -extra-args1 -extra-arg2")
     success_mock.assert_called_once()
-
-
-@pytest.mark.usefixtures("staging_is_clean", "commit_mock")
-def test_commit_command_with_message_length_limit(
-    config, success_mock: MockType, mocker: MockFixture
-):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prefix = "feat"
-    subject = "random subject"
-    message_length = len(prefix) + len(": ") + len(subject)
-    prompt_mock.return_value = {
-        "prefix": prefix,
-        "subject": subject,
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "random body",
-        "footer": "random footer",
-    }
-
-    commands.Commit(config, {"message_length_limit": message_length})()
-    success_mock.assert_called_once()
-
-    with pytest.raises(CommitMessageLengthExceededError):
-        commands.Commit(config, {"message_length_limit": message_length - 1})()
 
 
 @pytest.mark.usefixtures("staging_is_clean")
@@ -475,28 +311,20 @@ def test_manual_edit(editor, config, mocker: MockFixture, tmp_path):
         assert edited_message == test_message.strip()
 
 
-@pytest.mark.usefixtures("staging_is_clean")
+@pytest.mark.usefixtures("staging_is_clean", "prompt_mock_feat")
 @pytest.mark.parametrize(
     "out", ["no changes added to commit", "nothing added to commit"]
 )
 def test_commit_when_nothing_added_to_commit(config, mocker: MockFixture, out):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prompt_mock.return_value = {
-        "prefix": "feat",
-        "subject": "user created",
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "",
-        "footer": "",
-    }
-
-    commit_mock = mocker.patch("commitizen.git.commit")
-    commit_mock.return_value = cmd.Command(
-        out=out,
-        err="",
-        stdout=out.encode(),
-        stderr=b"",
-        return_code=0,
+    commit_mock = mocker.patch(
+        "commitizen.git.commit",
+        return_value=cmd.Command(
+            out=out,
+            err="",
+            stdout=out.encode(),
+            stderr=b"",
+            return_code=0,
+        ),
     )
     error_mock = mocker.patch("commitizen.out.error")
 
@@ -508,22 +336,20 @@ def test_commit_when_nothing_added_to_commit(config, mocker: MockFixture, out):
 
 @pytest.mark.usefixtures("staging_is_clean", "commit_mock")
 def test_commit_command_with_config_message_length_limit(
-    config, success_mock: MockType, mocker: MockFixture
+    config, success_mock: MockType, prompt_mock_feat: MockType
 ):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prefix = "feat"
-    subject = "random subject"
-    message_length = len(prefix) + len(": ") + len(subject)
-    prompt_mock.return_value = {
-        "prefix": prefix,
-        "subject": subject,
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "random body",
-        "footer": "random footer",
-    }
+    prefix = prompt_mock_feat.return_value["prefix"]
+    subject = prompt_mock_feat.return_value["subject"]
+    message_length = len(f"{prefix}: {subject}")
+
+    commands.Commit(config, {"message_length_limit": message_length})()
+    success_mock.assert_called_once()
+
+    with pytest.raises(CommitMessageLengthExceededError):
+        commands.Commit(config, {"message_length_limit": message_length - 1})()
 
     config.settings["message_length_limit"] = message_length
+    success_mock.reset_mock()
     commands.Commit(config, {})()
     success_mock.assert_called_once()
 
@@ -531,26 +357,8 @@ def test_commit_command_with_config_message_length_limit(
     with pytest.raises(CommitMessageLengthExceededError):
         commands.Commit(config, {})()
 
-
-@pytest.mark.usefixtures("staging_is_clean")
-def test_commit_command_cli_overrides_config_message_length_limit(
-    config, success_mock: MockType, mocker: MockFixture, commit_mock: MockType
-):
-    prompt_mock = mocker.patch("questionary.prompt")
-    prefix = "feat"
-    subject = "random subject"
-    message_length = len(prefix) + len(": ") + len(subject)
-    prompt_mock.return_value = {
-        "prefix": prefix,
-        "subject": subject,
-        "scope": "",
-        "is_breaking_change": False,
-        "body": "random body",
-        "footer": "random footer",
-    }
-
-    config.settings["message_length_limit"] = message_length - 1
-
+    # Test config message length limit is overridden by CLI argument
+    success_mock.reset_mock()
     commands.Commit(config, {"message_length_limit": message_length})()
     success_mock.assert_called_once()
 


### PR DESCRIPTION
## Changes made

- Extract `prompt_mock`
- Merge `message_length` related tests into one