### PR TITLE
fix(conventional_commits): add missing version bump notes for all change types

### DIFF
--- a/commitizen/cz/conventional_commits/conventional_commits.py
+++ b/commitizen/cz/conventional_commits/conventional_commits.py
@@ -62,7 +62,10 @@ class ConventionalCommitsCz(BaseCommitizen):
                     },
                     {
                         "value": "docs",
-                        "name": "docs: Documentation only changes",
+                        "name": (
+                            "docs: Documentation only changes. "
+                            "Correlates with no version bump in SemVer"
+                        ),
                         "key": "d",
                     },
                     {
@@ -70,7 +73,8 @@ class ConventionalCommitsCz(BaseCommitizen):
                         "name": (
                             "style: Changes that do not affect the "
                             "meaning of the code (white-space, formatting,"
-                            " missing semi-colons, etc)"
+                            " missing semi-colons, etc). "
+                            "Correlates with no version bump in SemVer"
                         ),
                         "key": "s",
                     },
@@ -78,25 +82,33 @@ class ConventionalCommitsCz(BaseCommitizen):
                         "value": "refactor",
                         "name": (
                             "refactor: A code change that neither fixes "
-                            "a bug nor adds a feature"
+                            "a bug nor adds a feature. "
+                            "Correlates with PATCH in SemVer"
                         ),
                         "key": "r",
                     },
                     {
                         "value": "perf",
-                        "name": "perf: A code change that improves performance",
+                        "name": (
+                            "perf: A code change that improves performance. "
+                            "Correlates with PATCH in SemVer"
+                        ),
                         "key": "p",
                     },
                     {
                         "value": "test",
-                        "name": ("test: Adding missing or correcting existing tests"),
+                        "name": (
+                            "test: Adding missing or correcting existing tests. "
+                            "Correlates with no version bump in SemVer"
+                        ),
                         "key": "t",
                     },
                     {
                         "value": "build",
                         "name": (
                             "build: Changes that affect the build system or "
-                            "external dependencies (example scopes: pip, docker, npm)"
+                            "external dependencies (example scopes: pip, docker, npm). "
+                            "Correlates with no version bump in SemVer"
                         ),
                         "key": "b",
                     },
@@ -104,7 +116,8 @@ class ConventionalCommitsCz(BaseCommitizen):
                         "value": "ci",
                         "name": (
                             "ci: Changes to CI configuration files and "
-                            "scripts (example scopes: GitLabCI)"
+                            "scripts (example scopes: GitLabCI). "
+                            "Correlates with no version bump in SemVer"
                         ),
                         "key": "c",
                     },

--- a/commitizen/cz/conventional_commits/conventional_commits_info.txt
+++ b/commitizen/cz/conventional_commits/conventional_commits_info.txt
@@ -15,11 +15,16 @@ A BREAKING CHANGE can be part of commits of any type.
 Others: commit types other than fix: and feat: are allowed,
 like chore:, docs:, style:, refactor:, perf:, test:, and others.
 
-We also recommend improvement for commits that improve a current
-implementation without adding a new feature or fixing a bug.
-
 Notice these types are not mandated by the conventional commits specification,
 and have no implicit effect in semantic versioning (unless they include a BREAKING CHANGE).
+
+Commitizen extends this set with sensible defaults: by default, refactor: and perf:
+correlate with PATCH in semantic versioning, while docs:, style:, test:, build:, ci:,
+and other types do not bump the version (unless they include a BREAKING CHANGE).
+These defaults can be customized via the `bump_map` and `bump_pattern` settings.
+
+We also recommend improvement for commits that improve a current
+implementation without adding a new feature or fixing a bug.
 
 A scope may be provided to a commit’s type, to provide additional contextual
 information and is contained within parenthesis, e.g., feat(parser): add ability to parse arrays.

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -30,6 +30,11 @@ The version follows the `MAJOR.MINOR.PATCH` format, with increments determined b
 | `MINOR`   | New features                | `feat`                  |
 | `PATCH`   | Fixes and improvements      | `fix`, `perf`, `refactor`|
 
