### PR TITLE
fix: add pytest ruff rule PT and fix missing deprecation warning

### DIFF
--- a/commitizen/changelog_formats/__init__.py
+++ b/commitizen/changelog_formats/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from importlib import metadata
 from typing import TYPE_CHECKING, ClassVar, Protocol
 
@@ -99,5 +100,11 @@ def _guess_changelog_format(filename: str | None) -> type[ChangelogFormat] | Non
 
 def __getattr__(name: str) -> Callable[[str], type[ChangelogFormat] | None]:
     if name == "guess_changelog_format":
+        warnings.warn(
+            "guess_changelog_format is deprecated and will be removed in v5. "
+            "Use _guess_changelog_format instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return _guess_changelog_format
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,8 @@ select = [
     "RUF022",
     # unused-noqa
     "RUF100",
+    # flake8-pytest-style
+    "PT",
     # Checks for uses of the assert keyword.
     "S101",
     # flake8-type-checking (TC)
@@ -233,7 +235,16 @@ select = [
     "TC005",
     "TC006",
 ]
-ignore = ["E501", "D1", "D415"]
+ignore = [
+    "E501",
+    "D1",
+    "D415",
+    "PT006", # TODO(bearomorphism): enable this rule
+    "PT007", # TODO(bearomorphism): enable this rule
+    "PT011", # TODO(bearomorphism): enable this rule
+    "PT022", # TODO(bearomorphism): enable this rule
+    "PT030", # TODO(bearomorphism): enable this rule
+]
 extend-safe-fixes = [
     "TC", # Move imports inside/outside TYPE_CHECKING blocks
     "UP", # Update syntaxes for current Python version recommendations

--- a/tests/commands/test_init_command.py
+++ b/tests/commands/test_init_command.py
@@ -133,7 +133,7 @@ def pre_commit_installed(mocker: MockFixture):
     )
 
 
-@pytest.fixture(scope="function", params=["pyproject.toml", ".cz.json", ".cz.yaml"])
+@pytest.fixture(params=["pyproject.toml", ".cz.json", ".cz.yaml"])
 def default_choice(request, mocker: MockFixture):
     mocker.patch(
         "questionary.select",
@@ -150,7 +150,7 @@ def default_choice(request, mocker: MockFixture):
         "questionary.checkbox",
         return_value=FakeQuestion(["commit-msg", "pre-push"]),
     )
-    yield request.param
+    return request.param
 
 
 def check_cz_config(config_filepath: str):
@@ -179,7 +179,7 @@ def check_pre_commit_config(expected: list[dict[str, Any]]):
 @pytest.mark.usefixtures("pre_commit_installed")
 class TestPreCommitCases:
     def test_no_existing_pre_commit_config(
-        _, default_choice: str, tmpdir, config: BaseConfig
+        self, default_choice: str, tmpdir, config: BaseConfig
     ):
         with tmpdir.as_cwd():
             commands.Init(config)()
@@ -187,7 +187,7 @@ class TestPreCommitCases:
             check_pre_commit_config([cz_hook_config])
 
     def test_empty_pre_commit_config(
-        _, default_choice: str, tmpdir, config: BaseConfig
+        self, default_choice: str, tmpdir, config: BaseConfig
     ):
         with tmpdir.as_cwd():
             p = tmpdir.join(pre_commit_config_filename)
@@ -198,7 +198,7 @@ class TestPreCommitCases:
             check_pre_commit_config([cz_hook_config])
 
     def test_pre_commit_config_without_cz_hook(
-        _, default_choice: str, tmpdir, config: BaseConfig
+        self, default_choice: str, tmpdir, config: BaseConfig
     ):
         existing_hook_config = {
             "repo": "https://github.com/pre-commit/pre-commit-hooks",
@@ -215,7 +215,7 @@ class TestPreCommitCases:
             check_pre_commit_config([existing_hook_config, cz_hook_config])
 
     def test_cz_hook_exists_in_pre_commit_config(
-        _, default_choice: str, tmpdir, config: BaseConfig
+        self, default_choice: str, tmpdir, config: BaseConfig
     ):
         with tmpdir.as_cwd():
             p = tmpdir.join(pre_commit_config_filename)
@@ -228,8 +228,9 @@ class TestPreCommitCases:
 
 
 class TestNoPreCommitInstalled:
+    @pytest.mark.usefixtures("default_choice")
     def test_pre_commit_not_installed(
-        _, mocker: MockFixture, config: BaseConfig, default_choice: str, tmpdir
+        self, mocker: MockFixture, config: BaseConfig, tmpdir
     ):
         # Assume `pre-commit` is not installed
         mocker.patch(

--- a/tests/test_bump_hooks.py
+++ b/tests/test_bump_hooks.py
@@ -38,5 +38,5 @@ def test_run_error(mocker: MockFixture):
 
 def test_format_env():
     result = hooks._format_env("TEST_", {"foo": "bar", "bar": "baz"})
-    assert "TEST_FOO" in result and result["TEST_FOO"] == "bar"
-    assert "TEST_BAR" in result and result["TEST_BAR"] == "baz"
+    assert result["TEST_FOO"] == "bar"
+    assert result["TEST_BAR"] == "baz"

--- a/tests/test_bump_update_version_in_files.py
+++ b/tests/test_bump_update_version_in_files.py
@@ -57,7 +57,6 @@ def docker_compose_file(sample_file: SampleFileFixture) -> Path:
 
 
 @pytest.fixture(
-    scope="function",
     params=(
         "multiple_versions_to_update_pyproject.toml",
         "multiple_versions_to_update_pyproject_wo_eol.toml",

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -184,16 +184,16 @@ class TestReadCfg:
     @pytest.mark.parametrize(
         "config_files_manager", defaults.CONFIG_FILES, indirect=True
     )
-    def test_load_conf(_, config_files_manager):
+    def test_load_conf(self, config_files_manager):
         cfg = config.read_cfg()
         assert cfg.settings == _settings
 
-    def test_conf_returns_default_when_no_files(_, tmpdir):
+    def test_conf_returns_default_when_no_files(self, tmpdir):
         with tmpdir.as_cwd():
             cfg = config.read_cfg()
             assert cfg.settings == defaults.DEFAULT_SETTINGS
 
-    def test_load_empty_pyproject_toml_and_cz_toml_with_config(_, tmpdir):
+    def test_load_empty_pyproject_toml_and_cz_toml_with_config(self, tmpdir):
         with tmpdir.as_cwd():
             p = tmpdir.join("pyproject.toml")
             p.write("")
@@ -203,7 +203,7 @@ class TestReadCfg:
             cfg = config.read_cfg()
             assert cfg.settings == _settings
 
-    def test_load_pyproject_toml_from_config_argument(_, tmpdir):
+    def test_load_pyproject_toml_from_config_argument(self, tmpdir):
         with tmpdir.as_cwd():
             _not_root_path = tmpdir.mkdir("not_in_root").join("pyproject.toml")
             _not_root_path.write(PYPROJECT)
@@ -211,7 +211,7 @@ class TestReadCfg:
             cfg = config.read_cfg(filepath="./not_in_root/pyproject.toml")
             assert cfg.settings == _settings
 
-    def test_load_cz_json_not_from_config_argument(_, tmpdir):
+    def test_load_cz_json_not_from_config_argument(self, tmpdir):
         with tmpdir.as_cwd():
             _not_root_path = tmpdir.mkdir("not_in_root").join(".cz.json")
             _not_root_path.write(JSON_STR)
@@ -220,7 +220,7 @@ class TestReadCfg:
             json_cfg_by_class = JsonConfig(data=JSON_STR, path=_not_root_path)
             assert cfg.settings == json_cfg_by_class.settings
 
-    def test_load_cz_yaml_not_from_config_argument(_, tmpdir):
+    def test_load_cz_yaml_not_from_config_argument(self, tmpdir):
         with tmpdir.as_cwd():
             _not_root_path = tmpdir.mkdir("not_in_root").join(".cz.yaml")
             _not_root_path.write(YAML_STR)
@@ -229,7 +229,7 @@ class TestReadCfg:
             yaml_cfg_by_class = YAMLConfig(data=YAML_STR, path=_not_root_path)
             assert cfg.settings == yaml_cfg_by_class._settings
 
-    def test_load_empty_pyproject_toml_from_config_argument(_, tmpdir):
+    def test_load_empty_pyproject_toml_from_config_argument(self, tmpdir):
         with tmpdir.as_cwd():
             _not_root_path = tmpdir.mkdir("not_in_root").join("pyproject.toml")
             _not_root_path.write("")
@@ -260,7 +260,7 @@ class TestWarnMultipleConfigFiles:
         ],
     )
     def test_warn_multiple_config_files_same_dir(
-        _, tmpdir, capsys, files, expected_path, should_warn
+        self, tmpdir, capsys, files, expected_path, should_warn
     ):
         """Test warning when multiple config files exist in same directory."""
         with tmpdir.as_cwd():
@@ -296,7 +296,7 @@ class TestWarnMultipleConfigFiles:
         ],
     )
     def test_warn_same_filename_different_directories_with_git(
-        _, tmpdir, capsys, config_file, content
+        self, tmpdir, capsys, config_file, content
     ):
         """Test warning when same config filename exists in the current directory and in the git root."""
         with tmpdir.as_cwd():
@@ -317,7 +317,7 @@ class TestWarnMultipleConfigFiles:
                 assert f"Using config file: '{config_file}'" in captured.err
                 assert cfg.path == Path(config_file)
 
-    def test_no_warn_with_explicit_config_path(_, tmpdir, capsys):
+    def test_no_warn_with_explicit_config_path(self, tmpdir, capsys):
         """Test that no warning is issued when user explicitly specifies config."""
         with tmpdir.as_cwd():
             # Create multiple config files
@@ -352,7 +352,7 @@ class TestWarnMultipleConfigFiles:
         ],
     )
     def test_no_warn_with_single_config_file(
-        _, tmpdir, capsys, config_file, content, with_git
+        self, tmpdir, capsys, config_file, content, with_git
     ):
         """Test that no warning is issued when user explicitly specifies config."""
         with tmpdir.as_cwd():

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -5,25 +5,27 @@ from commitizen import changelog_formats, defaults
 
 def test_getattr_deprecated_vars():
     # Test each deprecated variable
