### PR TITLE
ci: rebase before push in screenshots workflow

### DIFF
--- a/.github/workflows/docspublish.yml
+++ b/.github/workflows/docspublish.yml
@@ -41,6 +41,7 @@ jobs:
 
           if [[ -n "$(git status --porcelain)" ]]; then
             git commit -m "docs(cli/screenshots): update CLI screenshots" -m "[skip ci]"
+            git pull --rebase origin master
             git push
           else
             echo "No changes to commit. Skipping."


### PR DESCRIPTION
## Description

Fixes the race condition in the `update-cli-screenshots` job where `git push` fails with a non-fast-forward rejection when another commit lands on `master` during the workflow run.

Added `git pull --rebase origin master` before `git push` so the screenshot commit is rebased on top of any new remote commits.

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [X] Manually test the changes:
  - [X] Verify the feature/bug fix works as expected in real-world scenarios
  - [X] Ensure backward compatibility is maintained
- N/A: No test cases needed (CI workflow YAML change only)
- N/A: No documentation update needed

## Expected Behavior

When another commit is pushed to `master` while the screenshots workflow is running, the workflow should rebase its screenshot commit on top and push successfully instead of failing.

## Steps to Test This Pull Request

1. Trigger the docs workflow while another commit lands on master
2. Observe the push step succeeds after rebasing

## Additional Context

- Failed run: https://github.com/commitizen-tools/commitizen/actions/runs/25272582802/job/74097326885