### PR TITLE
feat(config): add strict_config option to reject unknown config keys

### DIFF
--- a/commitizen/config/base_config.py
+++ b/commitizen/config/base_config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from commitizen.defaults import DEFAULT_SETTINGS, Settings
+from commitizen.exceptions import InvalidConfigurationError
 
 if TYPE_CHECKING:
     import sys
@@ -13,6 +14,8 @@ if TYPE_CHECKING:
         from typing_extensions import Self
     else:
         from typing import Self
+
+_VALID_CONFIG_KEYS: frozenset[str] = frozenset(Settings.__annotations__)
 
 
 class BaseConfig:
@@ -47,6 +50,12 @@ class BaseConfig:
         raise NotImplementedError()
 
     def update(self, data: Settings) -> None:
+        if self._settings.get("strict_config"):
+            unknown = sorted(set(data) - _VALID_CONFIG_KEYS)
+            if unknown:
+                raise InvalidConfigurationError(
+                    f"Unknown commitizen config keys: {', '.join(unknown)}"
+                )
         self._settings.update(data)
 
     def _parse_setting(self, data: bytes | str) -> None:

--- a/commitizen/config/base_config.py
+++ b/commitizen/config/base_config.py
@@ -50,7 +50,7 @@ class BaseConfig:
         raise NotImplementedError()
 
     def update(self, data: Settings) -> None:
