### PR TITLE
docs(skill): point install guidance at docs README

### DIFF
--- a/.agents/skills/commitizen/SKILL.md
+++ b/.agents/skills/commitizen/SKILL.md
@@ -6,7 +6,7 @@ compatibility: Git repository with Python and Commitizen available as `cz` or ru
 metadata:
   project: commitizen-tools/commitizen
   docs: https://commitizen-tools.github.io/commitizen/
-  install: "pip install commitizen"
+  install: "pipx install commitizen"
 ---
 
 # Commitizen
@@ -39,7 +39,7 @@ Commitizen is a CLI for enforcing Conventional Commits, automating version bumps
 
 ## Important domain details
 
-- Commitizen installs with `pip install commitizen` or `uv add commitizen`.
+- Commitizen supports both global installation (recommended for the `cz` CLI) and project-local installation; see the installation section in `docs/README.md` for the full matrix of supported tools.
 - The default version scheme is PEP 440; `semver` and `semver2` are also supported.
 - Common version providers include `commitizen`, `pep621`, `poetry`, `cargo`, `npm`, `composer`, `uv`, and `scm`.
 - `cz changelog` generates Markdown changelogs.
@@ -63,6 +63,8 @@ Commitizen is a CLI for enforcing Conventional Commits, automating version bumps
   - `docs/tutorials/gitlab_ci.md`
 - Error handling:
   - `docs/exit_codes.md`
+- Installation:
+  - `docs/README.md` (see the *Installation* section for global vs project-local options)
 
 ## Examples
 


### PR DESCRIPTION
## Description

Follow-up to #1949 addressing review feedback from @philipp-horstenkamp:

> [Shouldn't this be pipx or uv?](https://github.com/commitizen-tools/commitizen/pull/1949#discussion_r3210779160)

The merged `.agents/skills/commitizen/SKILL.md` advertised `pip install commitizen` as the install command, but `docs/README.md` recommends `pipx install commitizen` or `uv tool install commitizen` for global installs of the `cz` CLI; `pip install -U commitizen` is documented only as a project-specific install.

### Changes

- Frontmatter `install:` updated from `pip install commitizen` to `pipx install commitizen` to match the docs' primary recommendation.
- Replaced the inline install command list in *Important domain details* (which had the same `pip`/`uv add` discrepancy) with a short pointer that defers to `docs/README.md`'s Installation section.
- Added an `Installation:` entry under *Suggested references*, matching the file's existing pattern of referencing `docs/...md`.

### Why a pointer instead of duplicating the matrix

Keeping the full install command list in two places was the root cause of the original review comment: the SKILL.md had drifted from the docs. Pointing at `docs/README.md` makes the docs the single source of truth. The frontmatter still carries one canonical command because the Agent Skills spec expects a literal command there.

### Why not extract a separate `docs/installation.md`

That was considered, but it expands scope (mkdocs nav + `llmstxt` config + risk of breaking external links to the README's `#installation` anchor) beyond the original review concern. It can be a separate proposal if desired.

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot CLI)

Generated-by: GitHub Copilot CLI following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [ ] Add test cases to all the changes you introduce (N/A - docs only)
- [X] Run `uv run poe all` locally to ensure this change passes linter check and tests (no Python files touched; pre-commit hooks pass on push)
- [X] Manually test the changes:
  - [X] Verify the feature/bug fix works as expected in real-world scenarios (verified install commands match `docs/README.md` lines 62-122)
  - [X] Test edge cases and error conditions
  - [X] Ensure backward compatibility is maintained
- [X] Update the documentation for the changes

### Documentation Changes

- [X] Run `uv run poe doc` locally to ensure the documentation pages renders correctly (only `.agents/skills/commitizen/SKILL.md` changed, not part of the mkdocs site)
- [X] Check and fix any broken links (internal or external) - verified `docs/README.md` reference is valid

## Steps to Test This Pull Request

1. Open `.agents/skills/commitizen/SKILL.md`.
2. Confirm the frontmatter `install:` is `pipx install commitizen`.
3. Confirm the *Important domain details* item points to `docs/README.md` rather than listing install commands inline.
4. Confirm *Suggested references* contains an `Installation` entry pointing to `docs/README.md`.

## Additional Context

Addresses unresolved review feedback from #1949 (already merged).