### PR TITLE
ci(bump): fix email generation

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -19,22 +19,23 @@ jobs:
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Check out
         uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
           fetch-tags: true
-          persist-credentials: false
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - uses: commitizen-tools/setup-cz@main
         with:
           # Information extracted from the app token
           # Under actions/create-github-app-token is documented how to generate username and email for the bot
-          # The hardcoded number is the user ID of the bot account, found in the bot API
           git-user-name: "${{ steps.app-token.outputs.app-slug }}[bot]"
-          git-user-email: "274190853+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git-user-email: "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
       - id: bump-version
         run: |
           cz bump --yes


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

This one should work 🙏🏻 

I've changed the bot_id, to generate it based on the API (as shown in the action docs), so if users copy-paste the bump action, it would work with their bot, instead of having our bot id.