### PR TITLE
ci: specify junit.xml path for Codecov test results upload

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -68,3 +68,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
+          file: junit.xml


### PR DESCRIPTION
## Description

The "Upload test results to Codecov" step in CI intermittently fails with:

```
info - Found 0 test_results files to report
error - No JUnit XML reports found. Please review our documentation
(https://docs.codecov.com/docs/test-result-ingestion-beta) to generate and upload the file.
```

The poe `cover` task (run via `poe ci`) generates `junit.xml` in the project root (`--junitxml=junit.xml` in pyproject.toml line 299), but the `codecov/codecov-action@v6` with `report_type: test_results` relies on auto-discovery which is unreliable.

### Fix

Add `file: junit.xml` to explicitly point the Codecov action at the generated JUnit XML report.

### Evidence of flaky behavior

Same branch, same workflow, same step — different outcomes:

| Run | Job | "Upload test results to Codecov" | Link |
|---|---|---|---|
| 25276231285 | python-check (3.10, ubuntu-22.04) | **success** | [link](https://github.com/commitizen-tools/commitizen/actions/runs/25276231285) |
| 25276415667 | python-check (3.10, ubuntu-22.04) | **failure** | [link](https://github.com/commitizen-tools/commitizen/actions/runs/25276415667) |

Both runs executed the same workflow without `file:` specified. The Codecov CLI auto-discovery found `junit.xml` in one run but not the other. Adding an explicit path eliminates this non-determinism.

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes

Generated-by: GitHub Copilot CLI
