### PR TITLE
ci: place --no-raise before bump subcommand in bumpversion.yml

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -39,7 +39,7 @@ jobs:
       - id: bump-version
         run: |
           old_sha="$(git rev-parse HEAD)"
-          cz bump --yes --no-raise 21
+          cz --no-raise 21 bump --yes
 
           if [ "$(git rev-parse HEAD)" = "$old_sha" ]; then
             echo "No bump-eligible commits found, skipping release."


### PR DESCRIPTION
## Description

Fixes the bump workflow that has been failing on master since #1950 was merged.

The bump step uses:

```bash
cz bump --yes --no-raise 21
```

but [`--no-raise` is a top-level commitizen option](https://github.com/commitizen-tools/commitizen/blob/master/commitizen/cli.py#L100-L106), so it must come **before** the `bump` subcommand. With it placed after, argparse treats `--no-raise 21` as unknown trailing arguments and the CLI exits with code 18 (`INVALID_COMMAND_ARGUMENT`):

> Invalid commitizen arguments were found: `--no-raise`. Please use -- separator for extra git args

This is what failed [run 25542335831](https://github.com/commitizen-tools/commitizen/actions/runs/25542335831/job/74970749920).

## Fix

Move `--no-raise 21` before `bump`:

```bash
cz --no-raise 21 bump --yes
```

Verified locally:

```
$ cz bump --yes --dry-run --no-raise 21
Invalid commitizen arguments were found: `--no-raise`. Please use -- separator for extra git args
$ echo $?
18

$ cz --no-raise 21 bump --yes --dry-run
bump: version 4.15.1 → 4.16.0
tag to create: v4.16.0
increment detected: MINOR
$ echo $?
0
```

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing/)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot
