### PR TITLE
test(conftest): make GPG-signing fixture work on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,7 @@ ignore_missing_imports = true
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = '.git*,*.svg,*.lock'
 check-hidden = true
-ignore-words-list = 'asend'
+ignore-words-list = 'asend,fpr'
 
 [tool.poe]
 executor.type = "uv"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -123,12 +123,22 @@ def tmp_commitizen_project_initial(
 
 
 def _get_gpg_keyid(signer_mail):
-    _new_key = cmd.run(["gpg", "--list-secret-keys", signer_mail])
-    _m = re.search(
-        r"[a-zA-Z0-9 \[\]-_]*\n[ ]*([0-9A-Za-z]*)\n[\na-zA-Z0-9 \[\]-_<>@]*",
-        _new_key.out,
-    )
-    return _m.group(1) if _m else None
+    """Return the primary fingerprint of the first secret key matching ``signer_mail``.
+
+    Uses the stable ``--with-colons`` machine-readable format so we don't rely
+    on ``gpg``'s human-friendly layout, which differs between platforms (notably
+    CRLF on Windows).
+    """
+    _new_key = cmd.run(["gpg", "--with-colons", "--list-secret-keys", signer_mail])
+    in_sec = False
+    for line in _new_key.out.splitlines():
+        if line.startswith("sec:"):
+            in_sec = True
+        elif in_sec and line.startswith("fpr:"):
+            fields = line.split(":")
+            # Field index 9 holds the fingerprint per gpg(1) DETAILS.
+            return fields[9] if len(fields) > 9 and fields[9] else None
+    return None
 
 
 @pytest.fixture
@@ -139,6 +149,12 @@ def tmp_commitizen_project_with_gpg(tmp_commitizen_project):
     old_gnupghome = os.environ.get("GNUPGHOME")
     if os.name != "nt":
         os.environ["GNUPGHOME"] = gpg_home.name  # tempdir = temp keyring
+
+    # Resolve the absolute path to the gpg binary used by this fixture so that
+    # git invokes the same one (and therefore the same keyring). This matters
+    # on Windows where Git for Windows ships its own gpg binary that has a
+    # different keyring than a system-wide GnuPG/Gpg4win install.
+    gpg_binary = shutil.which("gpg")
 
     try:
         # create a key (a keyring will be generated within GPUPGHOME)
@@ -161,6 +177,8 @@ def tmp_commitizen_project_with_gpg(tmp_commitizen_project):
         # configure git to use gpg signing
         cmd.run(["git", "config", "commit.gpgsign", "true"])
         cmd.run(["git", "config", "user.signingkey", key_id])
+        if gpg_binary:
+            cmd.run(["git", "config", "gpg.program", gpg_binary])
 
         yield tmp_commitizen_project
     finally:


### PR DESCRIPTION
## Description

Make the GPG-related bump tests work on Windows hosts where Gpg4win and Git for Windows ship separate `gpg` binaries with separate keyrings.

Currently, the `tmp_commitizen_project_with_gpg` fixture fails on a typical Windows developer machine for two reasons:

1. `_get_gpg_keyid` parses `gpg --list-secret-keys` output with a regex that only handles LF line endings. On Windows, gpg emits CRLF, so the regex never matches and the fixture asserts out at `assert key_id`.
2. Even when a fingerprint can be extracted, the test key is created by the gpg in PATH (Gpg4win, `%APPDATA%\gnupg`), but `git commit -S` invokes the gpg bundled with Git for Windows (`~/.gnupg`). That gpg can't find the secret key and signing fails with `gpg: skipped "<fingerprint>": No secret key`.

## Changes

- Rewrite `_get_gpg_keyid` to parse the stable `gpg --with-colons --list-secret-keys` machine-readable format. Field 9 of the first `fpr:` line under a `sec:` block is the primary key fingerprint per the gpg DETAILS specification. This is line-ending agnostic.
- In `tmp_commitizen_project_with_gpg`, pin `git config gpg.program` to the absolute path of the gpg binary used to create the key (resolved via `shutil.which("gpg")`). This guarantees git uses the same gpg/keyring as the fixture on every platform.
- Add `fpr` to the codespell ignore list (`pyproject.toml`) so the gpg colon-output prefix used in the parser doesn't trip the spell check.

Behaviour on Linux / macOS is unchanged: `shutil.which("gpg")` returns the same gpg the subprocess call would have invoked anyway, and the `--with-colons` parser produces the same fingerprint as the previous regex.

## Verification

Locally on Windows (Gpg4win 2.5.19 + Git for Windows 2.4.9):

- Before: `test_bump_minor_increment_signed[*]` and `test_bump_minor_increment_signed_config_file[*]` error out during fixture setup (4 errors).
- After: full suite passes — 1289 passed, 3 skipped, 2 xfailed.

## Checklist

- [x] `uv run poe lint` clean
- [x] Existing test suite green locally on Windows