### PR TITLE
feat(bump): add --merge-prerelease flag

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -313,6 +313,16 @@ data = {
                         "help": "Output changelog to stdout.",
                     },
                     {
+                        "name": "--merge-prerelease",
+                        "action": "store_true",
+                        "default": None,
+                        "help": (
+                            "Collect all changes from prereleases into the next non-prerelease "
+                            "when generating the changelog. "
+                            "Overrides the `changelog_merge_prerelease` setting."
+                        ),
+                    },
+                    {
                         "name": ["--git-output-to-stderr"],
                         "action": "store_true",
                         "default": False,

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -56,6 +56,7 @@ class BumpArgs(Settings, total=False):
     increment: Increment | None
     local_version: bool
     manual_version: str | None
+    merge_prerelease: bool | None
     no_verify: bool
     prerelease: Prerelease | None
     retry: bool
@@ -319,6 +320,9 @@ class Bump:
                 # governs logic for merge_prerelease
                 "during_version_bump": self.arguments["prerelease"] is None,
             }
+            merge_prerelease = self.arguments.get("merge_prerelease")
+            if merge_prerelease is not None:
+                changelog_args["merge_prerelease"] = merge_prerelease
             if self.changelog_to_stdout:
                 try:
                     Changelog(

--- a/docs/commands/bump.md
+++ b/docs/commands/bump.md
@@ -226,6 +226,16 @@ Useful when used with `--changelog-to-stdout` and piping the output to a file.
 
 For example, `git commit` output may pollute `stdout`, so it is recommended to use this flag when piping the output to a file.
 
+### `--merge-prerelease`
+
+Collect all changes from prereleases into the next non-prerelease entry when generating the incremental changelog.
+
+This mirrors the `--merge-prerelease` flag of `cz changelog` and overrides the [`changelog_merge_prerelease`](./changelog.md#--merge-prerelease) setting for a single bump invocation. It is useful when you want to keep prerelease entries in the changelog by default but collapse them on a release bump:
+
+```bash
+cz bump --changelog --merge-prerelease
+```
+
 ### `--retry`
 
 If you use tools like [pre-commit](https://pre-commit.com/), you can add this flag.

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1426,6 +1426,37 @@ def test_is_initial_tag(mocker: MockFixture, tmp_commitizen_project, util: UtilF
 @pytest.mark.parametrize("test_input", ["rc", "alpha", "beta"])
 @pytest.mark.usefixtures("tmp_commitizen_project")
 @pytest.mark.freeze_time("2025-01-01")
+def test_changelog_cli_flag_merge_prerelease(
+    mocker: MockFixture,
+    util: UtilFixture,
+    changelog_path: Path,
+    config_path: Path,
+    file_regression: FileRegressionFixture,
+    test_input: str,
+):
+    """`cz bump --merge-prerelease` overrides the (default false) config setting."""
+    with config_path.open("a") as f:
+        f.write("update_changelog_on_bump = true\n")
+        f.write("annotated_tag = true\n")
+
+    util.create_file_and_commit("irrelevant commit")
+    mocker.patch("commitizen.git.GitTag.date", "1970-01-01")
+    git.tag("0.1.0")
+
+    util.create_file_and_commit("feat: add new output")
+    util.create_file_and_commit("fix: output glitch")
+    util.run_cli("bump", "--prerelease", test_input, "--yes")
+
+    util.run_cli("bump", "--changelog", "--merge-prerelease")
+
+    out = changelog_path.read_text()
+
+    file_regression.check(out, extension=".md")
+
+
+@pytest.mark.parametrize("test_input", ["rc", "alpha", "beta"])
+@pytest.mark.usefixtures("tmp_commitizen_project")
+@pytest.mark.freeze_time("2025-01-01")
 def test_changelog_config_flag_merge_prerelease(
     mocker: MockFixture,
     util: UtilFixture,

--- a/tests/commands/test_bump_command/test_changelog_cli_flag_merge_prerelease_alpha_.md
+++ b/tests/commands/test_bump_command/test_changelog_cli_flag_merge_prerelease_alpha_.md
@@ -1,0 +1,11 @@
+## 0.2.0 (2025-01-01)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## 0.1.0 (1970-01-01)

--- a/tests/commands/test_bump_command/test_changelog_cli_flag_merge_prerelease_beta_.md
+++ b/tests/commands/test_bump_command/test_changelog_cli_flag_merge_prerelease_beta_.md
@@ -1,0 +1,11 @@
+## 0.2.0 (2025-01-01)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## 0.1.0 (1970-01-01)

--- a/tests/commands/test_bump_command/test_changelog_cli_flag_merge_prerelease_rc_.md
+++ b/tests/commands/test_bump_command/test_changelog_cli_flag_merge_prerelease_rc_.md
@@ -1,0 +1,11 @@
+## 0.2.0 (2025-01-01)
+
+### Feat
+
+- add new output
+
+### Fix
+
+- output glitch
+
+## 0.1.0 (1970-01-01)

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_10_bump_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_10_bump_.txt
@@ -6,9 +6,10 @@ usage: cz bump [-h] [--dry-run] [--files-only] [--version-files-only]
                [--increment-mode {linear,exact}] [--check-consistency]
                [--annotated-tag]
                [--annotated-tag-message ANNOTATED_TAG_MESSAGE] [--gpg-sign]
-               [--changelog-to-stdout] [--git-output-to-stderr] [--retry]
-               [--major-version-zero] [--template TEMPLATE] [--extra EXTRA]
-               [--file-name FILE_NAME] [--prerelease-offset PRERELEASE_OFFSET]
+               [--changelog-to-stdout] [--merge-prerelease]
+               [--git-output-to-stderr] [--retry] [--major-version-zero]
+               [--template TEMPLATE] [--extra EXTRA] [--file-name FILE_NAME]
+               [--prerelease-offset PRERELEASE_OFFSET]
                [--version-scheme {pep440,semver,semver2}]
                [--version-type {pep440,semver,semver2}]
                [--build-metadata BUILD_METADATA] [--get-next]
@@ -64,6 +65,9 @@ options:
   --gpg-sign, -s        Sign tag instead of lightweight one.
   --changelog-to-stdout
                         Output changelog to stdout.
+  --merge-prerelease    Collect all changes from prereleases into the next
+                        non-prerelease when generating the changelog.
+                        Overrides the `changelog_merge_prerelease` setting.
   --git-output-to-stderr
                         Redirect git output to stderr.
   --retry               Retry commit if it fails for the first time.

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_11_bump_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_11_bump_.txt
@@ -6,9 +6,10 @@ usage: cz bump [-h] [--dry-run] [--files-only] [--version-files-only]
                [--increment-mode {linear,exact}] [--check-consistency]
                [--annotated-tag]
                [--annotated-tag-message ANNOTATED_TAG_MESSAGE] [--gpg-sign]
-               [--changelog-to-stdout] [--git-output-to-stderr] [--retry]
-               [--major-version-zero] [--template TEMPLATE] [--extra EXTRA]
-               [--file-name FILE_NAME] [--prerelease-offset PRERELEASE_OFFSET]
+               [--changelog-to-stdout] [--merge-prerelease]
+               [--git-output-to-stderr] [--retry] [--major-version-zero]
+               [--template TEMPLATE] [--extra EXTRA] [--file-name FILE_NAME]
+               [--prerelease-offset PRERELEASE_OFFSET]
                [--version-scheme {pep440,semver,semver2}]
                [--version-type {pep440,semver,semver2}]
                [--build-metadata BUILD_METADATA] [--get-next]
@@ -64,6 +65,9 @@ options:
   --gpg-sign, -s        Sign tag instead of lightweight one.
   --changelog-to-stdout
                         Output changelog to stdout.
+  --merge-prerelease    Collect all changes from prereleases into the next
+                        non-prerelease when generating the changelog.
+                        Overrides the `changelog_merge_prerelease` setting.
   --git-output-to-stderr
                         Redirect git output to stderr.
   --retry               Retry commit if it fails for the first time.

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_12_bump_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_12_bump_.txt
@@ -6,9 +6,10 @@ usage: cz bump [-h] [--dry-run] [--files-only] [--version-files-only]
                [--increment-mode {linear,exact}] [--check-consistency]
                [--annotated-tag]
                [--annotated-tag-message ANNOTATED_TAG_MESSAGE] [--gpg-sign]
-               [--changelog-to-stdout] [--git-output-to-stderr] [--retry]
-               [--major-version-zero] [--template TEMPLATE] [--extra EXTRA]
-               [--file-name FILE_NAME] [--prerelease-offset PRERELEASE_OFFSET]
+               [--changelog-to-stdout] [--merge-prerelease]
+               [--git-output-to-stderr] [--retry] [--major-version-zero]
+               [--template TEMPLATE] [--extra EXTRA] [--file-name FILE_NAME]
+               [--prerelease-offset PRERELEASE_OFFSET]
                [--version-scheme {pep440,semver,semver2}]
                [--version-type {pep440,semver,semver2}]
                [--build-metadata BUILD_METADATA] [--get-next]
@@ -64,6 +65,9 @@ options:
   --gpg-sign, -s        Sign tag instead of lightweight one.
   --changelog-to-stdout
                         Output changelog to stdout.
+  --merge-prerelease    Collect all changes from prereleases into the next
+                        non-prerelease when generating the changelog.
+                        Overrides the `changelog_merge_prerelease` setting.
   --git-output-to-stderr
                         Redirect git output to stderr.
   --retry               Retry commit if it fails for the first time.

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_13_bump_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_13_bump_.txt
@@ -6,9 +6,10 @@ usage: cz bump [-h] [--dry-run] [--files-only] [--version-files-only]
                [--increment-mode {linear,exact}] [--check-consistency]
                [--annotated-tag]
                [--annotated-tag-message ANNOTATED_TAG_MESSAGE] [--gpg-sign]
-               [--changelog-to-stdout] [--git-output-to-stderr] [--retry]
-               [--major-version-zero] [--template TEMPLATE] [--extra EXTRA]
-               [--file-name FILE_NAME] [--prerelease-offset PRERELEASE_OFFSET]
+               [--changelog-to-stdout] [--merge-prerelease]
+               [--git-output-to-stderr] [--retry] [--major-version-zero]
+               [--template TEMPLATE] [--extra EXTRA] [--file-name FILE_NAME]
+               [--prerelease-offset PRERELEASE_OFFSET]
                [--version-scheme {pep440,semver,semver2}]
                [--version-type {pep440,semver,semver2}]
                [--build-metadata BUILD_METADATA] [--get-next]
@@ -64,6 +65,9 @@ options:
   --gpg-sign, -s        Sign tag instead of lightweight one.
   --changelog-to-stdout
                         Output changelog to stdout.
+  --merge-prerelease    Collect all changes from prereleases into the next
+                        non-prerelease when generating the changelog.
+                        Overrides the `changelog_merge_prerelease` setting.
   --git-output-to-stderr
                         Redirect git output to stderr.
   --retry               Retry commit if it fails for the first time.

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_14_bump_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_14_bump_.txt
@@ -6,9 +6,10 @@ usage: cz bump [-h] [--dry-run] [--files-only] [--version-files-only]
                [--increment-mode {linear,exact}] [--check-consistency]
                [--annotated-tag]
                [--annotated-tag-message ANNOTATED_TAG_MESSAGE] [--gpg-sign]
-               [--changelog-to-stdout] [--git-output-to-stderr] [--retry]
-               [--major-version-zero] [--template TEMPLATE] [--extra EXTRA]
-               [--file-name FILE_NAME] [--prerelease-offset PRERELEASE_OFFSET]
+               [--changelog-to-stdout] [--merge-prerelease]
+               [--git-output-to-stderr] [--retry] [--major-version-zero]
+               [--template TEMPLATE] [--extra EXTRA] [--file-name FILE_NAME]
+               [--prerelease-offset PRERELEASE_OFFSET]
                [--version-scheme {pep440,semver,semver2}]
                [--version-type {pep440,semver,semver2}]
                [--build-metadata BUILD_METADATA] [--get-next]
@@ -64,6 +65,9 @@ options:
   --gpg-sign, -s        Sign tag instead of lightweight one.
   --changelog-to-stdout
                         Output changelog to stdout.
+  --merge-prerelease    Collect all changes from prereleases into the next
+                        non-prerelease when generating the changelog.
+                        Overrides the `changelog_merge_prerelease` setting.
   --git-output-to-stderr
                         Redirect git output to stderr.
   --retry               Retry commit if it fails for the first time.


### PR DESCRIPTION
## Description

Closes #1934.

### Why

`cz changelog` already exposes a `--merge-prerelease` flag that overrides the `changelog_merge_prerelease` config setting for a single invocation. The same flag is missing on `cz bump`, even though `cz bump --changelog` runs the same changelog generator under the hood. Users who want prerelease entries to live as separate sections in their changelog by default, but be merged into the release entry on the actual release bump, currently have to either edit `pyproject.toml` for one bump and revert it, or run `cz bump` followed by a separate `cz changelog --merge-prerelease`.

The original issue calls for parity:

> It would be great to enable/disable `changelog_merge_prerelease` when calling `cz bump` in combination with `update_changelog_on_bump = true`/`--changelog`.

### What changed

| File | Change |
| --- | --- |
| `commitizen/cli.py` | New `--merge-prerelease` argument under the `bump` subcommand (mirrors the one under `changelog`). |
| `commitizen/commands/bump.py` | `BumpArgs` gains `merge_prerelease: bool \| None`; `Bump.__call__` forwards it into `changelog_args` only when explicitly set. |
| `docs/commands/bump.md` | New `### --merge-prerelease` section. |
| `tests/commands/test_bump_command.py` | New parameterised `test_changelog_cli_flag_merge_prerelease[rc\|alpha\|beta]` that exercises the flag without setting the config. |
| `tests/commands/test_bump_command/test_changelog_cli_flag_merge_prerelease_*.md` | Three regression fixtures (one per prerelease variant). |
| `tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_*_bump_.txt` | Regenerated `cz bump --help` snapshots (one per supported Python). |

### How it works

1. The argparse argument uses `action="store_true", default=None`. The `None` default is intentional: it lets `Bump.__call__` distinguish "user did not pass the flag" from "user passed `--no-merge-prerelease`-equivalent" without a separate negation flag. When the flag is absent the embedded `Changelog` invocation falls back to `self.config.settings["changelog_merge_prerelease"]` exactly as before — no behaviour change.
2. In `Bump.__call__`, `merge_prerelease` is injected into `changelog_args` only when `is not None`. Because `Changelog.__init__` evaluates `arguments.get("merge_prerelease") or self.config.settings["changelog_merge_prerelease"]`, omitting the key from `changelog_args` correctly preserves the legacy behaviour.
3. Both code paths in `Bump.__call__` that construct a `Changelog` (the `changelog_to_stdout` path and the regular file path) receive the `changelog_args` dict, so the new flag is effective in both modes.
4. The flag has no effect unless `cz bump` actually generates a changelog (`--changelog`, `--changelog-to-stdout`, or `update_changelog_on_bump = true`); a no-op flag without `--changelog` matches `cz changelog`'s behaviour and avoids surprises.

### Backward compatibility

- All existing config combinations behave identically when the flag is absent.
- `BumpArgs.merge_prerelease: bool | None` is additive on a `total=False` TypedDict.
- The full pre-existing bump test suite (134 non-GPG tests) and `cz bump --help` snapshot tests pass unchanged after regeneration.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests (`poe lint` clean; 134 non-GPG bump tests + 14 common-command help-text tests pass; the 4 GPG-signing test errors on Windows are pre-existing and unrelated to this change)
- [x] Manually test the changes (see "Steps to Test" below for the exact commands)
- [x] Update the documentation for the changes

### Documentation Changes

- [x] Added a `### --merge-prerelease` section to `docs/commands/bump.md`
- [x] Help-text snapshots regenerated via `uv run poe test:regen`
- [x] Run `uv run poe doc` locally to ensure the documentation pages render correctly
- [x] Check and fix any broken links (internal or external)

## Expected Behavior

| Scenario | Outcome |
| --- | --- |
| `cz bump --changelog` (no flag, `changelog_merge_prerelease = false` — default) | Prereleases keep their own sections in the changelog (legacy behaviour). |
| `cz bump --changelog --merge-prerelease` | Prereleases between previous and new non-prerelease are collapsed into the new entry. |
| `cz bump --changelog` with `changelog_merge_prerelease = true` in config | Prereleases are merged (legacy behaviour). |
| `cz bump --merge-prerelease` (no `--changelog`, no `update_changelog_on_bump`) | Flag is a no-op; no changelog is generated. |
| `cz bump --changelog-to-stdout --merge-prerelease` | Stdout changelog also has prereleases merged. |

## Steps to Test This Pull Request

```sh
git fetch fork feat/1934-bump-merge-prerelease-flag
git checkout fork/feat/1934-bump-merge-prerelease-flag

# 1. Targeted regression test (3 new + 6 pre-existing parametrised cases).
uv run pytest tests/commands/test_bump_command.py -k merge_prerelease -v
# expected: 9 passed

# 2. Full bump-command suite (sanity check that nothing else broke).
uv run pytest tests/commands/test_bump_command.py -k 'not signed' -q
# expected: 134 passed (GPG-signing tests are excluded on Windows)

# 3. Help snapshots updated correctly.
uv run pytest tests/commands/test_common_command.py -q
# expected: 14 passed

# 4. End-to-end smoke (optional, requires a temp git repo):
mkdir -p /tmp/cz-1968 && cd /tmp/cz-1968 && git init -q
echo '[tool.commitizen]\nname = "cz_conventional_commits"\nversion = "0.1.0"\nupdate_changelog_on_bump = true\ntag_format = "v$version"' > pyproject.toml
git add . && git -c user.email=a@b -c user.name=t commit -qm "feat: a"
uv run cz bump --yes -pr alpha   # -> v0.2.0a0
git -c user.email=a@b -c user.name=t commit --allow-empty -qm "fix: b"
uv run cz bump --yes --changelog --merge-prerelease   # collapses 0.2.0a0 entry
cat CHANGELOG.md     # 0.2.0 should contain both feat:a and fix:b under it
```

## Additional Context

Surfaced while triaging open issues in #1965. Reviewed by an internal `claude-sonnet-4.6` code-review pass and by GitHub Copilot; both reported no findings.
