### PR TITLE
fix: add match parameter to pytest.warns to resolve PT030

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ ignore = [
     "PT007", # TODO(bearomorphism): enable this rule
     "PT011", # TODO(bearomorphism): enable this rule
     "PT022", # TODO(bearomorphism): enable this rule
-    "PT030", # TODO(bearomorphism): enable this rule
 ]
 extend-safe-fixes = [
     "TC", # Move imports inside/outside TYPE_CHECKING blocks

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1027,7 +1027,7 @@ def test_bump_with_major_version_zero_with_plugin(
 def test_bump_command_version_type_deprecation(util: UtilFixture):
     util.create_file_and_commit("feat: check deprecation on --version-type")
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match=r".*--version-type.*deprecated"):
         util.run_cli(
             "bump",
             "--prerelease",
@@ -1044,7 +1044,7 @@ def test_bump_command_version_type_deprecation(util: UtilFixture):
 def test_bump_command_version_scheme_priority_over_version_type(util: UtilFixture):
     util.create_file_and_commit("feat: check deprecation on --version-type")
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match=r".*--version-type.*deprecated"):
         util.run_cli(
             "bump",
             "--prerelease",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
This PR addresses `ruff` rule **PT030** ("pytest.warns() is too broad") in the test suite. 

Before
<img width="669" height="365" alt="image" src="https://github.com/user-attachments/assets/46313b5b-48a4-4cf2-a7cb-1816671a28db" />

After
<img width="571" height="34" alt="image" src="https://github.com/user-attachments/assets/6cf9bfd2-55a4-481f-bb7f-080fb4890e0f" />

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (gemini 3 pro)

<!--
Generated-by: [Tool Name] following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)
-->

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [X] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes


<!--
When running `uv run poe doc`, any broken internal documentation links will be reported in the console output like this:

```text
INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
```
-->

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->
- Use `pytest.warns(DeprecationWarning, match=r".*--version-type.*deprecated")` instead of a generic catch.
- Running `uv run ruff check` should pass without `PT030` errors.
- The tests should correctly identify and match the "version-type is deprecated" warning.


## Steps to Test This Pull Request
1. Run linting check to ensure PT030 is resolved:
   `uv run ruff check`

## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
