### PR TITLE
test(test_deprecated): use pytest.mark.parametrize

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,8 +237,9 @@ select = [
 ]
 ignore = ["E501", "D1", "D415"]
 extend-safe-fixes = [
-    "TC", # Move imports inside/outside TYPE_CHECKING blocks
-    "UP", # Update syntaxes for current Python version recommendations
+    "TC",    # Move imports inside/outside TYPE_CHECKING blocks
+    "UP",    # Update syntaxes for current Python version recommendations
+    "PT006", # Use tuple in pytest.mark.parametrize
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -3,33 +3,33 @@ import pytest
 from commitizen import changelog_formats, defaults
 
 
-def test_getattr_deprecated_vars():
+@pytest.mark.parametrize(
+    ("deprecated_var_getter", "replacement"),
+    [
+        (lambda: defaults.bump_pattern, defaults.BUMP_PATTERN),
+        (lambda: defaults.bump_map, defaults.BUMP_MAP),
+        (
+            lambda: defaults.bump_map_major_version_zero,
+            defaults.BUMP_MAP_MAJOR_VERSION_ZERO,
+        ),
+        (lambda: defaults.bump_message, defaults.BUMP_MESSAGE),
+        (lambda: defaults.change_type_order, defaults.CHANGE_TYPE_ORDER),
+        (lambda: defaults.encoding, defaults.ENCODING),
+        (lambda: defaults.name, defaults.DEFAULT_SETTINGS["name"]),
+        (
+            lambda: changelog_formats.guess_changelog_format,
+            changelog_formats._guess_changelog_format,
+        ),
+    ],
+)
+def test_getattr_deprecated_vars(deprecated_var_getter, replacement):
     # Test each deprecated variable
     with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
-        assert defaults.bump_pattern == defaults.BUMP_PATTERN
-    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
-        assert defaults.bump_map == defaults.BUMP_MAP
-    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
-        assert (
-            defaults.bump_map_major_version_zero == defaults.BUMP_MAP_MAJOR_VERSION_ZERO
-        )
-    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
-        assert defaults.bump_message == defaults.BUMP_MESSAGE
-    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
-        assert defaults.change_type_order == defaults.CHANGE_TYPE_ORDER
-    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
-        assert defaults.encoding == defaults.ENCODING
-    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
-        assert defaults.name == defaults.DEFAULT_SETTINGS["name"]
-    with pytest.warns(DeprecationWarning, match="is deprecated and will be removed"):
-        assert (
-            changelog_formats._guess_changelog_format
-            == changelog_formats.guess_changelog_format
-        )
+        val = deprecated_var_getter()
+    assert val == replacement
 
 
 def test_getattr_non_existent():
     # Test non-existent attribute
-    with pytest.raises(AttributeError) as exc_info:
+    with pytest.raises(AttributeError, match="is not an attribute of"):
         _ = defaults.non_existent_attribute
-    assert "is not an attribute of" in str(exc_info.value)


### PR DESCRIPTION
As title. This makes the test more scalable.