### PR TITLE
ci: add PR bump preview workflow

### DIFF
--- a/.github/workflows/pr-bump-preview.yml
+++ b/.github/workflows/pr-bump-preview.yml
@@ -10,19 +10,30 @@ permissions:
 
 jobs:
   bump-preview:
-    if: ${{ github.event.pull_request.draft == false }}
+    # Skip drafts, and skip fork PRs entirely. `pull_request_target` runs with
+    # the base repo's GITHUB_TOKEN (write access to PR comments). `cz bump`
+    # can render Jinja templates from the checked-out workspace whenever
+    # `update_changelog_on_bump` is set in config, and the renderer is not
+    # sandboxed (FileSystemLoader('.')) — running it against fork-controlled
+    # files would risk RCE / token exfiltration. Same-repo PRs are written by
+    # collaborators who already have push access, so the same risk doesn't
+    # apply.
+    if: >
+      ${{
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name ==
+          github.event.pull_request.base.repo.full_name
+      }}
     runs-on: ubuntu-latest
     steps:
-      # Using pull_request_target means GITHUB_TOKEN has write access to PR
-      # comments even for fork PRs. We deliberately only run `cz bump --dry-run`
-      # against the checked-out PR commits — no PR-controlled scripts are
-      # executed, so this is safe.
       - name: Check out PR head
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           fetch-tags: true
+          # Defense in depth: don't write the workflow token to .git/config.
+          persist-credentials: false
 
       - name: Set up Commitizen
         uses: commitizen-tools/setup-cz@main

--- a/.github/workflows/pr-bump-preview.yml
+++ b/.github/workflows/pr-bump-preview.yml
@@ -1,0 +1,83 @@
+name: PR bump preview
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bump-preview:
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      # Using pull_request_target means GITHUB_TOKEN has write access to PR
+      # comments even for fork PRs. We deliberately only run `cz bump --dry-run`
+      # against the checked-out PR commits — no PR-controlled scripts are
+      # executed, so this is safe.
+      - name: Check out PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Commitizen
+        uses: commitizen-tools/setup-cz@main
+        with:
+          set-git-config: false
+
+      - name: Run cz bump --dry-run
+        id: dry-run
+        run: |
+          set +e
+          output="$(cz bump --dry-run --yes 2>&1)"
+          status=$?
+          set -e
+          {
+            echo "status=${status}"
+            echo "output<<__CZ_BUMP_PREVIEW__"
+            printf '%s\n' "${output}"
+            echo "__CZ_BUMP_PREVIEW__"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build comment body
+        env:
+          STATUS: ${{ steps.dry-run.outputs.status }}
+          OUTPUT: ${{ steps.dry-run.outputs.output }}
+        run: |
+          {
+            echo "<!-- commitizen-bump-preview -->"
+            echo "## 🔍 Commitizen bump preview"
+            echo ""
+            case "${STATUS}" in
+              0)
+                echo "Merging this PR will produce the following bump:"
+                echo ""
+                echo '```'
+                printf '%s\n' "${OUTPUT}"
+                echo '```'
+                ;;
+              21)
+                echo "No commits in this PR are eligible for a version bump."
+                ;;
+              *)
+                echo "⚠️ \`cz bump --dry-run\` exited with status \`${STATUS}\`:"
+                echo ""
+                echo '```'
+                printf '%s\n' "${OUTPUT}"
+                echo '```'
+                ;;
+            esac
+          } > comment.md
+
+      - name: Post or update PR comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: comment.md
+          body-includes: "<!-- commitizen-bump-preview -->"
+          edit-mode: replace

