### PR TITLE
fix(config): fix contains_commitizen_section failing for completely e…

### DIFF
--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -27,7 +27,10 @@ class JsonConfig(BaseConfig):
 
     def contains_commitizen_section(self) -> bool:
         with self.path.open("rb") as json_file:
-            config_doc = json.load(json_file)
+            try:
+                config_doc = json.load(json_file)
+            except json.JSONDecodeError:
+                return False
         return config_doc.get("commitizen") is not None
 
     def init_empty_config_content(self) -> None:

--- a/commitizen/config/yaml_config.py
+++ b/commitizen/config/yaml_config.py
@@ -35,7 +35,7 @@ class YAMLConfig(BaseConfig):
     def contains_commitizen_section(self) -> bool:
         with self.path.open("rb") as yaml_file:
             config_doc = yaml.load(yaml_file, Loader=yaml.FullLoader)
-        return config_doc.get("commitizen") is not None
+        return config_doc is not None and config_doc.get("commitizen") is not None
 
     def _parse_setting(self, data: bytes | str) -> None:
         """We expect to have a section in cz.yaml looking like

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -242,6 +242,22 @@ class TestReadCfg:
             with pytest.raises(ConfigFileIsEmpty):
                 config.read_cfg(filepath="./not_in_root/pyproject.toml")
 
+    def test_load_empty_json_from_config_argument(self, tmpdir):
+        with tmpdir.as_cwd():
+            _not_root_path = tmpdir.mkdir("not_in_root").join(".cz.json")
+            _not_root_path.write("")
+
+            with pytest.raises(ConfigFileIsEmpty):
+                config.read_cfg(filepath="./not_in_root/.cz.json")
+
+    def test_load_empty_yaml_from_config_argument(self, tmpdir):
+        with tmpdir.as_cwd():
+            _not_root_path = tmpdir.mkdir("not_in_root").join(".cz.yaml")
+            _not_root_path.write("")
+
+            with pytest.raises(ConfigFileIsEmpty):
+                config.read_cfg(filepath="./not_in_root/.cz.yaml")
+
 
 class TestWarnMultipleConfigFiles:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
The new contains_commitizen_section broke JSON and YAML configs that are completely empty files.
For TOML configs, the check was working as expected and not failing for empty files.
This PR just adds some basic error handling for empty files.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes
No doc changes

## Expected Behavior
Commitizen no longer fails on empty JSON/YAML config files.


## Steps to Test This Pull Request
1. create empty config with `touch .cz.yaml`
2. run `cz --config .cz.yaml check COMMIT..COMMIT`
3. Success
4. Repeat for `.cz.json`


## Additional Context
Updated commitizen and CI jobs in exisiting repositories started failing. Short investigation revealed new empty config file check did not account for completely empty files.
