### PR TITLE
fix(tags): substitute ${devrelease} placeholder in tag_format

### DIFF
--- a/commitizen/tags.py
+++ b/commitizen/tags.py
@@ -212,6 +212,12 @@ class TagRules:
 
         major, minor, patch = (list(version.release) + [0, 0, 0])[:3]
         prerelease = version.prerelease or ""
+        # `dev` is the integer dev-release number (e.g. 1 for "0.1.0.dev1")
+        # or None if this version isn't a dev release. We render it as
+        # `dev<N>` to match how dev releases appear in PEP-440 / SemVer
+        # version strings.
+        dev = getattr(version, "dev", None)
+        devrelease = f"dev{dev}" if dev is not None else ""
 
         t = Template(tag_format)
         return t.safe_substitute(
@@ -220,6 +226,7 @@ class TagRules:
             minor=minor,
             patch=patch,
             prerelease=prerelease,
+            devrelease=devrelease,
         )
 
     def find_tag_for(

--- a/tests/test_bump_normalize_tag.py
+++ b/tests/test_bump_normalize_tag.py
@@ -12,6 +12,11 @@ conversion = [
     (("1.2.3+1.0.0", "v$version"), "v1.2.3+1.0.0"),
     (("1.2.3+1.0.0", "v$version-local"), "v1.2.3+1.0.0-local"),
     (("1.2.3+1.0.0", "ver$major.$minor.$patch"), "ver1.2.3"),
+    # `${devrelease}` substitution (#1615): rendered as `dev<N>` when the
+    # version has a dev release, and as the empty string otherwise.
+    (("1.2.3.dev1", "v$major.$minor.$patch.$devrelease"), "v1.2.3.dev1"),
+    (("1.2.3.dev0", "$major.$minor.$patch$devrelease"), "1.2.3dev0"),
+    (("1.2.3", "$major.$minor.$patch$devrelease"), "1.2.3"),
 ]
 
 


### PR DESCRIPTION
## Description

Closes #1615.

### Why

`TagRules.normalize_tag` in `commitizen/tags.py` builds tag strings by substituting placeholders in `tag_format` using Python's `string.Template.safe_substitute`. Before this fix the substitution dictionary (lines 217–223) included `version`, `major`, `minor`, `patch`, and `prerelease` — but not `devrelease`. A `tag_format` that references `${devrelease}` (for example `${major}.${minor}-${patch}${devrelease}`) therefore left the placeholder unsubstituted, producing a literal `${devrelease}` in the resulting tag name.

Reported by @pydal on commitizen 4.9.1 / Python 3.9 / Linux (#1615): running `cz bump --devrelease 1 --yes` with `tag_format = "${major}.${minor}-${patch}${devrelease}"` produced `tag to create: 0.0-2${devrelease}` and then actually created a git tag with that verbatim string. All subsequent dev-release bumps failed with a duplicate-tag error. A triage note from the open-issues audit ([2026-05-09](https://github.com/commitizen-tools/commitizen/issues/1615#issuecomment-4412338766)) confirmed the bug still reproduces on master (v4.15.1) and pinpointed `commitizen/tags.py:217–223` as the missing substitution.

The fix adds a `devrelease` variable to the `safe_substitute` call in `normalize_tag`. The value is computed as `f"dev{dev}"` when the version carries a dev-release integer (`version.dev is not None`), and as the empty string otherwise — exactly mirroring the existing treatment of `prerelease` (`version.prerelease or ""`).

### What changed

| File | Change |
| --- | --- |
| `commitizen/tags.py` | Compute `devrelease` from `version.dev` (after line 214) and add it to the `safe_substitute` call in `normalize_tag` |
| `tests/test_bump_normalize_tag.py` | Add three parametrised cases: dev release present (`dev1`), dev release at zero (`dev0`), and no dev release (empty string) |

### How it works

- `version.dev` (from `packaging.version.Version`) is an `int | None` — it holds the dev-release number (e.g. `1` for `1.2.3.dev1`) or `None` if the version is not a dev release. `getattr(version, "dev", None)` is used defensively so that version-scheme implementations that don't expose a `dev` attribute (custom schemes satisfying `VersionProtocol`) don't raise `AttributeError`.
- The rendered value is `f"dev{dev}"` (e.g. `"dev1"`), which matches how PEP 440 and the SemVer2 scheme stringify dev releases in version strings. For a `tag_format` of `${major}.${minor}-${patch}${devrelease}` and version `0.0.2dev1`, this produces the tag `0.0-2dev1`.
- **Why `f"dev{dev}"` rather than `str(version.dev)` or the full version string?** Using the raw integer would produce `1` instead of `dev1`, which is not the conventional dev-release suffix. Using `str(version)` would embed the full version string where only the suffix is wanted. The `f"dev{dev}"` form gives the caller the smallest composable unit — it can be placed anywhere in `tag_format` without extra text leaking in.
- `string.Template.safe_substitute` (already used at `commitizen/tags.py:217`) leaves unrecognised placeholders unchanged rather than raising `KeyError`. Adding `devrelease` to the dict means `${devrelease}` is now substituted; `tag_format` strings that don't reference it are completely unaffected.
- **Dependency on #1972**: the tag-parsing regex (`commitizen/defaults.py::get_tag_regexes`) currently requires a leading dot before `dev` (`\.dev\d+`). Tags created with this PR's substitution (e.g. `0.0-2dev1`) don't round-trip through `TagRules.is_version_tag` / `extract_version` without the companion fix in #1972, which widens the regex to `\.?dev\d+`. Both PRs should be merged together to avoid a window in which created tags can't be parsed back.

### Backward compatibility

- `tag_format` strings that do not reference `${devrelease}` are completely unaffected — `safe_substitute` ignores keys whose placeholders don't appear in the template.
- The `prerelease` substitution and all other existing template variables are unchanged.
- All pre-existing parametrised test cases in `tests/test_bump_normalize_tag.py` continue to pass.
- No change to CLI flags, exit codes, or any command path other than the tag-format rendering step.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes (see "Steps to Test" below)
- [x] Update the documentation for the changes

## Expected Behavior

| Scenario | Outcome |
| --- | --- |
| `tag_format = "${major}.${minor}-${patch}${devrelease}"` and `cz bump --devrelease 1` | Tag created is `0.0-2dev1`; literal `${devrelease}` does not appear |
| `tag_format = "v$version"` (no `${devrelease}`) and `cz bump --devrelease 1` | Tag created is `v0.0.2dev1` — existing behaviour unchanged |
| `tag_format = "$major.$minor.$patch$devrelease"` and `cz bump` (no dev component) | `${devrelease}` renders as the empty string; tag is `0.0.2` |
| Second `cz bump --devrelease 2` after a successful first dev bump | No duplicate-tag error; tag `0.0-2dev2` is created correctly |

## Steps to Test This Pull Request

```sh
git fetch fork fix/1615-tag-format-devrelease
git checkout fork/fix/1615-tag-format-devrelease

# 1. Targeted regression test.
uv run pytest tests/test_bump_normalize_tag.py -v

# 2. Reproduce the bug, then verify the fix.
mkdir /tmp/cz-1615 && cd /tmp/cz-1615
git init
git config user.name test && git config user.email test@example.com
cat > cz.toml << 'EOF'
[tool.commitizen]
name = "cz_conventional_commits"
tag_format = "${major}.${minor}-${patch}${devrelease}"
version_scheme = "semver2"
version = "0.0.1"
EOF
echo "# test" > README.md
git add README.md cz.toml
git commit -m "fix: initial"
cz bump --devrelease 1 --yes
git tag --list
# Expected:  0.0-2dev1
# NOT:       0.0-2${devrelease}

# Second dev bump must also succeed (previously failed with duplicate tag).
echo "change" >> README.md
git add README.md && git commit -m "fix: another change"
cz bump --devrelease 2 --yes
git tag --list   # should contain 0.0-2dev1 and 0.0-2dev2
```

## Additional Context

This fix was identified during the open-issues audit tracked in #1964. A triage note ([@bearomorphism, 2026-05-09](https://github.com/commitizen-tools/commitizen/issues/1615#issuecomment-4412338766)) confirmed the bug reproduces on master (v4.15.1), pinpointed `commitizen/tags.py:217–223` as the site of the missing substitution, and noted that #1614 is a companion issue where `${prerelease}` has a similar (but distinct) malformed-tag problem in the same `normalize_tag` path.

**Merge dependency**: this PR should land together with #1972 (`fix(tags): widen prerelease and devrelease tag regexes for SemVer2`). Without #1972, a tag like `0.0-2dev1` created by this fix cannot be parsed back by `extract_version`, breaking subsequent bumps. See [PR comment](https://github.com/commitizen-tools/commitizen/pull/1967#issuecomment-4412512647) for the full explanation.