### PR TITLE
fix(providers/uv): treat uv.lock as optional

### DIFF
--- a/commitizen/providers/uv_provider.py
+++ b/commitizen/providers/uv_provider.py
@@ -26,6 +26,12 @@ class UvProvider(TomlProvider):
         self.set_lock_version(version)
 
     def set_lock_version(self, version: str) -> None:
+        if not self.lock_file.exists():
+            # `uv.lock` is optional: a freshly initialised project (or a uv
+            # workspace member, since the lock lives at the workspace root)
+            # may not have one yet. Updating `pyproject.toml` is enough.
+            return
+
         pyproject_toml_content = tomlkit.parse(
             self.file.read_text(encoding=self._get_encoding())
         )

--- a/commitizen/providers/uv_provider.py
+++ b/commitizen/providers/uv_provider.py
@@ -23,15 +23,16 @@ class UvProvider(TomlProvider):
 
     def set_version(self, version: str) -> None:
         super().set_version(version)
-        self.set_lock_version(version)
+        # `uv.lock` is optional: a freshly initialised project (or a uv
+        # workspace member, since the lock lives at the workspace root)
+        # may not have one yet. Updating `pyproject.toml` is enough.
+        # Use `is_file()` (not `exists()`) to skip directories or other
+        # path-shaped artefacts as well, matching the convention in
+        # `cargo_provider.py` / `npm_provider.py`.
+        if self.lock_file.is_file():
+            self.set_lock_version(version)
 
     def set_lock_version(self, version: str) -> None:
-        if not self.lock_file.exists():
-            # `uv.lock` is optional: a freshly initialised project (or a uv
-            # workspace member, since the lock lives at the workspace root)
-            # may not have one yet. Updating `pyproject.toml` is enough.
-            return
-
         pyproject_toml_content = tomlkit.parse(
             self.file.read_text(encoding=self._get_encoding())
         )

