### PR TITLE
feat: add `--allow-no-commit` to `changelog` command

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -330,7 +330,11 @@ class Bump:
 
             changelog_cmd = Changelog(
                 self.config,
-                {**changelog_args, "file_name": self.file_name},  # type: ignore[typeddict-item]
+                {
+                    **changelog_args,  # type: ignore[typeddict-item]
+                    "file_name": self.file_name,
+                    "allow_no_commit": self.arguments["allow_no_commit"],
+                },
             )
             changelog_cmd()
             changelog_file_name = changelog_cmd.file_name

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -333,7 +333,7 @@ class Bump:
                 {
                     **changelog_args,  # type: ignore[typeddict-item]
                     "file_name": self.file_name,
-                    "allow_no_commit": self.arguments["allow_no_commit"],
+                    "allow_no_commit": bool(self.arguments["allow_no_commit"]),
                 },
             )
             changelog_cmd()

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -43,6 +43,7 @@ class ChangelogArgs(TypedDict, total=False):
     extras: dict[str, Any]
     export_template: str
     during_version_bump: bool | None
+    allow_no_commit: bool  # --allow-no-commit is still invalid in the changelog command
 
 
 class Changelog:
@@ -124,6 +125,7 @@ class Changelog:
         self.export_template_to = arguments.get("export_template")
 
         self.during_version_bump: bool = arguments.get("during_version_bump") or False
+        self.allow_no_commit: bool = arguments.get("allow_no_commit") or False
 
     def _find_incremental_rev(self, latest_version: str, tags: Iterable[GitTag]) -> str:
         """Try to find the 'start_rev'.
@@ -255,8 +257,10 @@ class Changelog:
                     changelog_meta.unreleased_end = latest_full_release_info.index + 1
 
         commits = git.get_commits(start=start_rev, end=end_rev, args="--topo-order")
-        if not commits and (
-            self.current_version is None or not self.current_version.is_prerelease
+        if (
+            not self.allow_no_commit
+            and not commits
+            and (self.current_version is None or not self.current_version.is_prerelease)
         ):
             raise NoCommitsFoundError("No commits found")
 

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -43,7 +43,7 @@ class ChangelogArgs(TypedDict, total=False):
     extras: dict[str, Any]
     export_template: str
     during_version_bump: bool | None
-    allow_no_commit: bool  # --allow-no-commit is still invalid in the changelog command
+    allow_no_commit: bool | None
 
 
 class Changelog:
@@ -125,7 +125,8 @@ class Changelog:
         self.export_template_to = arguments.get("export_template")
 
         self.during_version_bump: bool = arguments.get("during_version_bump") or False
-        self.allow_no_commit: bool = arguments.get("allow_no_commit") or False
+        # Internal flag used when changelog is invoked from `cz bump --allow-no-commit`.
+        self.allow_no_commit: bool = bool(arguments.get("allow_no_commit"))
 
     def _find_incremental_rev(self, latest_version: str, tags: Iterable[GitTag]) -> str:
         """Try to find the 'start_rev'.

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -43,7 +43,7 @@ class ChangelogArgs(TypedDict, total=False):
     extras: dict[str, Any]
     export_template: str
     during_version_bump: bool | None
-    allow_no_commit: bool | None
+    allow_no_commit: bool | None  # Internal-only when invoked by bump.
 
 
 class Changelog:

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -473,6 +473,11 @@ cz bump --allow-no-commit 2.0.0
     cz bump --allow-no-commit 2.0.0
     ```
 
+!!! note "Behavior with changelog updates"
+    When `update_changelog_on_bump = true` (or `--changelog` is used), `cz bump --allow-no-commit` also generates a changelog entry even if there are no commits in the selected range.
+
+    This makes the new release visible in the changelog while still showing that no commit-based changes were included.
+
 ### `--tag-format`
 
 `tag_format` and [version_scheme][version_scheme] are combined to make Git tag names from versions.

--- a/docs/commands/changelog.md
+++ b/docs/commands/changelog.md
@@ -2,6 +2,8 @@
 
 Generates a changelog following the committing rules established.
 
+When changelog generation is triggered by `cz bump --allow-no-commit` (with `--changelog` or `update_changelog_on_bump = true`), Commitizen still creates a release entry even when no commits are found in the selected revision range.
+
 !!! tip
     To create the changelog automatically on bump, add the setting [update_changelog_on_bump](../config/bump.md#update_changelog_on_bump)
 

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1554,4 +1554,4 @@ def test_bump_allow_no_commit_issue(
     util.run_cli("bump", "--yes", "--allow-no-commit", "--prerelease", "beta")
     util.run_cli(
         "bump", "--allow-no-commit", "--prerelease", "rc"
-    )  # Failed because the bump command called changelog command
+    )  # Should not fail when changelog generation runs with no new commits

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1548,33 +1548,9 @@ def test_bump_allow_no_commit_issue(
     util: UtilFixture,
 ) -> None:
     """Issue #1866: bump command called changelog command with allow_no_commit=True, but changelog command raised NoCommitsFoundError"""
-    tmp_commitizen_project = tmp_commitizen_project_initial(version="1.0.0")
-    with (tmp_commitizen_project / "pyproject.toml").open("w") as f:
-        f.write(
-            dedent(
-                r"""
-            [project]
-            name = "abc"
-            version = "4.14.0"
-
-            [tool.commitizen]
-            name = "cz_customize"
-            tag_format = "$version"
-            version_scheme = "semver2"
-            version_provider = "pep621"
-            update_changelog_on_bump = true
-
-            [tool.commitizen.customize]
-            bump_pattern = '^(feat|fix|ci|build|perf|refactor|chore|remove|style|test)'
-            bump_map = {feat = "MINOR", fix = "PATCH", ci = "PATCH", build = "PATCH", perf = "PATCH", refactor = "PATCH", chore = "PATCH", remove = "PATCH", style = "PATCH", test = "PATCH" }
-            schema_pattern = "(build|bump|chore|ci|dev|docs|feat|fix|perf|refactor|remove|style|test):(\\s.*)"
-            commit_parser = "^(?P<change_type>build|bump|chore|ci|dev|docs|feat|fix|perf|refactor|remove|style|test):\\s(?P<message>.*)?"
-            change_type_map = {"feat" = "New Features", "fix" = "Bug Fixes", "perf" = "Performance Improvements", "refactor" = "Refactoring", "chore" = "General Improvements", "remove" = "Removed", "style" = "Stylistic Changes", "test" = "Testing", "build" = "Build"}
-            change_type_order = ["BREAKING CHANGE", "New Features", "Bug Fixes", "Performance Improvements", "Refactoring", "General Improvements", "Removed", "Stylistic Changes", "Testing", "Build"]
-            changelog_pattern = "^(build|chore|feat|fix|perf|refactor|remove|style|test)"
-"""
-            )
-        )
+    tmp_commitizen_project_initial(
+        version="1.0.0", config_extra="update_changelog_on_bump = true\n"
+    )
     util.run_cli("bump", "--yes", "--allow-no-commit", "--prerelease", "beta")
     util.run_cli(
         "bump", "--allow-no-commit", "--prerelease", "rc"


### PR DESCRIPTION
… but changelog command raised NoCommitsFoundError

Fixes #1866 

<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [ ] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)
-->

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes
<!-- You can skip this section if you are not making any documentation changes -->


- [ ] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external)

<!--
When running `uv run poe doc`, any broken internal documentation links will be reported in the console output like this:

```text
INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
```
-->

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
