### PR TITLE
feat(init): discover third-party version providers via entry points

### DIFF
--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -83,6 +83,14 @@ def _construct_version_provider_choices() -> list[questionary.Choice]:
     third-party providers that register themselves under the
     `commitizen.provider` entry-point group. Third-party providers are
     not loaded — only their entry-point name is used for the choice.
+
+    Names already registered as built-ins are skipped to avoid showing
+    them twice (commitizen's own providers register under the same
+    entry-point group). When two distributions register a third-party
+    provider under the same name, the choice list deduplicates by name
+    so the user does not see ambiguous duplicate entries; the conflict
+    will surface with a clear error from `get_provider()` if the user
+    actually selects that name.
     """
     builtin_names = {
         option.provider_name for option in _BUILTIN_VERSION_PROVIDER_OPTIONS
@@ -91,14 +99,18 @@ def _construct_version_provider_choices() -> list[questionary.Choice]:
         questionary.Choice(title=option.title, value=option.provider_name)
         for option in _BUILTIN_VERSION_PROVIDER_OPTIONS
     ]
-    third_party_choices = [
-        questionary.Choice(
-            title=f"{ep.name}: third-party version provider",
-            value=ep.name,
+    third_party_choices: list[questionary.Choice] = []
+    seen_names: set[str] = set(builtin_names)
+    for ep in metadata.entry_points(group=PROVIDER_ENTRYPOINT):
+        if ep.name in seen_names:
+            continue
+        seen_names.add(ep.name)
+        third_party_choices.append(
+            questionary.Choice(
+                title=f"{ep.name}: third-party version provider",
+                value=ep.name,
+            )
         )
-        for ep in metadata.entry_points(group=PROVIDER_ENTRYPOINT)
-        if ep.name not in builtin_names
-    ]
     return [*builtin_choices, *third_party_choices]
 
 

--- a/commitizen/commands/init.py
+++ b/commitizen/commands/init.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -17,6 +18,7 @@ from commitizen.exceptions import (
     NoAnswersError,
 )
 from commitizen.git import get_latest_tag_name, get_tag_names, smart_open
+from commitizen.providers import PROVIDER_ENTRYPOINT
 from commitizen.version_schemes import (
     KNOWN_SCHEMES,
     VersionProtocol,
@@ -38,43 +40,66 @@ class _VersionProviderOption(NamedTuple):
         return f"{self.provider_name}: {self.description}"
 
 
-_VERSION_PROVIDER_CHOICES = tuple(
-    questionary.Choice(title=option.title, value=option.provider_name)
-    for option in (
-        _VersionProviderOption(
-            provider_name="commitizen",
-            description="Fetch and set version in commitizen config (default)",
-        ),
-        _VersionProviderOption(
-            provider_name="cargo",
-            description="Get and set version from Cargo.toml:project.version field",
-        ),
-        _VersionProviderOption(
-            provider_name="composer",
-            description="Get and set version from composer.json:project.version field",
-        ),
-        _VersionProviderOption(
-            provider_name="npm",
-            description="Get and set version from package.json:project.version field",
-        ),
-        _VersionProviderOption(
-            provider_name="pep621",
-            description="Get and set version from pyproject.toml:project.version field",
-        ),
-        _VersionProviderOption(
-            provider_name="poetry",
-            description="Get and set version from pyproject.toml:tool.poetry.version field",
-        ),
-        _VersionProviderOption(
-            provider_name="uv",
-            description="Get and set version from pyproject.toml and uv.lock",
-        ),
-        _VersionProviderOption(
-            provider_name="scm",
-            description="Fetch the version from git and does not need to set it back",
-        ),
-    )
+_BUILTIN_VERSION_PROVIDER_OPTIONS: tuple[_VersionProviderOption, ...] = (
+    _VersionProviderOption(
+        provider_name="commitizen",
+        description="Fetch and set version in commitizen config (default)",
+    ),
+    _VersionProviderOption(
+        provider_name="cargo",
+        description="Get and set version from Cargo.toml:project.version field",
+    ),
+    _VersionProviderOption(
+        provider_name="composer",
+        description="Get and set version from composer.json:project.version field",
+    ),
+    _VersionProviderOption(
+        provider_name="npm",
+        description="Get and set version from package.json:project.version field",
+    ),
+    _VersionProviderOption(
+        provider_name="pep621",
+        description="Get and set version from pyproject.toml:project.version field",
+    ),
+    _VersionProviderOption(
+        provider_name="poetry",
+        description="Get and set version from pyproject.toml:tool.poetry.version field",
+    ),
+    _VersionProviderOption(
+        provider_name="uv",
+        description="Get and set version from pyproject.toml and uv.lock",
+    ),
+    _VersionProviderOption(
+        provider_name="scm",
+        description="Fetch the version from git and does not need to set it back",
+    ),
 )
+
+
+def _construct_version_provider_choices() -> list[questionary.Choice]:
+    """Build the version-provider picker for `cz init`.
+
+    Built-in providers come first (with curated descriptions), then any
+    third-party providers that register themselves under the
+    `commitizen.provider` entry-point group. Third-party providers are
+    not loaded — only their entry-point name is used for the choice.
+    """
+    builtin_names = {
+        option.provider_name for option in _BUILTIN_VERSION_PROVIDER_OPTIONS
+    }
+    builtin_choices = [
+        questionary.Choice(title=option.title, value=option.provider_name)
+        for option in _BUILTIN_VERSION_PROVIDER_OPTIONS
+    ]
+    third_party_choices = [
+        questionary.Choice(
+            title=f"{ep.name}: third-party version provider",
+            value=ep.name,
+        )
+        for ep in metadata.entry_points(group=PROVIDER_ENTRYPOINT)
+        if ep.name not in builtin_names
+    ]
+    return [*builtin_choices, *third_party_choices]
 
 
 class Init:
@@ -254,7 +279,7 @@ class Init:
 
         version_provider: str = questionary.select(
             "Choose the source of the version:",
-            choices=_VERSION_PROVIDER_CHOICES,
+            choices=_construct_version_provider_choices(),
             style=self.cz.style,
             default=project_info.get_default_version_provider(),
         ).unsafe_ask()

--- a/docs/config/version_provider.md
+++ b/docs/config/version_provider.md
@@ -297,6 +297,10 @@ setup(
    version_provider = "my-provider"
    ```
 
+   Once installed, the provider is also offered as a choice during `cz init`,
+   labelled `my-provider: third-party version provider`. Built-in providers
+   keep their curated descriptions and appear first in the picker.
+
 ### Provider Implementation Guidelines
 
 When creating a custom provider, keep these guidelines in mind:

--- a/tests/commands/test_init_command.py
+++ b/tests/commands/test_init_command.py
@@ -551,3 +551,42 @@ def test_construct_version_provider_choices_discovers_third_party(
     # with the generic third-party suffix.
     assert values.count("pep621") == 1
     assert "pep621: third-party version provider" not in titles
+
+
+def test_construct_version_provider_choices_dedupes_duplicate_third_party(
+    mocker: MockFixture,
+):
+    """Two distributions registering the same provider name only show once."""
+    from commitizen.commands.init import _construct_version_provider_choices
+    from commitizen.providers import PROVIDER_ENTRYPOINT
+
+    real_entry_points = metadata.entry_points
+
+    duplicate_eps = [
+        metadata.EntryPoint(
+            name="duplicated",
+            value="dist_a.module:Provider",
+            group=PROVIDER_ENTRYPOINT,
+        ),
+        metadata.EntryPoint(
+            name="duplicated",
+            value="dist_b.module:Provider",
+            group=PROVIDER_ENTRYPOINT,
+        ),
+    ]
+
+    def fake_entry_points(*args: Any, **kwargs: Any):
+        eps = real_entry_points(*args, **kwargs)
+        if kwargs.get("group") == PROVIDER_ENTRYPOINT:
+            return list(eps) + duplicate_eps
+        return eps
+
+    mocker.patch(
+        "commitizen.commands.init.metadata.entry_points",
+        side_effect=fake_entry_points,
+    )
+
+    choices = _construct_version_provider_choices()
+    values = [choice.value for choice in choices]
+
+    assert values.count("duplicated") == 1

--- a/tests/commands/test_init_command.py
+++ b/tests/commands/test_init_command.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -483,3 +484,70 @@ def test_construct_name_choice_from_registry(config: BaseConfig):
         choices[2].description
         == "<ignored text> <ISSUE_KEY> <ignored text> #<COMMAND> <optional COMMAND_ARGUMENTS>"
     )
+
+
+def test_construct_version_provider_choices_includes_builtins():
+    """Built-in providers appear first with curated descriptions."""
+    from commitizen.commands.init import _construct_version_provider_choices
+
+    choices = _construct_version_provider_choices()
+    values = [choice.value for choice in choices]
+    titles = [choice.title for choice in choices]
+
+    # All eight built-ins must be present.
+    for builtin in (
+        "commitizen",
+        "cargo",
+        "composer",
+        "npm",
+        "pep621",
+        "poetry",
+        "uv",
+        "scm",
+    ):
+        assert builtin in values
+
+    # And they must come with their curated descriptions, not the
+    # generic "third-party version provider" suffix.
+    assert "commitizen: Fetch and set version in commitizen config (default)" in titles
+    for title in titles[:8]:
+        assert "third-party" not in title
+
+
+def test_construct_version_provider_choices_discovers_third_party(
+    mocker: MockFixture,
+):
+    """Third-party providers registered under `commitizen.provider` are appended."""
+    from commitizen.commands.init import _construct_version_provider_choices
+    from commitizen.providers import PROVIDER_ENTRYPOINT
+
+    real_entry_points = metadata.entry_points
+
+    fake_third_party = metadata.EntryPoint(
+        name="my-third-party",
+        value="some.module:Provider",
+        group=PROVIDER_ENTRYPOINT,
+    )
+
+    def fake_entry_points(*args: Any, **kwargs: Any):
+        eps = real_entry_points(*args, **kwargs)
+        if kwargs.get("group") == PROVIDER_ENTRYPOINT:
+            return list(eps) + [fake_third_party]
+        return eps
+
+    mocker.patch(
+        "commitizen.commands.init.metadata.entry_points",
+        side_effect=fake_entry_points,
+    )
+
+    choices = _construct_version_provider_choices()
+    values = [choice.value for choice in choices]
+    titles = [choice.title for choice in choices]
+
+    assert "my-third-party" in values
+    assert "my-third-party: third-party version provider" in titles
+    # Built-in `pep621` already lives in the entry-point group; ensure we
+    # didn't duplicate it once with the curated description and again
+    # with the generic third-party suffix.
+    assert values.count("pep621") == 1
+    assert "pep621: third-party version provider" not in titles


### PR DESCRIPTION
## Description

Closes #1258.

### Why

`cz init` interactively asks the user to pick a `version_provider`. The picker's options were hard-coded to the eight built-in providers (`commitizen`, `cargo`, `composer`, `npm`, `pep621`, `poetry`, `uv`, `scm`), even though commitizen already supports third-party providers via the `commitizen.provider` entry-point group at runtime (`commitizen/providers/__init__.py:get_provider`). The mismatch meant a user who installed e.g. `commitizen-deno-provider` had to either know the provider name from memory and hand-edit the config, or skip `cz init` entirely. The original reporter offered the implementation sketch.

### What changed

| File | Change |
| --- | --- |
| `commitizen/commands/init.py` | `_VERSION_PROVIDER_CHOICES` (a tuple of `questionary.Choice`) is replaced by `_BUILTIN_VERSION_PROVIDER_OPTIONS` (data-only) and a new `_construct_version_provider_choices()` helper that builds the picker list at call time. `_ask_version_provider()` now invokes that helper. |
| `tests/commands/test_init_command.py` | Three new tests: built-ins-only, third-party-discovered, duplicate-third-party-deduped. |
| `docs/config/version_provider.md` | One-paragraph note in the "Custom Provider Plugins" section explaining that `cz init` now surfaces the plugin once installed. |

### How it works

1. **Built-ins still come first, with curated descriptions.** The `_BUILTIN_VERSION_PROVIDER_OPTIONS` tuple keeps the human-readable labels (e.g. `"pep621: Get and set version from pyproject.toml:project.version field"`) instead of falling back to a generic suffix.
2. **Third-party providers are discovered, never loaded.** Only `ep.name` is read; `ep.load()` is **not** called, so installing a malicious `cz_*` plugin can't execute its module just because the user opened `cz init`.
3. **Two layers of dedup, both necessary:**
   - The eight built-ins are themselves registered under `[project.entry-points."commitizen.provider"]` in `pyproject.toml:73-81`. A naive listing would yield each one twice. We seed `seen_names` with the built-in set and skip any entry-point name already in it.
   - Two distributions can register a third-party provider under the same name (e.g. two unrelated forks both publishing `cz_jira`). After the first occurrence is added we mark the name `seen` and skip the rest. We deliberately don't try to merge the duplicates: `commitizen.providers.get_provider()` raises `VersionProviderUnknown` when more than one entry point matches, so the user picking the duplicated name gets a clear error instead of the picker silently choosing whichever distribution loaded first.
4. **No registry caching.** Each `cz init` invocation re-reads the entry-point group, so a provider installed mid-shell-session is picked up immediately.

### Backward compatibility

- Users without any third-party plugin see exactly the same picker as v4.15.1 (same eight built-ins, same order, same titles).
- The function signature change is internal (`_VERSION_PROVIDER_CHOICES` was a leading-underscore module global, never exported).

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce (3 new tests, see the targeted commands below)
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests (`poe lint` clean; 33/33 init tests pass)
- [x] Manually test the changes (see "Steps to Test" below)
- [x] Update the documentation for the changes

### Documentation Changes

- [x] Added a paragraph about auto-discovery to `docs/config/version_provider.md`
- [x] Run `uv run poe doc` locally to ensure the documentation pages render correctly
- [x] Check and fix any broken links (internal or external)

## Expected Behavior

| Scenario | Outcome |
| --- | --- |
| `cz init` with no third-party providers installed | Same eight built-in choices, same order, same descriptions as before. |
| `cz init` with a third-party plugin installed (e.g. `commitizen-deno-provider` exposing `commitizen.provider` -> `deno`) | The eight built-ins appear first, then `deno: third-party version provider`. Selecting it writes `version_provider = "deno"` to `pyproject.toml`. |
| Two installed distributions both register `commitizen.provider` -> `dup` | `dup` appears once in the picker. Selecting it surfaces the existing `VersionProviderUnknown` error from `get_provider()` so the conflict is loud, not silent. |

## Steps to Test This Pull Request

```sh
git fetch fork feat/1258-init-discover-providers
git checkout fork/feat/1258-init-discover-providers

# 1. Built-ins-only test (no plugins installed): all eight present, none labelled third-party.
uv run pytest tests/commands/test_init_command.py::test_construct_version_provider_choices_includes_builtins -v

# 2. Third-party-discovered test: a fake EntryPoint("my-third-party") is patched in.
uv run pytest tests/commands/test_init_command.py::test_construct_version_provider_choices_discovers_third_party -v

# 3. Duplicate-third-party-deduped test: two EntryPoint(name="duplicated") -> only one choice.
uv run pytest tests/commands/test_init_command.py::test_construct_version_provider_choices_dedupes_duplicate_third_party -v

# 4. Full init suite (32 pre-existing + 1 new dedup test).
uv run pytest tests/commands/test_init_command.py -q
# expected: 33 passed
```

## Additional Context

Surfaced while triaging open issues in #1965. The implementation follows the original reporter's sketch but uses a single discover-on-call function and dedupes against the built-in list rather than building a separate registry. The duplicate-name handling was added in fixup commit `1bad9047` after a GitHub Copilot review pass flagged it as a potential UX gap.