-    with pytest.warns(DeprecationWarning) as record:
+    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
         assert defaults.bump_pattern == defaults.BUMP_PATTERN
+    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
         assert defaults.bump_map == defaults.BUMP_MAP
+    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
         assert (
             defaults.bump_map_major_version_zero == defaults.BUMP_MAP_MAJOR_VERSION_ZERO
         )
+    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
         assert defaults.bump_message == defaults.BUMP_MESSAGE
+    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
         assert defaults.change_type_order == defaults.CHANGE_TYPE_ORDER
+    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
         assert defaults.encoding == defaults.ENCODING
+    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
         assert defaults.name == defaults.DEFAULT_SETTINGS["name"]
+    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
         assert (
             changelog_formats._guess_changelog_format
             == changelog_formats.guess_changelog_format
         )
-
-    # Verify warning messages
-    assert len(record) == 7
-    for warning in record:
-        assert "is deprecated and will be removed" in str(warning.message)
 
 
 def test_getattr_non_existent():

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -52,14 +52,13 @@ def test_discover_plugins(tmp_path):
     )
 
     sys.path.append(tmp_path.as_posix())
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(
+        UserWarning,
+        match="Legacy plugin 'cz_legacy' has been ignored: please expose it the 'commitizen.plugin' entrypoint",
+    ):
         discovered_plugins = discover_plugins([tmp_path.as_posix()])
     sys.path.pop()
 
