### PR TITLE
Fix and improve test: message_length_limit

### DIFF
--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -46,8 +46,12 @@ class Check:
         )
 
         self.use_default_range = bool(arguments.get("use_default_range"))
-        self.max_msg_length = arguments.get(
-            "message_length_limit", config.settings.get("message_length_limit", 0)
+
+        message_length_limit = arguments.get("message_length_limit")
+        self.message_length_limit: int = (
+            message_length_limit
+            if message_length_limit is not None
+            else config.settings["message_length_limit"]
         )
 
         # we need to distinguish between None and [], which is a valid value
@@ -100,7 +104,7 @@ class Check:
                     pattern=pattern,
                     allow_abort=self.allow_abort,
                     allowed_prefixes=self.allowed_prefixes,
-                    max_msg_length=self.max_msg_length,
+                    max_msg_length=self.message_length_limit,
                     commit_hash=commit.rev,
                 )
             ).is_valid

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -21,7 +21,7 @@ class CheckArgs(TypedDict, total=False):
     commit_msg: str
     rev_range: str
     allow_abort: bool
-    message_length_limit: int
+    message_length_limit: int | None
     allowed_prefixes: list[str]
     message: str
     use_default_range: bool

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -35,7 +35,7 @@ class CommitArgs(TypedDict, total=False):
     dry_run: bool
     edit: bool
     extra_cli_args: str
-    message_length_limit: int
+    message_length_limit: int | None
     no_retry: bool
     signoff: bool
     write_message_to_file: Path | None

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -54,6 +54,13 @@ class Commit:
         self.arguments = arguments
         self.backup_file_path = get_backup_file_path()
 
+        message_length_limit = arguments.get("message_length_limit")
+        self.message_length_limit: int = (
+            message_length_limit
+            if message_length_limit is not None
+            else config.settings["message_length_limit"]
+        )
+
     def _read_backup_message(self) -> str | None:
         # Check the commit backup file exists
         if not self.backup_file_path.is_file():
@@ -85,19 +92,14 @@ class Commit:
         return message
 
     def _validate_subject_length(self, message: str) -> None:
-        message_length_limit = self.arguments.get(
-            "message_length_limit", self.config.settings.get("message_length_limit", 0)
-        )
         # By the contract, message_length_limit is set to 0 for no limit
-        if (
-            message_length_limit is None or message_length_limit <= 0
-        ):  # do nothing for no limit
+        if self.message_length_limit <= 0:
             return
 
         subject = message.partition("\n")[0].strip()
-        if len(subject) > message_length_limit:
+        if len(subject) > self.message_length_limit:
             raise CommitMessageLengthExceededError(
-                f"Length of commit message exceeds limit ({len(subject)}/{message_length_limit}), subject: '{subject}'"
+                f"Length of commit message exceeds limit ({len(subject)}/{self.message_length_limit}), subject: '{subject}'"
             )
 
     def manual_edit(self, message: str) -> str:

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -351,23 +351,25 @@ def test_check_command_with_amend_prefix_default(config, success_mock):
     success_mock.assert_called_once()
 
 
-def test_check_command_with_config_message_length_limit(config, success_mock):
+def test_check_command_with_config_message_length_limit_and_cli_none(config, success_mock: MockType):
     message = "fix(scope): some commit message"
     config.settings["message_length_limit"] = len(message) + 1
     commands.Check(
         config=config,
-        arguments={"message": message},
+        arguments={"message": message, "message_length_limit": None},
     )()
     success_mock.assert_called_once()
 
 
-def test_check_command_with_config_message_length_limit_exceeded(config):
+def test_check_command_with_config_message_length_limit_exceeded_and_cli_none(
+    config,
+):
     message = "fix(scope): some commit message"
     config.settings["message_length_limit"] = len(message) - 1
     with pytest.raises(CommitMessageLengthExceededError):
         commands.Check(
             config=config,
-            arguments={"message": message},
+            arguments={"message": message, "message_length_limit": None},
         )()
 
 
@@ -376,7 +378,7 @@ def test_check_command_cli_overrides_config_message_length_limit(
 ):
     message = "fix(scope): some commit message"
     config.settings["message_length_limit"] = len(message) - 1