-        if self._settings.get("strict_config"):
+        if self._settings.get("strict_config") or data.get("strict_config"):
             unknown = sorted(set(data) - _VALID_CONFIG_KEYS)
             if unknown:
                 raise InvalidConfigurationError(

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -65,6 +65,6 @@ class JsonConfig(BaseConfig):
             raise InvalidConfigurationError(f"Failed to parse {self.path}: {e}")
 
         try:
-            self.settings.update(doc["commitizen"])
+            self.update(doc["commitizen"])
         except KeyError:
             pass

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -65,6 +65,6 @@ class TomlConfig(BaseConfig):
             raise InvalidConfigurationError(f"Failed to parse {self.path}: {e}")
 
         try:
-            self.settings.update(doc["tool"]["commitizen"])  # type: ignore[index,typeddict-item] # TODO: fix this
+            self.update(doc["tool"]["commitizen"])  # type: ignore[index,arg-type]
         except exceptions.NonExistentKey:
             pass

--- a/commitizen/config/yaml_config.py
+++ b/commitizen/config/yaml_config.py
@@ -51,7 +51,7 @@ class YAMLConfig(BaseConfig):
             raise InvalidConfigurationError(f"Failed to parse {self.path}: {e}")
 
         try:
-            self.settings.update(doc["commitizen"])
+            self.update(doc["commitizen"])
         except (KeyError, TypeError):
             pass
 

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -65,6 +65,7 @@ class Settings(TypedDict, total=False):
     version_type: str | None
     version: str | None
     breaking_change_exclamation_in_title: bool
+    strict_config: bool
 
 
 CONFIG_FILES: tuple[str, ...] = (
@@ -115,6 +116,7 @@ DEFAULT_SETTINGS: Settings = {
     "extras": {},
     "breaking_change_exclamation_in_title": False,
     "message_length_limit": 0,  # 0 for no limit
+    "strict_config": False,
 }
 
 MAJOR = "MAJOR"

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -497,3 +497,65 @@ class TestYamlConfig:
         with pytest.raises(InvalidConfigurationError) as excinfo:
             YAMLConfig(data=existing_content, path=path)
         assert config_file in str(excinfo.value)
+
+
+class TestStrictConfig:
+    """Tests for the strict_config option that rejects unknown config keys."""
+
+    def test_toml_strict_config_raises_on_unknown_key(self, tmp_path):
+        data = """
+[tool.commitizen]
+strict_config = true
+tga_format = "v$version"
+"""
+        path = tmp_path / "pyproject.toml"
+        with pytest.raises(InvalidConfigurationError, match="tga_format"):
+            TomlConfig(data=data, path=path)
+
+    def test_json_strict_config_raises_on_unknown_key(self, tmp_path):
+        data = json.dumps(
+            {"commitizen": {"strict_config": True, "tga_format": "v$version"}}
+        )
+        path = tmp_path / ".cz.json"
+        with pytest.raises(InvalidConfigurationError, match="tga_format"):
+            JsonConfig(data=data, path=path)
+
+    def test_yaml_strict_config_raises_on_unknown_key(self, tmp_path):
+        data = "commitizen:\n  strict_config: true\n  tga_format: v$version\n"
+        path = tmp_path / ".cz.yaml"
+        with pytest.raises(InvalidConfigurationError, match="tga_format"):
+            YAMLConfig(data=data, path=path)
+
+    def test_strict_config_off_by_default_ignores_unknown_key(self, tmp_path):
+        data = """
+[tool.commitizen]
+tga_format = "v$version"
+"""
+        path = tmp_path / "pyproject.toml"
+        cfg = TomlConfig(data=data, path=path)
+        assert cfg.settings.get("strict_config") is False
+
+    def test_strict_config_allows_all_known_keys(self, tmp_path):
+        data = """
+[tool.commitizen]
+strict_config = true
+name = "cz_conventional_commits"
+tag_format = "v$version"
+"""
+        path = tmp_path / "pyproject.toml"
+        cfg = TomlConfig(data=data, path=path)
+        assert cfg.settings["strict_config"] is True
+        assert cfg.settings["tag_format"] == "v$version"
+
+    def test_strict_config_error_lists_all_unknown_keys(self, tmp_path):
+        data = """
+[tool.commitizen]
+strict_config = true
+typo_one = "foo"
+typo_two = "bar"
+"""
+        path = tmp_path / "pyproject.toml"
+        with pytest.raises(InvalidConfigurationError) as excinfo:
+            TomlConfig(data=data, path=path)
+        assert "typo_one" in str(excinfo.value)
+        assert "typo_two" in str(excinfo.value)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -112,6 +112,7 @@ _settings: dict[str, Any] = {
     "extras": {},
     "breaking_change_exclamation_in_title": False,
     "message_length_limit": 0,
+    "strict_config": False,
 }
 
 _new_settings: dict[str, Any] = {
@@ -152,6 +153,7 @@ _new_settings: dict[str, Any] = {
     "extras": {},
     "breaking_change_exclamation_in_title": False,
     "message_length_limit": 0,
+    "strict_config": False,
 }
 
 


### PR DESCRIPTION
## Summary

Closes #300

When users have a typo in their commitizen config (e.g. `tga_format` instead of `tag_format`), commitizen silently ignores the unknown key. This PR adds a `strict_config` option that raises `InvalidConfigurationError` on unrecognised config keys, catching mistakes early.

### Usage

```toml
[tool.commitizen]
strict_config = true
tga_format = "v$version"   # typo — raises InvalidConfigurationError
```

```
commitizen.exceptions.InvalidConfigurationError: Unknown commitizen config keys: tga_format
```

When `strict_config = false` (the default), behaviour is unchanged.

### Changes

- `commitizen/defaults.py` — added `strict_config: bool` to `Settings` TypedDict and `"strict_config": False` to `DEFAULT_SETTINGS`
- `commitizen/config/base_config.py` — added `_VALID_CONFIG_KEYS` (derived from `Settings.__annotations__`); added unknown-key check in `update()` when `strict_config=True`
- `commitizen/config/toml_config.py`, `json_config.py`, `yaml_config.py` — changed `self.settings.update(...)` → `self.update(...)` so the validation runs during config loading
- `tests/test_conf.py` — new `TestStrictConfig` class covering TOML, JSON, and YAML parsers; default-off behaviour; valid keys; and multi-key error messages