--- a/tests/providers/test_uv_provider.py
+++ b/tests/providers/test_uv_provider.py
@@ -119,3 +119,24 @@ def test_uv_provider(
 
     file_regression.check(updated_pyproject_toml_content, extension=".toml")
     file_regression.check(updated_uv_lock_content, extension=".lock")
+
+
+def test_uv_provider_without_lock_file(config: BaseConfig, tmp_path, monkeypatch):
+    """Regression for #1383: a freshly initialised uv project (or a uv
+    workspace member) has no `uv.lock` yet; bumping must still update
+    `pyproject.toml` instead of raising `FileNotFoundError`."""
+    monkeypatch.chdir(tmp_path)
+    pyproject_toml_file = tmp_path / UvProvider.filename
+    pyproject_toml_file.write_text(PYPROJECT_TOML, encoding="utf-8")
+    assert not (tmp_path / UvProvider.lock_filename).exists()
+
+    config.settings["version_provider"] = "uv"
+
+    provider = get_provider(config)
+    assert isinstance(provider, UvProvider)
+    assert provider.get_version() == "4.2.1"
+
+    provider.set_version("100.100.100")
+    assert provider.get_version() == "100.100.100"
+    assert "100.100.100" in pyproject_toml_file.read_text(encoding="utf-8")
+    assert not (tmp_path / UvProvider.lock_filename).exists()


### PR DESCRIPTION
## Description

Closes #1383.

### Why

`UvProvider.set_lock_version()` unconditionally read `uv.lock` via `self.lock_file.read_text()`, so `cz bump` crashed with `FileNotFoundError: [Errno 2] No such file or directory: 'uv.lock'` whenever the lock had not been written yet. Two real-world reproducers:

1. A freshly initialised uv project that has never had `uv sync` run (the original reporter's reproduction, posted in the issue thread).
2. A uv workspace member: the lock lives at the workspace root, not next to the package's own `pyproject.toml`. A user reported this in a follow-up comment using uv 0.7.9 / cz 4.8.0.

The maintainer (`@Lee-W`) confirmed in the issue thread: *"hmmm... I thought we have it long ago. yep, we'll definitely need it."*

### What changed

| File | Change |
| --- | --- |
| `commitizen/providers/uv_provider.py` | `set_version()` now wraps the `set_lock_version(version)` call in `if self.lock_file.is_file():`, mirroring the convention used by `cargo_provider.py:42` and `npm_provider.py:53,62`. `set_lock_version()` itself is unchanged so external callers that already verified the lock exists keep working. |
| `tests/providers/test_uv_provider.py` | New `test_uv_provider_without_lock_file` — creates a `pyproject.toml` without a sibling `uv.lock`, runs `set_version("100.100.100")`, asserts `pyproject.toml` was updated and no `uv.lock` was created. |

### How it works

- The guard uses `Path.is_file()`, not `Path.exists()`. `exists()` is also true for directories and symlinks-to-non-files, both of which would still trip `read_text()`. The cargo and npm providers already make this distinction; the uv provider was the outlier.
- The guard is hoisted to `set_version()` rather than placed at the top of `set_lock_version()`. This matches `cargo_provider.py`'s structure and means the lock-rewrite path can keep its precondition: "if you call `set_lock_version`, the lock must exist."
- For uv workspace members the lock is at the workspace root, not next to the package. The `lock_file` property here resolves to the cwd-relative `uv.lock`, which won't exist for a workspace member running from its own subdirectory; the `is_file()` guard skips the rewrite cleanly. A future PR could add proper workspace-root resolution, but that's a feature, not part of this fix — uv reconciles the lock on the next `uv sync` either way.
- TOCTOU race (lock created between `is_file()` and `read_text()`) is benign — the subsequent `read_text()` would simply succeed with the new content.

### Backward compatibility

- Existing path (lock present, single-package uv project) is exercised by the unchanged `test_uv_provider[hyphenated|underscore]` and produces byte-identical output.
- No public API change; `set_lock_version()` keeps the same signature.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce (1 new regression test)
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests (`poe lint` clean; 3/3 uv_provider tests pass — 2 existing + 1 new)
- [x] Manually test the changes (see "Steps to Test" below for the issue reporter's exact reproduction script)
- [x] Update the documentation for the changes (no doc change required — the lock-handling behaviour is internal)

## Expected Behavior

| Scenario | Before this PR | After this PR |
| --- | --- | --- |
| Fresh uv project, no `uv.lock` yet | `cz bump` crashes with `FileNotFoundError: 'uv.lock'` | `pyproject.toml` is updated, no lock written, exit 0. |
| uv workspace member running from subdirectory | Same `FileNotFoundError` | Same — package's `pyproject.toml` updated, lock-rewrite skipped (workspace root will be reconciled by next `uv sync`). |
| Single-package project with a populated `uv.lock` | Both files updated | Both files updated (unchanged). |
| `uv.lock` is a directory or symlink to a non-file | Crashes with the same error | Skipped via `is_file()` (matches cargo/npm convention). |

## Steps to Test This Pull Request

```sh
git fetch fork fix/1383-uv-lock-optional
git checkout fork/fix/1383-uv-lock-optional

# 1. Targeted regression test (3 cases).
uv run pytest tests/providers/test_uv_provider.py -v
# expected: 3 passed

# 2. Reproduce the original bug, then verify the fix (matches the issue reporter's script).
mkdir -p /tmp/cz-1383 && cd /tmp/cz-1383
git init -q
uv init --quiet
uv run cz init --no-prompt   # or follow the prompts; pick `uv` as the version provider
sed -i.bak 's/pep621/uv/' pyproject.toml
git add . && git -c user.email=a@b -c user.name=t commit -qm "feat: a"
# On master this would now crash. On this PR it should succeed:
uv run cz bump --yes
test -f uv.lock && echo "lock exists" || echo "no lock — expected"
grep '^version' pyproject.toml   # should show the bumped version
```

## Additional Context

Surfaced while triaging open issues in #1976 (round 3). Switched from `Path.exists()` to `Path.is_file()` in fixup commit `f204942e` after GitHub Copilot's review noted that the existing convention in `cargo_provider.py:42` and `npm_provider.py:53,62` is `is_file()` (and that `exists()` would still trip if the lock path happened to be a directory). The issue had been open for 11 months and was already labelled `good first issue` + `wait-for-implementation`; the previously assigned contributor confirmed they were happy for someone else to take it over.
