### PR TITLE
Clarify cz_customize deprecation warning with rationale link

### DIFF
--- a/docs/customization/config_file.md
+++ b/docs/customization/config_file.md
@@ -6,6 +6,7 @@ The basic steps are:
 2. Declare `name = "cz_customize"` in your configuration file, or add `-n cz_customize` when running Commitizen.
 !!! warning
     `cz_customize` is likely to be removed or renamed in the next major release.
+    This change is still under discussion; you can continue using `cz_customize` for now and follow [#1385](https://github.com/commitizen-tools/commitizen/issues/1385) for the rationale, options, and current status.
 
 Example:
 


### PR DESCRIPTION

## Description

https://commitizen-tools.github.io/commitizen/customization/config_file/

- The existing warning said that cz_customize is likely to be removed or renamed in the next major release, but did not point to any background discussion or roadmap.
- This change makes it explicit that the change is still under discussion, that users can continue using cz_customize for now, and that #1385 is the place to track the rationale and design/alternative discussions.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-by: [Cursor] following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes
<!-- You can skip this section if you are not making any documentation changes -->


- [X] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [X] Check and fix any broken links (internal or external)

<!--
When running `uv run poe doc`, any broken internal documentation links will be reported in the console output like this:

```text
INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
```
-->

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->

- Clarifies the cz_customize warning in the configuration docs.
- Adds a reference to #1385 so users can follow the rationale, options, and current status.

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->


## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