--- a/docs/tutorials/github_actions.md
+++ b/docs/tutorials/github_actions.md
@@ -123,6 +123,108 @@ jobs:
 
 You can find the complete workflow in our repository at [bumpversion.yml](https://github.com/commitizen-tools/commitizen/blob/master/.github/workflows/bumpversion.yml).
 
+### Previewing the version bump on pull requests
+
+To help reviewers spot unexpected version bumps before merging, you can run
+`cz bump --dry-run` on every pull request and post (or update) a sticky
+comment summarizing the would-be version bump and changelog entries.
+
+Create `.github/workflows/pr-bump-preview.yml`:
+
+```yaml title=".github/workflows/pr-bump-preview.yml"
+name: PR bump preview
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bump-preview:
+    if: ${{ github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: commitizen-tools/setup-cz@main
+        with:
+          set-git-config: false
+      - name: Run cz bump --dry-run
+        id: dry-run
+        run: |
+          set +e
+          output="$(cz bump --dry-run --yes 2>&1)"
+          status=$?
+          set -e
+          {
+            echo "status=${status}"
+            echo "output<<__CZ_BUMP_PREVIEW__"
+            printf '%s\n' "${output}"
+            echo "__CZ_BUMP_PREVIEW__"
+          } >> "$GITHUB_OUTPUT"
+      - name: Build comment body
+        env:
+          STATUS: ${{ steps.dry-run.outputs.status }}
+          OUTPUT: ${{ steps.dry-run.outputs.output }}
+        run: |
+          {
+            echo "<!-- commitizen-bump-preview -->"
+            echo "## 🔍 Commitizen bump preview"
+            echo ""
+            case "${STATUS}" in
+              0)
+                echo "Merging this PR will produce the following bump:"
+                echo ""
+                echo '```'
+                printf '%s\n' "${OUTPUT}"
+                echo '```'
+                ;;
+              21)
+                echo "No commits in this PR are eligible for a version bump."
+                ;;
+              *)
+                echo "⚠️ \`cz bump --dry-run\` exited with status \`${STATUS}\`:"
+                echo ""
+                echo '```'
+                printf '%s\n' "${OUTPUT}"
+                echo '```'
+                ;;
+            esac
+          } > comment.md
+      - uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: comment.md
+          body-includes: "<!-- commitizen-bump-preview -->"
+          edit-mode: replace
+```
+
+#### How it works
+
+- **Trigger**: `pull_request_target` runs in the context of the base
+  repository, which gives the workflow `pull-requests: write` permission
+  even for PRs from forks. The job only runs `cz bump --dry-run`, a
+  read-only command, so it does not execute any PR-controlled scripts.
+- **Setup**: [`commitizen-tools/setup-cz`](https://github.com/commitizen-tools/setup-cz)
+  installs the Commitizen CLI; no language-specific build tooling is required.
+- **Dry-run**: `cz bump --dry-run --yes` computes the next version and the
+  changelog entries that would be produced. Exit code `21` (`NoneIncrementExit`)
+  is treated as "no eligible bump" rather than a failure.
+- **Sticky comment**: The hidden HTML marker `<!-- commitizen-bump-preview -->`
+  lets [`peter-evans/create-or-update-comment`](https://github.com/peter-evans/create-or-update-comment)
+  find and replace the previous preview on every push, instead of leaving a
+  growing trail of comments.
+
+You can find the complete workflow in our repository at [pr-bump-preview.yml](https://github.com/commitizen-tools/commitizen/blob/master/.github/workflows/pr-bump-preview.yml).
+
 ### Publishing a Python package
 
 After a new version tag is created by the bump workflow, you can automatically publish your package to PyPI.

--- a/docs/tutorials/github_actions.md
+++ b/docs/tutorials/github_actions.md
@@ -127,7 +127,7 @@ You can find the complete workflow in our repository at [bumpversion.yml](https:
 
 To help reviewers spot unexpected version bumps before merging, you can run
 `cz bump --dry-run` on every pull request and post (or update) a sticky
-comment summarizing the would-be version bump and changelog entries.
+comment summarizing the would-be version bump.
 
 Create `.github/workflows/pr-bump-preview.yml`:
 
@@ -144,7 +144,13 @@ permissions:
 
 jobs:
   bump-preview:
-    if: ${{ github.event.pull_request.draft == false }}
+    # Skip drafts and fork PRs (see "How it works" below).
+    if: >
+      ${{
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name ==
+          github.event.pull_request.base.repo.full_name
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out PR head
@@ -153,6 +159,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
       - uses: commitizen-tools/setup-cz@main
         with:
           set-git-config: false
@@ -211,17 +218,29 @@ jobs:
 
 - **Trigger**: `pull_request_target` runs in the context of the base
   repository, which gives the workflow `pull-requests: write` permission
-  even for PRs from forks. The job only runs `cz bump --dry-run`, a
-  read-only command, so it does not execute any PR-controlled scripts.
+  even for PRs from forks. We deliberately gate the job to **same-repo PRs
+  only** (`head.repo == base.repo`); fork PRs are skipped. This is because
+  `cz bump` renders [Jinja templates from the working directory][jinja]
+  whenever [`update_changelog_on_bump`](../config/configuration_file.md) is
+  enabled, and the renderer is not sandboxed — running it against
+  fork-controlled files under a write token would risk arbitrary code
+  execution and token exfiltration. Same-repo PRs are written by
+  collaborators who already have push access, so the same risk doesn't
+  apply.
 - **Setup**: [`commitizen-tools/setup-cz`](https://github.com/commitizen-tools/setup-cz)
   installs the Commitizen CLI; no language-specific build tooling is required.
-- **Dry-run**: `cz bump --dry-run --yes` computes the next version and the
-  changelog entries that would be produced. Exit code `21` (`NoneIncrementExit`)
+- **Defense in depth**: `persist-credentials: false` on `actions/checkout`
+  keeps the workflow token out of the local git config.
+- **Dry-run**: `cz bump --dry-run --yes` computes the next version (and, if
+  `update_changelog_on_bump` is set in your config, also the changelog
+  entries that would be produced). Exit code `21` (`NoneIncrementExit`)
   is treated as "no eligible bump" rather than a failure.
 - **Sticky comment**: The hidden HTML marker `<!-- commitizen-bump-preview -->`
   lets [`peter-evans/create-or-update-comment`](https://github.com/peter-evans/create-or-update-comment)
   find and replace the previous preview on every push, instead of leaving a
   growing trail of comments.
+
+[jinja]: https://github.com/commitizen-tools/commitizen/blob/master/commitizen/changelog.py
 
 You can find the complete workflow in our repository at [pr-bump-preview.yml](https://github.com/commitizen-tools/commitizen/blob/master/.github/workflows/pr-bump-preview.yml).
 


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow that runs `cz bump --dry-run` against every incoming pull request and posts (or updates) a sticky comment summarising the would-be version bump and changelog entries. Reviewers can spot unexpected version bumps before merging.

The pattern is also documented in `docs/tutorials/github_actions.md` so other projects can copy/paste the same workflow.

## How it works

- **Trigger**: `pull_request_target` (matches `label_pr.yml`) so the workflow has `pull-requests: write` even for fork PRs. The job only runs `cz bump --dry-run`, a read-only command, so PR-controlled scripts are not executed.
- **Setup**: Uses [`commitizen-tools/setup-cz`](https://github.com/commitizen-tools/setup-cz) — no language-specific toolchain required.
- **Dry-run**: Captures `cz bump --dry-run --yes` output and exit status. Exit code `21` (`NoneIncrementExit`) is treated as "no eligible bump" instead of an error; other non-zero codes are surfaced in the comment.
- **Sticky comment**: A hidden `<!-- commitizen-bump-preview -->` marker lets [`peter-evans/create-or-update-comment`](https://github.com/peter-evans/create-or-update-comment) edit the previous preview in place on every push instead of stacking comments.

Companion changes are being prepared for `commitizen-tools/commitizen-action` (replaces the draft #102 attempt) and `commitizen-tools/setup-cz` (`examples/`) so the same pattern is available to consumers of either action.

Closes #1510

## Type of changes

- [x] CI/CD related
- [x] Documentation update

## Steps to Test This Pull Request

The workflow self-tests once it lands on `master`: open a follow-up PR and confirm a `🔍 Commitizen bump preview` comment appears and updates as you push commits.

## Expected output

The workflow posts (and replaces on every push) a single sticky comment whose body depends on the dry-run exit code.

**`cz bump --dry-run --yes` succeeds (status 0) — eligible bump:**

<details>
<summary>Rendered comment</summary>

> ## 🔍 Commitizen bump preview
>
> Merging this PR will produce the following bump:
>
> ```
> bump: version 4.15.1 → 4.16.0
> tag to create: v4.16.0
> increment detected: MINOR
> ```

</details>

````markdown
<!-- commitizen-bump-preview -->
## 🔍 Commitizen bump preview

Merging this PR will produce the following bump:

```
bump: version 4.15.1 → 4.16.0
tag to create: v4.16.0
increment detected: MINOR
```
````

**`NoneIncrementExit` (status 21) — no eligible commits:**

> ## 🔍 Commitizen bump preview
>
> No commits in this PR are eligible for a version bump.

**Any other non-zero status — error surfaced inside the comment:**

> ## 🔍 Commitizen bump preview
>
> ⚠️ `cz bump --dry-run` exited with status `3`:
>
> ```
> NoCommitsFoundError
> ```

The status-0 example above is the literal output of `cz bump --dry-run --yes` against the current `master` of this repository (verified locally).

## Checklist

- [x] My PR title follows [conventional commit](https://www.conventionalcommits.org/) style
- [x] Documentation updated