+Other Conventional Commit types recognized by Commitizen (such as `docs`, `style`, `test`, `build`, `ci`, and `chore`) do not bump the version unless they include a `BREAKING CHANGE`. You can customize this behavior with the [`bump_map`](../config/bump.md) and [`bump_pattern`](../config/bump.md) settings.
+
+!!! tip "Recommended reading on versioning"
+    For background on the strengths and limitations of semantic versioning, and on alternative versioning strategies, see the [Recommended Reading on Versioning](../external_links.md#recommended-reading-on-versioning).
+
 ## Command line options
 
 ![cz bump --help](../images/cli_help/cz_bump___help.svg)

--- a/docs/external_links.md
+++ b/docs/external_links.md
@@ -16,4 +16,23 @@
 - [How to Write Better Git Commit Messages – A Step-By-Step Guide](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/?utm_source=tldrnewsletter) (English)
 - [Continuous delivery made easy (in Python)](https://blog.devgenius.io/continuous-delivery-made-easy-in-python-c085e9c82e69)
 
+## Recommended Reading on Versioning
+
+The following articles, surfaced in the discussion of [issue #515][issue-515],
+provide useful background on the strengths and limitations of semantic
+versioning and on alternative versioning strategies. They can help calibrate
+expectations about what a version bump can — and cannot — guarantee to
+downstream consumers.
+
+- [Semantic Versioning Will Not Save You](https://hynek.me/articles/semver-will-not-save-you/) by Hynek Schlawack
+- [Why I don't like SemVer anymore](https://snarky.ca/why-i-dont-like-semver/) by Brett Cannon
+- [Versioning Software](https://caremad.io/posts/2016/02/versioning-software/) by Donald Stufft
+- [Hyrum's Law](https://www.hyrumslaw.com/) — on implicit behavioral contracts beyond the documented API
+- [0ver — Zero-based Versioning](https://0ver.org/)
+- [CalVer — Calendar Versioning](https://calver.org/)
+- [PEP 440 — Version Identification and Dependency Specification](https://peps.python.org/pep-0440/)
+- [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+- [Semantic Versioning 2.0.0](https://semver.org/)
+
 [automatizando]: https://youtu.be/t3aE2M8UPBo
+[issue-515]: https://github.com/commitizen-tools/commitizen/issues/515


### PR DESCRIPTION
## Description

Closes #515

Adds explicit version-bump documentation for every Conventional Commit type, both in the interactive `cz commit` prompt and in the `cz info` output, so users can immediately see how each type affects semantic versioning under Commitizen's defaults. Also adds a "Recommended Reading on Versioning" docs section gathering the articles surfaced during the issue discussion.

The first task in the issue (fixing the inaccurate "fix + everything else" rule in the bump docs) was already addressed by #1452. This PR completes the remaining tasks:

- [x] Add notes in commit message instructions to identify what version bump occurs with all change types (e.g., `Correlates with no version bump in SemVer`)
- [x] Add the recommended-reading articles raised in the issue thread, per discussion with @Lee-W

### What changed

- `commitizen/cz/conventional_commits/conventional_commits.py` — every prompt choice now spells out its version-bump impact, using the `Correlates with X in SemVer` phrasing already established by `fix` and `feat`:
  - `fix`, `feat` (unchanged): already correlated with PATCH/MINOR
  - `refactor`, `perf`: "Correlates with PATCH in SemVer"
  - `docs`, `style`, `test`, `build`, `ci`: "Correlates with no version bump in SemVer"

  Reflects the actual default `bump_map` (per @woile's [comment](https://github.com/commitizen-tools/commitizen/issues/515#issuecomment-1135093481): "fix, refactor and perf are patch, not everything"), not the alternative spec-only mapping.
- `commitizen/cz/conventional_commits/conventional_commits_info.txt` — clarifies that, on top of the Conventional Commits spec, Commitizen's defaults bump PATCH for `refactor` and `perf`, and don't bump for `docs`/`style`/`test`/`build`/`ci`. Notes that this can be customized via `bump_map`/`bump_pattern`.
- `docs/external_links.md` — new "Recommended Reading on Versioning" section linking the articles cited by @adam-grant-hendry: Hynek's *Semantic Versioning Will Not Save You*, Brett Cannon's *Why I don't like SemVer anymore*, Donald Stufft's *Versioning Software*, Hyrum's Law, 0ver, CalVer, PEP 440, plus the Conventional Commits / SemVer specs.
- `docs/commands/bump.md` — adds a clarifying sentence under the Version Increment Rules table for non-bumping types, plus a `tip` admonition cross-linking to the new reading list.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
  - `poe lint` (ruff + mypy): clean
  - Targeted tests around commit prompts/info (`test_cz_conventional_commits.py`, `test_cz_search_filter.py`, `test_check_command.py`, `test_commit_command.py`, `test_cz_customize.py`): 161 passed
  - Full test suite: 1274 passed; the 4 errors / 1 failure observed locally are pre-existing environmental issues (GPG keystore pollution and a Windows long-path flake), reproducible against `master` without these changes.
- [x] Update the documentation for the changes

### Documentation Changes

- [x] Run `uv run poe doc` locally to ensure the documentation pages renders correctly (`mkdocs build` clean)
- [x] Check and fix any broken links (internal or external) — all 9 external links return HTTP 200; internal anchor `external_links.md#recommended-reading-on-versioning` verified in the rendered site.

## Expected Behavior

Running `cz commit` shows the version-bump impact next to every change type, e.g.:

```
? Select the type of change you are committing
  > fix:      A bug fix. Correlates with PATCH in SemVer
    feat:     A new feature. Correlates with MINOR in SemVer
    docs:     Documentation only changes. Correlates with no version bump in SemVer
    style:    ... Correlates with no version bump in SemVer
    refactor: ... Correlates with PATCH in SemVer
    perf:     ... Correlates with PATCH in SemVer
    test:     ... Correlates with no version bump in SemVer
    build:    ... Correlates with no version bump in SemVer
    ci:       ... Correlates with no version bump in SemVer
```

`cz info` now also calls out Commitizen's defaults explicitly.

## Steps to Test This Pull Request

1. `uv sync --frozen --group base --group test --group linters --group documentation`
2. `uv run cz commit` — observe the new version-bump notes in the change-type prompt.
3. `uv run cz info` — observe the new paragraph clarifying Commitizen's defaults.
4. `uv run poe doc` — visit `external_links.md` and `commands/bump.md` to verify the new section and cross-link render correctly.

## Additional Context

- Refs #515
- Builds on #1452 (which fixed the inaccurate "fix + everything else" line in the bump docs).