-    for message_length_limit in [len(message) + 1, 0]:
+    for message_length_limit in [len(message), 0]:
         success_mock.reset_mock()
         commands.Check(
             config=config,

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -351,7 +351,9 @@ def test_check_command_with_amend_prefix_default(config, success_mock):
     success_mock.assert_called_once()
 
 
-def test_check_command_with_config_message_length_limit_and_cli_none(config, success_mock: MockType):
+def test_check_command_with_config_message_length_limit_and_cli_none(
+    config, success_mock: MockType
+):
     message = "fix(scope): some commit message"
     config.settings["message_length_limit"] = len(message) + 1
     commands.Check(

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -377,7 +377,9 @@ def test_commit_message_length_uses_config_when_cli_unset(
 def test_commit_message_length_config_exceeded_when_cli_unset(
     config, prompt_mock_feat: MockType
 ):
-    config.settings["message_length_limit"] = _commit_first_line_len(prompt_mock_feat) - 1
+    config.settings["message_length_limit"] = (
+        _commit_first_line_len(prompt_mock_feat) - 1
+    )
     with pytest.raises(CommitMessageLengthExceededError):
         commands.Commit(config, {"message_length_limit": None})()
 
@@ -396,6 +398,8 @@ def test_commit_message_length_cli_overrides_stricter_config(
 def test_commit_message_length_cli_zero_disables_limit(
     config, success_mock: MockType, prompt_mock_feat: MockType
 ):
-    config.settings["message_length_limit"] = _commit_first_line_len(prompt_mock_feat) - 1
+    config.settings["message_length_limit"] = (
+        _commit_first_line_len(prompt_mock_feat) - 1
+    )
     commands.Commit(config, {"message_length_limit": 0})()
     success_mock.assert_called_once()

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -336,34 +336,66 @@ def test_commit_when_nothing_added_to_commit(config, mocker: MockFixture, out):
     error_mock.assert_called_once_with(out)
 
 
-@pytest.mark.usefixtures("staging_is_clean", "commit_mock")
-def test_commit_command_with_config_message_length_limit(
-    config, success_mock: MockType, prompt_mock_feat: MockType
-):
+def _commit_first_line_len(prompt_mock_feat: MockType) -> int:
     prefix = prompt_mock_feat.return_value["prefix"]
     subject = prompt_mock_feat.return_value["subject"]
-    message_length = len(f"{prefix}: {subject}")
+    scope = prompt_mock_feat.return_value["scope"]
 
-    commands.Commit(config, {"message_length_limit": message_length})()
+    formatted_scope = f"({scope})" if scope else ""
+    first_line = f"{prefix}{formatted_scope}: {subject}"
+    return len(first_line)
+
+
+@pytest.mark.usefixtures("staging_is_clean", "commit_mock", "prompt_mock_feat")
+def test_commit_message_length_cli_at_limit_succeeds(
+    config, success_mock: MockType, prompt_mock_feat: MockType
+):
+    message_len = _commit_first_line_len(prompt_mock_feat)
+    commands.Commit(config, {"message_length_limit": message_len})()
     success_mock.assert_called_once()
 
+
+@pytest.mark.usefixtures("staging_is_clean", "commit_mock", "prompt_mock_feat")
+def test_commit_message_length_cli_below_limit_raises(
+    config, prompt_mock_feat: MockType
+):
+    message_len = _commit_first_line_len(prompt_mock_feat)
     with pytest.raises(CommitMessageLengthExceededError):
-        commands.Commit(config, {"message_length_limit": message_length - 1})()
+        commands.Commit(config, {"message_length_limit": message_len - 1})()
 
-    config.settings["message_length_limit"] = message_length
-    success_mock.reset_mock()
-    commands.Commit(config, {})()
+
+@pytest.mark.usefixtures("staging_is_clean", "commit_mock", "prompt_mock_feat")
+def test_commit_message_length_uses_config_when_cli_unset(
+    config, success_mock: MockType, prompt_mock_feat: MockType
+):
+    config.settings["message_length_limit"] = _commit_first_line_len(prompt_mock_feat)
+    commands.Commit(config, {"message_length_limit": None})()
     success_mock.assert_called_once()
 
-    config.settings["message_length_limit"] = message_length - 1
+
+@pytest.mark.usefixtures("staging_is_clean", "commit_mock", "prompt_mock_feat")
+def test_commit_message_length_config_exceeded_when_cli_unset(
+    config, prompt_mock_feat: MockType
+):
+    config.settings["message_length_limit"] = _commit_first_line_len(prompt_mock_feat) - 1
     with pytest.raises(CommitMessageLengthExceededError):
-        commands.Commit(config, {})()
+        commands.Commit(config, {"message_length_limit": None})()
 
-    # Test config message length limit is overridden by CLI argument
-    success_mock.reset_mock()
-    commands.Commit(config, {"message_length_limit": message_length})()
+
+@pytest.mark.usefixtures("staging_is_clean", "commit_mock", "prompt_mock_feat")
+def test_commit_message_length_cli_overrides_stricter_config(
+    config, success_mock: MockType, prompt_mock_feat: MockType
+):
+    message_len = _commit_first_line_len(prompt_mock_feat)
+    config.settings["message_length_limit"] = message_len - 1
+    commands.Commit(config, {"message_length_limit": message_len})()
     success_mock.assert_called_once()
 
-    success_mock.reset_mock()
+
+@pytest.mark.usefixtures("staging_is_clean", "commit_mock", "prompt_mock_feat")
+def test_commit_message_length_cli_zero_disables_limit(
+    config, success_mock: MockType, prompt_mock_feat: MockType
+):
+    config.settings["message_length_limit"] = _commit_first_line_len(prompt_mock_feat) - 1
     commands.Commit(config, {"message_length_limit": 0})()
     success_mock.assert_called_once()

--- a/tests/test_cli_config_integration.py
+++ b/tests/test_cli_config_integration.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from commitizen.exceptions import CommitMessageLengthExceededError, DryRunExit
+from tests.utils import UtilFixture
+
+
+def _write_pyproject_with_message_length_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, message_length_limit: int
+) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.commitizen]\n"
+        'name = "cz_conventional_commits"\n'
+        f"message_length_limit = {message_length_limit}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+
+def _mock_commit_prompt(mocker, *, subject: str) -> None:
+    mocker.patch(
+        "questionary.prompt",
+        return_value={
+            "prefix": "feat",
+            "subject": subject,
+            "scope": "",
+            "is_breaking_change": False,
+            "body": "",
+            "footer": "",
+        },
+    )
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_cli_check_reads_message_length_limit_from_pyproject(
+    util: UtilFixture, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    _write_pyproject_with_message_length_limit(tmp_path, monkeypatch, 10)
+
+    long_message_file = tmp_path / "long_message.txt"
+    long_message_file.write_text("feat: this is definitely too long", encoding="utf-8")
+
+    with pytest.raises(CommitMessageLengthExceededError):
+        util.run_cli("check", "--commit-msg-file", str(long_message_file))
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_cli_commit_reads_message_length_limit_from_pyproject(
+    util: UtilFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker,
+    tmp_path: Path,
+):
+    _write_pyproject_with_message_length_limit(tmp_path, monkeypatch, 10)
+    _mock_commit_prompt(mocker, subject="this is definitely too long")
+    mocker.patch("commitizen.git.is_staging_clean", return_value=False)
+
+    with pytest.raises(CommitMessageLengthExceededError):
+        util.run_cli("commit", "--dry-run")
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_cli_check_cli_overrides_message_length_limit_from_pyproject(
+    util: UtilFixture, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    _write_pyproject_with_message_length_limit(tmp_path, monkeypatch, 10)
+
+    util.run_cli("check", "-l", "0", "--message", "feat: this is definitely too long")
+
+
+@pytest.mark.usefixtures("tmp_commitizen_project")
+def test_cli_commit_cli_overrides_message_length_limit_from_pyproject(
+    util: UtilFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    mocker,
+    tmp_path: Path,
+):
+    _write_pyproject_with_message_length_limit(tmp_path, monkeypatch, 10)
+    _mock_commit_prompt(mocker, subject="this is definitely too long")
+    mocker.patch("commitizen.git.is_staging_clean", return_value=False)
+
+    with pytest.raises(DryRunExit):
+        util.run_cli("commit", "--dry-run", "-l", "100")
+

--- a/tests/test_cli_config_integration.py
+++ b/tests/test_cli_config_integration.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from commitizen.exceptions import CommitMessageLengthExceededError, DryRunExit
-from tests.utils import UtilFixture
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from tests.utils import UtilFixture
 
 
 def _write_pyproject_with_message_length_limit(
@@ -84,4 +88,3 @@ def test_cli_commit_cli_overrides_message_length_limit_from_pyproject(
 
     with pytest.raises(DryRunExit):
         util.run_cli("commit", "--dry-run", "-l", "100")
-


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->
This PR fixes how message_length_limit is resolved when the CLI flag is unset. Previously, the CLI argument could be present as None, causing arguments.get("message_length_limit", ...) to return None and skip the config fallback—so the configured limit (e.g. in pyproject.toml) was effectively ignored.

```diff
-        self.max_msg_length = arguments.get(
-            "message_length_limit", config.settings.get("message_length_limit", 0)
+
+        message_length_limit = arguments.get("message_length_limit")
+        self.message_length_limit: int = (
+            message_length_limit
+            if message_length_limit is not None
+            else config.settings["message_length_limit"]
         )
```

Now the precedence is correctly enforced as CLI > config > default (0 = no limit) for both cz commit and cz check, and additional unit + integration tests are added to prevent regressions.

- unit tests: `test_commit_command.py`, `test_check_command.py`
- integration tests: `tests/test_cli_config_integration.py`

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)

Generated-with: [Cursor] following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [X] Add test cases to all the changes you introduce
- [X] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [X] Manually test the changes:
  - [X] Verify the feature/bug fix works as expected in real-world scenarios
  - [X] Test edge cases and error conditions
  - [X] Ensure backward compatibility is maintained
  - [X] Document any manual testing steps performed
- [ ] Update the documentation for the changes


## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->
When `message_length_limit` is configured, `cz commit / cz check` should enforce it unless explicitly overridden via `-l/--message-length-limit` (including `-l 0` to disable the limit).



## Steps to Test This Pull Request

Steps to reproduce the behavior:
1. Create a temp repo with a `pyproject.toml` containing:
```toml
[tool.commitizen]
name = "cz_conventional_commits"
message_length_limit = 10
```
2. Confirm config is enforced (should fail):
`cz check --message "feat: this is definitely too long"`
3. Confirm CLI overrides config (should succeed):
`cz check -l 0 --message "feat: this is definitely too long"`

## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
#1899