### PR TITLE
docs(exit_codes): note that --no-raise must precede the subcommand

### DIFF
--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -57,6 +57,24 @@ The `--no-raise` (or `-nr`) flag allows you to specify exit codes that should no
 
 Multiple exit codes can be specified as a comma-separated list.
 
+!!! warning "Flag placement"
+    `--no-raise` / `-nr` is a **top-level Commitizen flag**, so it must be passed
+    **before** the subcommand:
+
+    ```sh
+    cz --no-raise 21 bump --yes        # ✅ correct
+    cz -nr 21 bump --yes               # ✅ correct (short form)
+    ```
+
+    Placing it after the subcommand fails with exit code 18
+    (`InvalidCommandArgumentError`):
+
+    ```sh
+    cz bump --yes --no-raise 21        # ❌ wrong
+    # Invalid commitizen arguments were found: `--no-raise`.
+    # Please use -- separator for extra git args
+    ```
+
 ### Common Use Cases
 
 #### Ignoring No Increment Errors


### PR DESCRIPTION
## Description

Adds a placement warning for `--no-raise` / `-nr` in `docs/exit_codes.md`.

`--no-raise` is registered on the top-level parser ([`commitizen/cli.py:100-106`](https://github.com/commitizen-tools/commitizen/blob/master/commitizen/cli.py#L100-L106)), so it must appear **before** the subcommand. Placing it after falls into the unknown-args validator and exits with code 18 (`InvalidCommandArgumentError`):

> Invalid commitizen arguments were found: `--no-raise`. Please use -- separator for extra git args

All existing examples in `docs/exit_codes.md` already use the correct placement, but the constraint is never stated explicitly. Two recent PRs got it wrong despite the docs being clear by example:

- commitizen-tools/commitizen#1950 — broke the bump workflow on master ([failing run](https://github.com/commitizen-tools/commitizen/actions/runs/25542335831/job/74970749920); fix in #1954)
- commitizen-tools/setup-cz#17 — same mistake in copy-pasteable example workflows

This PR adds a `!!! warning "Flag placement"` admonition immediately after the flag is introduced, so the rule is impossible to miss when readers skim that section.

## Preview

````markdown
!!! warning "Flag placement"
    `--no-raise` / `-nr` is a **top-level Commitizen flag**, so it must be passed
    **before** the subcommand:

    ```sh
    cz --no-raise 21 bump --yes        # ✅ correct
    cz -nr 21 bump --yes               # ✅ correct (short form)
    ```

    Placing it after the subcommand fails with exit code 18
    (`InvalidCommandArgumentError`):

    ```sh
    cz bump --yes --no-raise 21        # ❌ wrong
    # Invalid commitizen arguments were found: `--no-raise`.
    # Please use -- separator for extra git args
    ```
````

No code changes; documentation only.

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing/)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot
