### PR TITLE
feat(version): add --tag for version command

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -553,6 +553,12 @@ data = {
                         "action": "store_true",
                         "exclusive_group": "group2",
                     },
+                    {
+                        "name": ["--tag"],
+                        "help": "get the version with tag prefix. Need to be used with --project or --verbose.",
+                        "action": "store_true",
+                        "exclusive_group": "group2",
+                    },
                 ],
             },
         ],

--- a/commitizen/commands/version.py
+++ b/commitizen/commands/version.py
@@ -7,6 +7,7 @@ from commitizen.__version__ import __version__
 from commitizen.config import BaseConfig
 from commitizen.exceptions import NoVersionSpecifiedError, VersionSchemeUnknown
 from commitizen.providers import get_provider
+from commitizen.tags import TagRules
 from commitizen.version_schemes import get_version_scheme
 
 
@@ -17,6 +18,7 @@ class VersionArgs(TypedDict, total=False):
     verbose: bool
     major: bool
     minor: bool
+    tag: bool
 
 
 class Version:
@@ -59,6 +61,9 @@ class Version:
                 version = f"{version_scheme.major}"
             elif self.arguments.get("minor"):
                 version = f"{version_scheme.minor}"
+            elif self.arguments.get("tag"):
+                tag_rules = TagRules.from_settings(self.config.settings)
+                version = tag_rules.normalize_tag(version_scheme)
 
             out.write(
                 f"Project Version: {version}"
@@ -71,6 +76,10 @@ class Version:
             out.error(
                 "Major or minor version can only be used with --project or --verbose."
             )
+            return
+
+        if self.arguments.get("tag"):
+            out.error("Tag can only be used with --project or --verbose.")
             return
 
         # If no arguments are provided, just show the installed commitizen version

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_10_version_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_10_version_.txt
@@ -1,4 +1,4 @@
-usage: cz version [-h] [-r | -p | -c | -v] [--major | --minor]
+usage: cz version [-h] [-r | -p | -c | -v] [--major | --minor | --tag]
 
 get the version of the installed commitizen or the current project (default:
 installed commitizen)
@@ -14,3 +14,5 @@ options:
                     or --verbose.
   --minor           get just the minor version. Need to be used with --project
                     or --verbose.
+  --tag             get the version with tag prefix. Need to be used with
+                    --project or --verbose.

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_11_version_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_11_version_.txt
@@ -1,4 +1,4 @@
-usage: cz version [-h] [-r | -p | -c | -v] [--major | --minor]
+usage: cz version [-h] [-r | -p | -c | -v] [--major | --minor | --tag]
 
 get the version of the installed commitizen or the current project (default:
 installed commitizen)
@@ -14,3 +14,5 @@ options:
                     or --verbose.
   --minor           get just the minor version. Need to be used with --project
                     or --verbose.
+  --tag             get the version with tag prefix. Need to be used with
+                    --project or --verbose.

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_12_version_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_12_version_.txt
@@ -1,4 +1,4 @@
-usage: cz version [-h] [-r | -p | -c | -v] [--major | --minor]
+usage: cz version [-h] [-r | -p | -c | -v] [--major | --minor | --tag]
 
 get the version of the installed commitizen or the current project (default:
 installed commitizen)
@@ -14,3 +14,5 @@ options:
                     or --verbose.
   --minor           get just the minor version. Need to be used with --project
                     or --verbose.
+  --tag             get the version with tag prefix. Need to be used with
+                    --project or --verbose.

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_13_version_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_13_version_.txt
@@ -1,4 +1,4 @@
-usage: cz version [-h] [-r | -p | -c | -v] [--major | --minor]
+usage: cz version [-h] [-r | -p | -c | -v] [--major | --minor | --tag]
 
 get the version of the installed commitizen or the current project (default:
 installed commitizen)
@@ -14,3 +14,5 @@ options:
                     or --verbose.
   --minor           get just the minor version. Need to be used with --project
                     or --verbose.
+  --tag             get the version with tag prefix. Need to be used with
+                    --project or --verbose.

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_14_version_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_14_version_.txt
@@ -1,4 +1,4 @@
-usage: cz version [-h] [-r | -p | -c | -v] [--major | --minor]
+usage: cz version [-h] [-r | -p | -c | -v] [--major | --minor | --tag]
 
 get the version of the installed commitizen or the current project (default:
 installed commitizen)
@@ -14,3 +14,5 @@ options:
                     or --verbose.
   --minor           get just the minor version. Need to be used with --project
                     or --verbose.
+  --tag             get the version with tag prefix. Need to be used with
+                    --project or --verbose.

--- a/tests/commands/test_version_command.py
+++ b/tests/commands/test_version_command.py
@@ -161,3 +161,42 @@ def test_version_just_major_error_no_project(config, capsys, argument: str):
         "Major or minor version can only be used with --project or --verbose."
         in captured.err
     )
+
+
+@pytest.mark.parametrize(
+    "version, tag_format, expected_output",
+    [
+        ("1.2.3", "v$version", "v1.2.3\n"),
+        ("1.2.3", "$version", "1.2.3\n"),
+        ("2.0.0", "release-$version", "release-2.0.0\n"),
+        ("0.1.0", "ver$version", "ver0.1.0\n"),
+    ],
+)
+def test_version_with_tag_format(
+    config, capsys, version: str, tag_format: str, expected_output: str
+):
+    """Test --tag option applies tag_format to version"""
+    config.settings["version"] = version
+    config.settings["tag_format"] = tag_format
+    commands.Version(
+        config,
+        {
+            "project": True,
+            "tag": True,
+        },
+    )()
+    captured = capsys.readouterr()
+    assert captured.out == expected_output
+
+
+def test_version_tag_without_project_error(config, capsys):
+    """Test --tag requires --project or --verbose"""
+    commands.Version(
+        config,
+        {
+            "tag": True,
+        },
+    )()
+    captured = capsys.readouterr()
+    assert not captured.out
+    assert "Tag can only be used with --project or --verbose." in captured.err


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
Add --tag flag to `cz version` command to output version with
configured tag_format applied (e.g., v1.2.3 instead of 1.2.3).
- Add --tag option to CLI arguments
- Implement tag formatting using TagRules.normalize_tag()
- Add error handling for invalid option combinations
- Update tests to match new error messages

Closes #1765

## Checklist

- [o] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/)

### Code Changes

- [o] Add test cases to all the changes you introduce
- [o] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [o] Manually test the changes:
- [o] Verify the feature/bug fix works as expected in real-world scenarios
- [o] Test edge cases and error conditions
- [o] Ensure backward compatibility is maintained
- [x] Document any manual testing steps performed
- [x] Update the documentation for the changes

## Steps to Test This Pull Request
<!-- 
Steps to reproduce the behavior:
1. uv run cz version --tag -> should have error since didn't use -p
2. uv run cz version -p --tag -> should have tag prefix (e.g., v1.2.3 instead of 1.2.3)
3. uv run cz version -v --tag -> like major and minor. only change sec line's format
 -->


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
