### PR TITLE
ci(bump): gracefully handle no bump-eligible commits

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -38,18 +38,29 @@ jobs:
           git-user-email: "${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
       - id: bump-version
         run: |
-          cz bump --yes
+          old_sha="$(git rev-parse HEAD)"
+          cz bump --yes --no-raise 21
+
+          if [ "$(git rev-parse HEAD)" = "$old_sha" ]; then
+            echo "No bump-eligible commits found, skipping release."
+            echo "bumped=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "bumped=true" >> $GITHUB_OUTPUT
           git push --follow-tags
           new_version="$(cz version -p)"
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
           new_version_tag="$(cz version -p --tag)"
           echo "new_version_tag=$new_version_tag" >> $GITHUB_OUTPUT
       - name: Build changelog for Release
+        if: steps.bump-version.outputs.bumped == 'true'
         env:
           NEW_VERSION: ${{ steps.bump-version.outputs.new_version }}
         run: |
           cz changelog --dry-run "${NEW_VERSION}" > .changelog.md
       - name: Release
+        if: steps.bump-version.outputs.bumped == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           NEW_VERSION_TAG: ${{ steps.bump-version.outputs.new_version_tag }}


### PR DESCRIPTION
## Description

When non-bump-eligible commits (e.g. `docs:`, `ci:`, `build(deps):`) are pushed to master, `cz bump --yes` exits with code 21 (`NO_COMMITS_TO_BUMP`), causing the bump workflow to fail.

Out of the last 20 runs, ~12 failed this way — see [recent example](https://github.com/commitizen-tools/commitizen/actions/runs/25540175155/job/74964187204).

This PR handles exit code 21 explicitly: log a message, set `bumped=false`, and exit 0. The `Build changelog` and `Release` steps are now conditional on `bumped == 'true'`. All other non-zero exit codes still fail the workflow as before.

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [X] This is a CI-only change (no code changes, no tests needed)
- [X] Manually test the changes:
  - [X] Verified by reviewing recent workflow run logs — exit code 21 is the sole cause of these failures
  - [X] Backward compatible — real bumps (exit code 0) and actual errors (other exit codes) behave identically

### Documentation Changes

N/A — CI workflow only.

## Expected Behavior

When commits like `docs:`, `ci:`, or `build(deps):` are pushed to master, the bump workflow should succeed gracefully (with a "No bump-eligible commits found" message) instead of failing with exit code 21.

## Steps to Test This Pull Request

1. Push a `docs:` or `ci:` commit to master
2. Observe the bump workflow succeeds and skips the changelog/release steps

## Additional Context

Related workflow: `.github/workflows/bumpversion.yml`