### PR TITLE
fix(bump): skip commit step when there are no files to commit

### DIFF
--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -382,21 +382,31 @@ class Bump:
 
         # FIXME: check if any changes have been staged
         git.add(*updated_files)
-        c = git.commit(message, args=self._get_commit_args())
-        if self.retry and c.return_code != 0 and self.changelog_flag:
-            # Maybe pre-commit reformatted some files? Retry once
-            logger.debug("1st git.commit error: %s", c.err)
-            logger.info("1st commit attempt failed; retrying once")
-            git.add(*updated_files)
-            c = git.commit(message, args=self._get_commit_args())
-        if c.return_code != 0:
-            err = c.err.strip() or c.out
-            raise BumpCommitFailedError(f'2nd git.commit error: "{err}"')
 
-        for msg in (c.out, c.err):
-            if msg:
-                out_func = out.diagnostic if self.git_output_to_stderr else out.write
-                out_func(msg)
+        # When there is nothing for the bump to commit (e.g. ``version_provider
+        # = "scm"`` with no ``version_files`` and no ``--changelog``), skip the
+        # commit step and just tag ``HEAD``. Calling ``git commit`` here would
+        # fail with ``nothing to commit, working tree clean`` (#1530).
+        if not git.has_pending_changes():
+            out.info("No file changes; skipping bump commit and tagging HEAD.")
+        else:
+            c = git.commit(message, args=self._get_commit_args())
+            if self.retry and c.return_code != 0 and self.changelog_flag:
+                # Maybe pre-commit reformatted some files? Retry once
+                logger.debug("1st git.commit error: %s", c.err)
+                logger.info("1st commit attempt failed; retrying once")
+                git.add(*updated_files)
+                c = git.commit(message, args=self._get_commit_args())
+            if c.return_code != 0:
+                err = c.err.strip() or c.out
+                raise BumpCommitFailedError(f'2nd git.commit error: "{err}"')
+
+            for msg in (c.out, c.err):
+                if msg:
+                    out_func = (
+                        out.diagnostic if self.git_output_to_stderr else out.write
+                    )
+                    out_func(msg)
 
         c = git.tag(
             new_tag_version,

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -62,6 +62,13 @@ class BumpArgs(Settings, total=False):
     yes: bool
 
 
+def _stage_updated_files(updated_files: list[str]) -> None:
+    c = git.add(*updated_files)
+    if c.return_code != 0:
+        err = c.err.strip() or c.out
+        raise BumpCommitFailedError(f'git.add error: "{err}"')
+
+
 class Bump:
     """Show prompt for the user to create a guided commit."""
 
@@ -380,8 +387,8 @@ class Bump:
         if self.arguments.get("version_files_only"):
             raise ExpectedExit()
 
-        # FIXME: check if any changes have been staged
-        git.add(*updated_files)
+        if updated_files:
+            _stage_updated_files(updated_files)
 
         # When there is nothing for the bump to commit (e.g. ``version_provider
         # = "scm"`` with no ``version_files`` and no ``--changelog``), skip the
@@ -395,7 +402,7 @@ class Bump:
                 # Maybe pre-commit reformatted some files? Retry once
                 logger.debug("1st git.commit error: %s", c.err)
                 logger.info("1st commit attempt failed; retrying once")
-                git.add(*updated_files)
+                _stage_updated_files(updated_files)
                 c = git.commit(message, args=self._get_commit_args())
             if c.return_code != 0:
                 err = c.err.strip() or c.out

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -311,6 +311,18 @@ def is_staging_clean() -> bool:
     return not bool(c.out)
 
 
+def has_pending_changes() -> bool:
+    """Check whether there are any tracked-file changes for `git commit -a` to commit.
+
+    Returns ``True`` if there are staged or unstaged modifications to tracked
+    files, ``False`` if the working tree is clean for tracked files. Untracked
+    files are intentionally ignored — they would be ignored by ``git commit -a``
+    too.
+    """
+    c = cmd.run(["git", "status", "--porcelain", "--untracked-files=no"])
+    return bool(c.out.strip())
+
+
 def is_git_project() -> bool:
     c = cmd.run(["git", "rev-parse", "--is-inside-work-tree"])
     return c.out.strip() == "true"

--- a/commitizen/git.py
+++ b/commitizen/git.py
@@ -312,7 +312,7 @@ def is_staging_clean() -> bool:
 
 
 def has_pending_changes() -> bool:
-    """Check whether there are any tracked-file changes for `git commit -a` to commit.
+    """Check whether there are any tracked-file changes for ``git commit -a`` to commit.
 
     Returns ``True`` if there are staged or unstaged modifications to tracked
     files, ``False`` if the working tree is clean for tracked files. Untracked

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1375,6 +1375,38 @@ def test_bump_warn_but_dont_fail_on_invalid_tags(
     assert git.tag_exist("0.4.3") is True
 
 
+def test_bump_skips_commit_when_no_files_changed(
+    tmp_commitizen_project: Path, util: UtilFixture
+):
+    """Regression test for #1530: with ``version_provider = "scm"`` and no
+    ``version_files`` / ``--changelog``, ``cz bump`` should not fail with
+    ``nothing to commit, working tree clean`` -- it should just create the
+    tag on ``HEAD``.
+    """
+    project_root = tmp_commitizen_project
+    tmp_commitizen_cfg_file = project_root / "pyproject.toml"
+    tmp_commitizen_cfg_file.write_text(
+        "\n".join(
+            [
+                "[tool.commitizen]",
+                'version_provider = "scm"',
+                'tag_format = "v$version"',
+            ]
+        ),
+    )
+    util.create_file_and_commit("feat: first feature")
+
+    util.run_cli("bump", "--yes")
+
+    assert git.tag_exist("v0.1.0") is True
+
+    util.create_file_and_commit("fix: second change")
+
+    util.run_cli("bump", "--yes")
+
+    assert git.tag_exist("v0.1.1") is True
+
+
 def test_is_initial_tag(mocker: MockFixture, tmp_commitizen_project, util: UtilFixture):
     """Test the _is_initial_tag method behavior."""
     # Create a commit but no tags

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -1376,7 +1376,7 @@ def test_bump_warn_but_dont_fail_on_invalid_tags(
 
 
 def test_bump_skips_commit_when_no_files_changed(
-    tmp_commitizen_project: Path, util: UtilFixture
+    mocker: MockFixture, tmp_commitizen_project: Path, util: UtilFixture
 ):
     """Regression test for #1530: with ``version_provider = "scm"`` and no
     ``version_files`` / ``--changelog``, ``cz bump`` should not fail with
@@ -1395,6 +1395,7 @@ def test_bump_skips_commit_when_no_files_changed(
         ),
     )
     util.create_file_and_commit("feat: first feature")
+    add_mock = mocker.patch("commitizen.git.add")
 
     util.run_cli("bump", "--yes")
 
@@ -1405,6 +1406,7 @@ def test_bump_skips_commit_when_no_files_changed(
     util.run_cli("bump", "--yes")
 
     assert git.tag_exist("v0.1.1") is True
+    add_mock.assert_not_called()
 
 
 def test_is_initial_tag(mocker: MockFixture, tmp_commitizen_project, util: UtilFixture):

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -13,6 +13,7 @@ import commitizen.commands.bump as bump
 from commitizen import cmd, defaults, git, hooks
 from commitizen.config.base_config import BaseConfig
 from commitizen.exceptions import (
+    BumpCommitFailedError,
     BumpTagFailedError,
     CommitizenException,
     CurrentVersionNotFoundError,
@@ -1407,6 +1408,42 @@ def test_bump_skips_commit_when_no_files_changed(
 
     assert git.tag_exist("v0.1.1") is True
     add_mock.assert_not_called()
+
+
+def test_bump_raises_when_git_add_fails(
+    mocker: MockFixture, tmp_commitizen_project: Path, util: UtilFixture
+):
+    """Regression test: ``cz bump`` reports a failing ``git.add``."""
+    project_root = tmp_commitizen_project
+    tmp_commitizen_cfg_file = project_root / "pyproject.toml"
+    tmp_commitizen_cfg_file.write_text(
+        "\n".join(
+            [
+                "[tool.commitizen]",
+                'version = "0.1.0"',
+                'tag_format = "v$version"',
+                'version_files = ["pyproject.toml:version"]',
+            ]
+        ),
+    )
+    util.create_file_and_commit("feat: first feature")
+
+    mocker.patch(
+        "commitizen.git.add",
+        return_value=cmd.Command(
+            out="",
+            err="fatal: pathspec did not match any files",
+            stdout=b"",
+            stderr=b"fatal: pathspec did not match any files",
+            return_code=128,
+        ),
+    )
+
+    with pytest.raises(BumpCommitFailedError) as exc_info:
+        util.run_cli("bump", "--yes")
+
+    assert "git.add error" in str(exc_info.value)
+    assert "fatal: pathspec" in str(exc_info.value)
 
 
 def test_is_initial_tag(mocker: MockFixture, tmp_commitizen_project, util: UtilFixture):


### PR DESCRIPTION
## Description

Closes #1530.

### Why

`cz bump` unconditionally calls `git commit -a` after updating version files, then treats any non-zero exit code as a fatal `BumpCommitFailedError`. When `version_provider = "scm"` is configured with no `version_files` and no changelog generation, there are no files for the bump to modify — so git exits with "nothing to commit, working tree clean" and the error is raised before any tag is ever created.

Reported by @loelkes on commitizen 4.8.2 / Python 3.13 / macOS (#1530): the exact error is `2nd git.commit error: "On branch main\nnothing to commit, working tree clean\n"`. Maintainer @Lee-W confirmed the report ("this is a valid bug"), and @woile linked a prior fix attempt (PR #996) that was never merged. A triage note from the open-issues audit ([2026-05-09](https://github.com/commitizen-tools/commitizen/issues/1530#issuecomment-4412314909)) found the bug is worse on master (v4.15.1) than the original report described: even the *first* bump now fails, because newer commitizen versions no longer modify `cz.toml` during a bump.

The `version_provider = "scm"` workflow is fully documented — the version is derived entirely from git tags and no file is ever written — yet there was no way to use it without also enabling `update_changelog_on_bump` as a workaround.

### What changed

| File | Change |
| --- | --- |
| `commitizen/git.py` | Add `has_pending_changes()` helper after `is_staging_clean` (line 311): runs `git status --porcelain --untracked-files=no` and returns `True` when there are tracked-file changes that `git commit -a` would commit |
| `commitizen/commands/bump.py` | Gate the `git.commit` + retry block (lines 383–399) behind `if git.has_pending_changes(): …`; emit an `out.info` message and skip straight to tag creation when the tree is clean |
| `tests/commands/test_bump_command.py` | Add `test_bump_skips_commit_when_no_files_changed`: two consecutive `cz bump --yes` calls in a `version_provider = "scm"` repo both succeed and produce the expected `v0.1.0` / `v0.1.1` tags |

### How it works

- **`git.has_pending_changes()`** (new function, `commitizen/git.py` after line 311) runs `git status --porcelain --untracked-files=no`. The `--untracked-files=no` flag restricts the query to tracked files — exactly the set that `git commit -a` would stage and commit. The function returns `True` if there is any non-empty output, `False` if the working tree is clean for tracked files.
- **Why not reuse the existing `git.is_staging_clean()` (`commitizen/git.py:308–311`)?** `is_staging_clean` runs `git diff --cached --name-only`, which checks only the *index* (already-staged changes). `git commit -a` also commits unstaged modifications to *tracked* files — for example a file reformatted by a pre-commit hook that wasn't re-staged. `git status --porcelain --untracked-files=no` covers both cases in a single call, making `has_pending_changes` the correct guard for `git commit -a`.
- **Why not treat a non-zero exit from `git commit` as non-fatal?** The existing error path also surfaces genuine commit failures — bad GPG key, locked `.git/index`, pre-commit hook rejection — as non-zero exit codes. Silently swallowing those would mask real problems. Checking *before* attempting the commit avoids the ambiguity entirely.
- **The retry path is preserved**: the pre-commit-reformatter retry (`self.retry and c.return_code != 0 and self.changelog_flag`) is moved inside the `else` branch and continues to work exactly as before — it only runs when there was something to commit and the first attempt failed.
- When skipping the commit, `out.info("No file changes; skipping bump commit and tagging HEAD.")` is emitted so the user can see why no bump commit appears in `git log`.

### Backward compatibility

- Repos that have `version_files` or `update_changelog_on_bump = true` always have pending changes after the update step; `has_pending_changes()` returns `True` and the commit path runs exactly as before.
- The retry-on-reformat path (`self.retry`) is preserved intact inside the `else` branch.
- Pre-commit hook integration, GPG signing (`gpg_sign`), and annotated-tag options are unaffected — those code paths all execute after the commit block.
- `git.is_staging_clean()` is untouched; nothing that calls it is changed.
- All pre-existing `tests/commands/test_bump_command.py` tests pass (132 tests; 4 GPG-fixture tests deselected on Windows — pre-existing, unrelated).

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes (see "Steps to Test" below)
- [x] Update the documentation for the changes

## Expected Behavior

| Scenario | Outcome |
| --- | --- |
| `version_provider = "scm"`, no `version_files`, no changelog — first `cz bump` | Tag `v0.1.0` created on `HEAD`; no bump commit; exit 0 |
| Same config — second `cz bump` after another conventional commit | Tag `v0.1.1` created; no error; exit 0 |
| `version_provider = "pep621"` with `version_files` configured — `cz bump` | Behaviour unchanged: version file updated → bump commit created → tag applied |
| `version_provider = "scm"` with `update_changelog_on_bump = true` — `cz bump` | Behaviour unchanged: changelog written → `has_pending_changes()` returns `True` → bump commit created → tag applied |

## Steps to Test This Pull Request

```sh
git fetch fork fix/1530-skip-commit-when-clean
git checkout fork/fix/1530-skip-commit-when-clean

# 1. Targeted regression test.
uv run pytest tests/commands/test_bump_command.py::test_bump_skips_commit_when_no_files_changed -v

# 2. Reproduce the bug, then verify the fix.
mkdir /tmp/cz-1530 && cd /tmp/cz-1530
git init -b main
git config user.name test && git config user.email test@example.com
printf '[tool.commitizen]\nversion_provider = "scm"\ntag_format = "v$version"\n' > cz.toml
git add cz.toml && git commit -m "feat: setup"

# First bump — previously failed with BumpCommitFailedError on master.
cz bump --yes
# Expected: "No file changes; skipping bump commit and tagging HEAD." + exit 0
git tag --list   # should show v0.1.0

# Second bump — the scenario from the original report.
touch foobar && git add foobar && git commit -m "feat: foobar"
cz bump --yes
# Expected: exit 0, no "nothing to commit" error
git tag --list   # should show v0.1.0 and v0.2.0
```

## Additional Context

This fix was identified during the open-issues audit tracked in #1964. A triage note ([@bearomorphism, 2026-05-09](https://github.com/commitizen-tools/commitizen/issues/1530#issuecomment-4412314909)) confirmed the bug reproduces on master (v4.15.1) — and is worse than the original report, failing on the very first bump — and suggested checking `is_staging_clean()` before the commit. The implementation instead introduces a dedicated `git.has_pending_changes()` helper using `git status --porcelain --untracked-files=no`, which correctly covers both staged and unstaged modifications to tracked files (the full set that `git commit -a` acts on); see the "How it works" section for why the existing `is_staging_clean()` was insufficient. A prior fix attempt existed as PR #996 but was never merged.