### PR TITLE
fix(pre-commit-hooks): remove magic constants on pre-push hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -19,7 +19,7 @@
     the fact (e.g., pre-push or in CI) without an expensive check of the entire
     repository history.
   entry: cz check
-  args: ["--rev-range", "$PRE_COMMIT_TO_REF $PRE_COMMIT_FROM_REF"]
+  args: [--rev-range, "$PRE_COMMIT_TO_REF $PRE_COMMIT_FROM_REF"]
   always_run: true
   pass_filenames: false
   language: python


### PR DESCRIPTION
## Description

 - Remove static reference to origin (work with other name)
 - Now work when remote/HEAD isn't setted (e.g. on `git init .; git remote add origin git@...`)

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes

- [x] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [x] Check and fix any broken links (internal or external) in the documentation

> When running `uv run poe doc`, any broken internal documentation links will be reported in the console output like this:
>
> ```text
> INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
> ```

## Expected Behavior

 - Expected it's work out-of-the-box, including when origin/HEAD isn't set (e.g. repository created by `git init`)
 - Expected the name of remote (usually `origin`) isn't hard coded (or isn't to set in configuration file)


## Steps to Test This Pull Request

1. `git init test-repo`
2. create empty repo in github or anything else
3. `cz init`
4. `pre-commit install --hook-type commit-msg --hook-type pre-push`
5. `git init && git add . && git commit -m "feat: well formed commit message"`
6. `git remote add github_origin https://github.com/<some repo>.git`
7. `git push -u github_origin main`


## Additional Context

 - No information found in document about previous behavior → no change in docs
 - It's applied for any user run `pre-commit autoupdate` including if commitizen isn't updated (when new release published)

FIX #704 
