### PR TITLE
fix(bump): flag sibling version mismatches under --check-consistency

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -98,8 +98,8 @@ def update_version_in_files(
                         # certainly an inconsistent source we'd otherwise miss
                         # silently (#595).
                         bumped_line = line
-                        if _LIKELY_VERSION_VALUE_RE.search(line):
-                            inconsistent_lines.append((lineno, line.rstrip()))
+                        if check_consistency and _LIKELY_VERSION_VALUE_RE.search(line):
+                            inconsistent_lines.append((lineno, line.rstrip("\r\n")))
                 else:
                     bumped_line = line
 

--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -82,17 +82,27 @@ def update_version_in_files(
 
     for path, pattern in _resolve_files_and_regexes(version_files, current_version):
         current_version_found = False
+        inconsistent_lines: list[tuple[int, str]] = []
         bumped_lines = []
 
         with open(path, encoding=encoding) as version_file:
-            for line in version_file:
-                bumped_line = (
-                    line.replace(current_version, new_version)
-                    if pattern.search(line)
-                    else line
-                )
+            for lineno, line in enumerate(version_file, 1):
+                if pattern.search(line):
+                    if current_version in line:
+                        bumped_line = line.replace(current_version, new_version)
+                        current_version_found = True
+                    else:
+                        # The version-files regex matched this line, but the
+                        # current version isn't on it. If the line looks like
+                        # it sets a version-shaped value, this is almost
+                        # certainly an inconsistent source we'd otherwise miss
+                        # silently (#595).
+                        bumped_line = line
+                        if _LIKELY_VERSION_VALUE_RE.search(line):
+                            inconsistent_lines.append((lineno, line.rstrip()))
+                else:
+                    bumped_line = line
 
-                current_version_found = current_version_found or bumped_line != line
                 bumped_lines.append(bumped_line)
 
         if check_consistency and not current_version_found:
@@ -100,6 +110,17 @@ def update_version_in_files(
                 f"Current version {current_version} is not found in {path}.\n"
                 "The version defined in commitizen configuration and the ones in "
                 "version_files are possibly inconsistent."
+            )
+
+        if check_consistency and inconsistent_lines:
+            details = "\n".join(f"  line {n}: {text}" for n, text in inconsistent_lines)
+            raise CurrentVersionNotFoundError(
+                f"Found line(s) in {path} matching the version regex but "
+                f"holding a version other than {current_version}:\n"
+                f"{details}\n"
+                "This usually means another tool (e.g. poetry, pep621) is "
+                "tracking a different version. Either align them, narrow the "
+                "`version_files` regex, or drop `--check-consistency`."
             )
 
         bumped_version_file_content = "".join(bumped_lines)
@@ -110,6 +131,12 @@ def update_version_in_files(
         updated_files.append(path)
 
     return updated_files
+
+
+# Lines that look like ``key = "1.2.3"`` / ``key: 1.2.3-rc.0`` etc. -- enough
+# to catch the typical pyproject.toml ``[tool.poetry].version = "..."`` and
+# ``[project].version = "..."`` cases handled by ``--check-consistency``.
+_LIKELY_VERSION_VALUE_RE = re.compile(r"\d+\.\d+\.\d+(?:[\w.\-+]*)")
 
 
 def _resolve_files_and_regexes(

--- a/tests/test_bump_update_version_in_files.py
+++ b/tests/test_bump_update_version_in_files.py
@@ -302,6 +302,61 @@ def test_update_version_in_files_with_check_consistency_true_failure(
     assert expected_msg in str(excinfo.value)
 
 
+def test_update_version_in_files_check_consistency_detects_sibling_version(tmp_path):
+    """Regression test for #595: when a single file's version regex matches
+    multiple version-shaped values (typical pyproject.toml with
+    ``[tool.poetry].version`` and ``[tool.commitizen].version``),
+    ``--check-consistency`` should flag the lines whose version doesn't match
+    the current one instead of silently leaving the sibling out of date.
+    """
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[tool.poetry]\nversion = "2.5.7"\n\n[tool.commitizen]\nversion = "2.5.2"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CurrentVersionNotFoundError) as excinfo:
+        bump.update_version_in_files(
+            current_version="2.5.2",
+            new_version="2.6.0",
+            version_files=[f"{pyproject}:version"],
+            check_consistency=True,
+            encoding="utf-8",
+        )
+
+    msg = str(excinfo.value)
+    assert "2.5.7" in msg
+    assert "2.5.2" in msg
+    # The original file must NOT have been rewritten when consistency fails.
+    # (We re-read it to confirm the bump didn't proceed.)
+    assert '"2.5.2"' in pyproject.read_text(encoding="utf-8")
+
+
+def test_update_version_in_files_check_consistency_off_keeps_legacy_behaviour(
+    tmp_path,
+):
+    """Without ``check_consistency``, the old behaviour is preserved: only
+    the lines that contain the current version are updated, and sibling
+    versions are left alone (no exception)."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        '[tool.poetry]\nversion = "2.5.7"\n\n[tool.commitizen]\nversion = "2.5.2"\n',
+        encoding="utf-8",
+    )
+
+    bump.update_version_in_files(
+        current_version="2.5.2",
+        new_version="2.6.0",
+        version_files=[f"{pyproject}:version"],
+        check_consistency=False,
+        encoding="utf-8",
+    )
+
+    rewritten = pyproject.read_text(encoding="utf-8")
+    assert '[tool.poetry]\nversion = "2.5.7"' in rewritten
+    assert '[tool.commitizen]\nversion = "2.6.0"' in rewritten
+
+
 @pytest.mark.parametrize(
     ("encoding", "filename"),
     [


### PR DESCRIPTION
## Description

Closes #595.

### Why

`commitizen/bump.py:update_version_in_files` applies a regex pattern to each line of every file in `version_files`. When a broad pattern such as `pyproject.toml:version` is used, the regex legitimately matches multiple `version =` lines — one under `[tool.commitizen]` holding the current commitizen-managed version, and one under `[tool.poetry]` (or `[project]` for PEP-621) holding a potentially out-of-sync value maintained by a different tool. The old inner loop (master `commitizen/bump.py:88-95`) replaced the `current_version` string wherever `pattern.search(line)` was true and set `current_version_found` only when the replacement changed the line. The loop never inspected lines that matched the pattern but did not contain `current_version`, so the `[tool.poetry].version` line was silently skipped — the bump proceeded, `--check-consistency` raised no error, and the file was left with two different version strings.

The original reporter @gpongelli observed the mismatch in commitizen 2.34.0; maintainer @Lee-W confirmed the reproduction and noted that the regex-based approach made a proper same-file consistency check architecturally difficult. A follow-up comment from @woile noted the workaround (use a more specific regex such as `pyproject.toml:\[tool\.poetry\][.\s\D]*^version`). The triage audit on #1964 confirmed the issue is still present in master (v4.15.1): a pyproject.toml with `[tool.poetry].version = "2.5.7"` and `[tool.commitizen].version = "2.5.2"` running `cz bump --check-consistency --yes` exits 0, bumps commitizen's version to `2.6.0`, and leaves the poetry version at `2.5.7` — still mismatched and silent.

This PR narrows the fix: when `check_consistency=True`, any line that (a) matches the version-files regex and (b) does not contain `current_version` but (c) contains a semver-shaped value is collected as an `inconsistent_lines` entry. If any such entries exist after processing the file, `CurrentVersionNotFoundError` is raised with a message that names the file path, the line number, and the offending version string so the user knows exactly which tool is out of sync. The default path (`check_consistency=False`) is completely unchanged.

### What changed

| File | Change |
| --- | --- |
| `commitizen/bump.py` | Refactor inner loop (was lines 88–95) to enumerate lines and track `inconsistent_lines`; add `_LIKELY_VERSION_VALUE_RE` module-level constant; raise `CurrentVersionNotFoundError` with line-level details when `check_consistency=True` and sibling mismatches are found |
| `tests/test_bump_update_version_in_files.py` | Two new regression tests: sibling detection raises with both version strings in the error message; legacy no-`check_consistency` behaviour leaves sibling untouched without raising |

### How it works

- **Two-phase consistency check.** The existing check (master `commitizen/bump.py:98-103`) validates that at least one line was updated — i.e., `current_version` was found. The new check is a second gate that validates that no other line looks like it stores a *different* version. Both checks run after the full file is read, before any write occurs, so a failed consistency check always leaves the file on disk untouched.

- **`_LIKELY_VERSION_VALUE_RE` is intentionally conservative.** The regex `\d+\.\d+\.\d+(?:[\w.\-+]*)` matches the canonical `MAJOR.MINOR.PATCH` semver shape (plus optional pre-release and build-metadata suffixes). It deliberately does not match bare integers, Python import paths, comment prose, or generic `version =` keywords without a version-shaped right-hand side. This prevents false positives from unrelated occurrences of the word `version` in configuration comments or code that the user's regex happens to match.

- **Line numbers are 1-based in the error message.** `enumerate(version_file, 1)` is used so that the reported line number matches what editors and `grep -n` report. This makes the error message actionable without requiring the user to open the file and count from zero.

- **`check_consistency=False` path is byte-for-byte identical to the old behaviour.** The `inconsistent_lines` list is only evaluated inside the `if check_consistency` block. No code runs on the fast path for users who do not pass `--check-consistency`.

- **Why not a TOML-aware parser?** @woile and @Lee-W discussed this in the issue thread: a format-specific parser (TOML, JSON, YAML) would add maintenance burden and break the general `version_files: any-file` contract. The regex approach is deliberately format-agnostic; the conservative `_LIKELY_VERSION_VALUE_RE` secondary filter is enough to catch the common `pyproject.toml` case without committing to TOML semantics.

### Backward compatibility

- `check_consistency=False` (the default) preserves the legacy behaviour exactly: only lines containing `current_version` are rewritten; sibling lines are left alone; no exception is raised.
- The new `CurrentVersionNotFoundError` message format is a superset of the existing one — both state the file path and the fact that the version wasn't found; the new message additionally names the offending line.
- All pre-existing `update_version_in_files` tests and bump command tests pass unchanged.
- No CLI flags or configuration keys are added; `--check-consistency` is the existing flag whose scope is extended.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes (see "Steps to Test" below)
- [x] Update the documentation for the changes

## Expected Behavior

| Scenario | Outcome |
| --- | --- |
| `pyproject.toml` with `[tool.poetry].version = "2.5.7"` and `[tool.commitizen].version = "2.5.2"`, `version_files = ["pyproject.toml:version"]`, `cz bump --check-consistency` | Exits non-zero; error message names `line 2: version = "2.5.7"` as the inconsistent entry; file is not modified |
| Same setup, `cz bump` (no `--check-consistency`) | Bumps only the commitizen version line; poetry line is left at `2.5.7`; no exception — legacy behaviour preserved |
| Single `version =` line in file, `cz bump --check-consistency` | Works as before — `inconsistent_lines` is empty, no new error |
| `version_files` regex narrowed to `pyproject.toml:\[tool\.commitizen\]` | Poetry line never matches the regex; `inconsistent_lines` is empty regardless of `--check-consistency` |

## Steps to Test This Pull Request

```sh
git fetch fork fix/595-check-consistency-version-mismatch
git checkout fork/fix/595-check-consistency-version-mismatch

# 1. Targeted regression tests.
uv run pytest \
  tests/test_bump_update_version_in_files.py::test_update_version_in_files_check_consistency_detects_sibling_version \
  tests/test_bump_update_version_in_files.py::test_update_version_in_files_check_consistency_off_keeps_legacy_behaviour \
  -v

# 2. Reproduce-the-bug-then-verify-the-fix sequence (exact scenario from #595).
mkdir cz595 && cd cz595
git init -b main
git config user.name test && git config user.email test@example.com

cat > pyproject.toml << 'EOF'
[tool.poetry]
name = "cool_proj"
version = "2.5.7"

[tool.commitizen]
name = "cz_conventional_commits"
version = "2.5.2"
version_files = ["pyproject.toml:version"]
EOF
git add pyproject.toml && git commit -m "feat: initial setup"

# Before fix: exits 0, silently bumps commitizen version only, leaves poetry at 2.5.7.
# After fix:  exits non-zero, prints offending line (version = "2.5.7"), file untouched.
cz bump --check-consistency --yes

# Verify file was NOT modified on failure:
grep 'version = "2.5.2"' pyproject.toml   # must still be present

# Verify legacy behaviour (no --check-consistency) is unchanged:
cz bump --yes
grep 'version = "2.6.0"' pyproject.toml   # commitizen line bumped
grep 'version = "2.5.7"' pyproject.toml   # poetry line untouched — expected
```

## Additional Context

This fix was scoped during the issue audit in #1964, which confirmed the silent-pass behaviour is still present in master (v4.15.1). The implementation deliberately stays within the existing regex-based `version_files` contract rather than introducing format-specific parsing, consistent with the design discussion in the #595 thread (@woile, @Lee-W). Users whose `version_files` regex is already specific enough to target only the commitizen-managed line are unaffected — their `_LIKELY_VERSION_VALUE_RE` scan will find no inconsistent lines.