### PR TITLE
test: add deprecated test back

### DIFF
--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1494,6 +1494,16 @@ def test_changelog_config_flag_merge_prerelease_only_prerelease_present(
     file_regression.check(out, extension=".md")
 
 
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_bump_deprecate_files_only(util: UtilFixture):
+    util.create_file_and_commit("feat: new file")
+    with (
+        pytest.warns(DeprecationWarning, match=r".*--files-only.*deprecated"),
+        pytest.raises(ExpectedExit),
+    ):
+        util.run_cli("bump", "--yes", "--files-only")
+
+
 @pytest.mark.parametrize(
     ("prerelease", "merge"),
     [


### PR DESCRIPTION
The test was accidentally removed in #1850 

I didn't review carefully

copilot really helped