### PR TITLE
docs: add git config user.* to commit successfully

### DIFF
--- a/docs/images/commit.tape
+++ b/docs/images/commit.tape
@@ -53,6 +53,10 @@ Sleep 500ms
 # Initialize git repository
 Type "git init"
 Enter
+Type "git config user.email 'you@example.com'"
+Enter
+Type "git config user.name 'Your Name'"
+Enter
 Sleep 500ms
 
 Type "git checkout -b awesome-feature"


### PR DESCRIPTION
Fixes #1876 

Verified the solution by running `vhs docs/images/commit.tape`, and the generated `/tmp/commitizen-demo` folder is with correct git log (with a commit authored by `you@example.com`)