### PR TITLE
fix(types): correct nullability of config fields in command TypedDicts

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -47,7 +47,7 @@ class BumpArgs(Settings, total=False):
     check_consistency: bool
     devrelease: int | None
     dry_run: bool
-    file_name: str
+    file_name: str | None
     files_only: bool | None
     version_files_only: bool | None
     get_next: bool  # TODO: maybe rename to `next_version_to_stdout`

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -31,17 +31,17 @@ class ChangelogArgs(TypedDict, total=False):
     change_type_order: list[str]
     current_version: str
     dry_run: bool
-    file_name: str
+    file_name: str | None
     incremental: bool
     merge_prerelease: bool
     rev_range: str
-    start_rev: str
-    tag_format: str
+    start_rev: str | None
+    tag_format: str | None
     unreleased_version: str | None
-    version_scheme: str
-    template: str
-    extras: dict[str, Any]
-    export_template: str
+    version_scheme: str | None
+    template: str | None
+    extras: dict[str, Any] | None
+    export_template: str | None
     during_version_bump: bool | None
     allow_no_commit: bool | None  # Internal-only when invoked by bump.
 

--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -21,8 +21,8 @@ class CheckArgs(TypedDict, total=False):
     commit_msg: str
     rev_range: str
     allow_abort: bool
-    message_length_limit: int
-    allowed_prefixes: list[str]
+    message_length_limit: int | None
+    allowed_prefixes: list[str] | None
     message: str
     use_default_range: bool
 

--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -35,7 +35,7 @@ class CommitArgs(TypedDict, total=False):
     dry_run: bool
     edit: bool
     extra_cli_args: list[str]
-    message_length_limit: int
+    message_length_limit: int | None
     no_retry: bool
     signoff: bool
     write_message_to_file: Path | None


### PR DESCRIPTION
## Description

Several command TypedDicts declared fields as non-nullable (`int`, `str`, `dict`, `list`) while argparse produces `None` when CLI flags are omitted. Runtime code already handles `None` correctly (via `or` fallbacks, `.get()`, explicit `None` checks), but the type annotations were misleading to both developers and mypy.

### Changes

- **CommitArgs**: `message_length_limit: int` → `int | None`
- **CheckArgs**: `message_length_limit: int` → `int | None`, `allowed_prefixes: list[str]` → `list[str] | None`
- **BumpArgs**: `file_name: str` → `str | None`
- **ChangelogArgs**: `file_name`, `start_rev`, `tag_format`, `version_scheme`, `export_template`, `template` → add `| None`; `extras` → `dict[str, Any] | None`

### Scope

Type annotations only — no behavioral changes.

### Audit findings

A full audit of all `Settings` fields and command TypedDicts found these inconsistency patterns:

**1. CLI args produce `None` but TypedDict says non-nullable (fixed in this PR)**

| Field | TypedDict | CLI default |
|---|---|---|
| `message_length_limit` | `int` in `CommitArgs`, `CheckArgs` | `None` (no argparse default) |
| `allowed_prefixes` | `list[str]` in `CheckArgs` | `None` (`nargs="*"`, no default) |
| `file_name` | `str` in `BumpArgs`, `ChangelogArgs` | `None` (no default) |
| `start_rev`, `tag_format`, `version_scheme`, `export_template`, `template` | `str` in `ChangelogArgs` | `None` |
| `extras` | `dict[str, Any]` in `ChangelogArgs` | `None` (`ParseKwargs` action, no default) |

**2. `<= 0` guard consistency for `message_length_limit`**

Both code paths correctly treat `0` and negatives as "no limit":
- `commit.py:92-93`: `if message_length_limit is None or message_length_limit <= 0`
- `check.py` → `base.py:133`: `if max_msg_length is not None and max_msg_length > 0`

The `None` check in `commit.py:93` was dead code to mypy (type said `int`). This PR makes it type-correct.

The behavioral bug where `arguments.get("key", fallback)` returns `None` instead of falling through to config is tracked separately in #1899 / #1900.

**3. Out of scope (no changes needed or separate concerns)**

- `Settings` TypedDict itself: already `total=False`, so missing defaults aren't a type error
- Fields missing from `DEFAULT_SETTINGS` (`annotated_tag`, `gpg_sign`, `change_type_map`, `style`, `customize`, `version_type`): all accessed via `.get()` or guarded — no runtime risk
- `BumpArgs(Settings)` inheritance design: structural refactor tracked in #1672 / #1812
- Config validation/coercion layer: `base_config.py:49` does raw `update()` with no type checking — larger effort

### Related

- #1899 — the `message_length_limit` config-ignored bug (this PR makes the types accurate; the behavioral fix is in #1900)
- #1900 — behavioral fix for `message_length_limit` precedence (complementary, no conflict)
- #1812 — `ChainMap`-based settings refactor (complementary, no conflict)
- #1672 — tracking issue for the settings chain redesign

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-with: GitHub Copilot CLI following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [X] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [X] Manually test the changes
- [ ] Update the documentation for the changes

No test or doc changes needed — this is a pure type annotation fix with no behavioral impact.