### PR TITLE
Fix `TypeError: Keys must be strings`

### DIFF
--- a/commitizen/changelog.py
+++ b/commitizen/changelog.py
@@ -193,7 +193,7 @@ def process_commit_message(
     messages = [processed_msg] if isinstance(processed_msg, dict) else processed_msg
     for msg in messages:
         change_type = msg.pop("change_type", None)
-        if change_type_map:
+        if change_type_map and change_type:
             change_type = change_type_map.get(change_type, change_type)
         ref_changes[change_type].append(msg)
 


### PR DESCRIPTION
## Description

fix: avoid raising an exception when a change_type is not defined.


## Checklist

- [ ] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes
<!-- You can skip this section if you are not making any documentation changes -->


- [ ] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external)

<!--
When running `uv run poe doc`, any broken internal documentation links will be reported in the console output like this:

```text
INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
```
-->

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->


## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