-    assert (
-        record[0].message.args[0]
-        == "Legacy plugin 'cz_legacy' has been ignored: please expose it the 'commitizen.plugin' entrypoint"
-    )
     assert "cz_legacy" not in discovered_plugins
 
 

--- a/tests/test_version_scheme_pep440.py
+++ b/tests/test_version_scheme_pep440.py
@@ -251,16 +251,6 @@ from tests.utils import VersionSchemeTestArgs
         ),
         (
             VersionSchemeTestArgs(
-                current_version="0.1.1",
-                increment="MINOR",
-                prerelease=None,
-                prerelease_offset=0,
-                devrelease=None,
-            ),
-            "0.2.0",
-        ),
-        (
-            VersionSchemeTestArgs(
                 current_version="0.2.0",
                 increment="MINOR",
                 prerelease=None,
@@ -735,26 +725,6 @@ from tests.utils import VersionSchemeTestArgs
         ),
         (
             VersionSchemeTestArgs(
-                current_version="1.1.0a0",
-                increment="PATCH",
-                prerelease="alpha",
-                prerelease_offset=0,
-                devrelease=None,
-            ),
-            "1.1.0a1",
-        ),
-        (
-            VersionSchemeTestArgs(
-                current_version="1.1.0a1",
-                increment="MINOR",
-                prerelease="alpha",
-                prerelease_offset=0,
-                devrelease=None,
-            ),
-            "1.1.0a2",
-        ),
-        (
-            VersionSchemeTestArgs(
                 current_version="1.1.0a2",
                 increment="PATCH",
                 prerelease="alpha",
@@ -1019,17 +989,6 @@ from tests.utils import VersionSchemeTestArgs
                 devrelease=None,
             ),
             "3.1.4rc0",
-        ),
-        #
-        (
-            VersionSchemeTestArgs(
-                current_version="3.1.4",
-                increment=None,
-                prerelease="alpha",
-                prerelease_offset=0,
-                devrelease=None,
-            ),
-            "3.1.4a0",
         ),
         (
             VersionSchemeTestArgs(

--- a/tests/test_version_scheme_semver.py
+++ b/tests/test_version_scheme_semver.py
@@ -273,16 +273,6 @@ from tests.utils import VersionSchemeTestArgs
         ),
         (
             VersionSchemeTestArgs(
-                current_version="0.1.1",
-                increment="MINOR",
-                prerelease=None,
-                prerelease_offset=0,
-                devrelease=None,
-            ),
-            "0.2.0",
-        ),
-        (
-            VersionSchemeTestArgs(
                 current_version="0.2.0",
                 increment="MINOR",
                 prerelease=None,

--- a/tests/test_version_scheme_semver2.py
+++ b/tests/test_version_scheme_semver2.py
@@ -222,16 +222,6 @@ from tests.utils import VersionSchemeTestArgs
         ),
         (
             VersionSchemeTestArgs(
-                current_version="1.0.0-alpha.1",
-                increment=None,
-                prerelease="alpha",
-                prerelease_offset=0,
-                devrelease=None,
-            ),
-            "1.0.0-alpha.2",
-        ),
-        (
-            VersionSchemeTestArgs(
                 current_version="1",
                 increment=None,
                 prerelease="rc",
@@ -270,16 +260,6 @@ from tests.utils import VersionSchemeTestArgs
                 devrelease=1,
             ),
             "0.1.1-dev.1",
-        ),
-        (
-            VersionSchemeTestArgs(
-                current_version="0.1.1",
-                increment="MINOR",
-                prerelease=None,
-                prerelease_offset=0,
-                devrelease=None,
-            ),
-            "0.2.0",
         ),
         (
             VersionSchemeTestArgs(
@@ -397,16 +377,6 @@ from tests.utils import VersionSchemeTestArgs
                 increment=None,
                 prerelease="alpha",
                 prerelease_offset=0,
-                devrelease=None,
-            ),
-            "1.0.0-alpha.2",
-        ),
-        (
-            VersionSchemeTestArgs(
-                current_version="1.0.0-alpha.1",
-                increment=None,
-                prerelease="alpha",
-                prerelease_offset=0,
                 devrelease=1,
             ),
             "1.0.0-alpha.2.dev.1",
@@ -450,16 +420,6 @@ from tests.utils import VersionSchemeTestArgs
                 devrelease=None,
             ),
             "1.0.0-beta.1",
-        ),
-        (
-            VersionSchemeTestArgs(
-                current_version="1.0.0-beta.1",
-                increment=None,
-                prerelease="rc",
-                prerelease_offset=0,
-                devrelease=None,
-            ),
-            "1.0.0-rc.0",
         ),
         (
             VersionSchemeTestArgs(

--- a/tests/test_version_schemes.py
+++ b/tests/test_version_schemes.py
@@ -38,7 +38,7 @@ def test_raise_for_unknown_version_scheme(config: BaseConfig):
 
 def test_version_scheme_from_deprecated_config(config: BaseConfig):
     config.settings["version_type"] = "semver"
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="Please use `version_scheme` instead"):
         scheme = get_version_scheme(config.settings)
     assert scheme is SemVer
 
@@ -46,7 +46,7 @@ def test_version_scheme_from_deprecated_config(config: BaseConfig):
 def test_version_scheme_from_config_priority(config: BaseConfig):
     config.settings["version_scheme"] = "pep440"
     config.settings["version_type"] = "semver"
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="Please use `version_scheme` instead"):
         scheme = get_version_scheme(config.settings)
     assert scheme is Pep440
 


### PR DESCRIPTION
There are still some ruff rules pending for enabling

The deleted test cases are duplicated