### PR TITLE
fix(message_length_limit): align the behavior of message_length_limit

### DIFF
--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -20,7 +20,7 @@ class CheckArgs(TypedDict, total=False):
     commit_msg: str
     rev_range: str
     allow_abort: bool
-    message_length_limit: int | None
+    message_length_limit: int
     allowed_prefixes: list[str]
     message: str
     use_default_range: bool
@@ -46,7 +46,7 @@ class Check:
 
         self.use_default_range = bool(arguments.get("use_default_range"))
         self.max_msg_length = arguments.get(
-            "message_length_limit", config.settings.get("message_length_limit", None)
+            "message_length_limit", config.settings.get("message_length_limit", 0)
         )
 
         # we need to distinguish between None and [], which is a valid value

--- a/commitizen/cz/base.py
+++ b/commitizen/cz/base.py
@@ -130,7 +130,7 @@ class BaseCommitizen(metaclass=ABCMeta):
         if any(map(commit_msg.startswith, allowed_prefixes)):
             return ValidationResult(True, [])
 
-        if max_msg_length is not None:
+        if max_msg_length is not None and max_msg_length > 0:
             msg_len = len(commit_msg.partition("\n")[0].strip())
             if msg_len > max_msg_length:
                 # TODO: capitalize the first letter of the error message for consistency in v5

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -48,7 +48,7 @@ class Settings(TypedDict, total=False):
     ignored_tag_formats: Sequence[str]
     legacy_tag_formats: Sequence[str]
     major_version_zero: bool
-    message_length_limit: int | None
+    message_length_limit: int
     name: str
     post_bump_hooks: list[str] | None
     pre_bump_hooks: list[str] | None
@@ -114,7 +114,7 @@ DEFAULT_SETTINGS: Settings = {
     "template": None,  # default provided by plugin
     "extras": {},
     "breaking_change_exclamation_in_title": False,
-    "message_length_limit": None,  # None for no limit
+    "message_length_limit": 0,  # 0 for no limit
 }
 
 MAJOR = "MAJOR"

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -363,5 +363,5 @@ def test_commit_command_with_config_message_length_limit(
     success_mock.assert_called_once()
 
     success_mock.reset_mock()
-    commands.Commit(config, {"message_length_limit": None})()
+    commands.Commit(config, {"message_length_limit": 0})()
     success_mock.assert_called_once()

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -106,7 +106,7 @@ _settings: dict[str, Any] = {
     "template": None,
     "extras": {},
     "breaking_change_exclamation_in_title": False,
-    "message_length_limit": None,
+    "message_length_limit": 0,
 }
 
 _new_settings: dict[str, Any] = {
@@ -146,7 +146,7 @@ _new_settings: dict[str, Any] = {
     "template": None,
     "extras": {},
     "breaking_change_exclamation_in_title": False,
-    "message_length_limit": None,
+    "message_length_limit": 0,
 }
 
 


### PR DESCRIPTION
The document says 0 is no limit

Also, in `test_check_command.py`, there is no need to copy and paste the function from its base class.