### PR TITLE
fix(bump): only consider commit titles when matching bump patterns

### DIFF
--- a/commitizen/bump.py
+++ b/commitizen/bump.py
@@ -34,7 +34,20 @@ def find_increment(
     increment: str | None = None
 
     for commit in commits:
-        for message in commit.message.split("\n"):
+        # We only consider:
+        #   * the commit title (the first line, where the commit type lives), and
+        #   * lines in the body that are a ``BREAKING CHANGE:`` /
+        #     ``BREAKING-CHANGE:`` footer (per the Conventional Commits spec).
+        # Scanning every body line for type-prefixed text matches generated
+        # commit bodies (e.g. Dependabot quoting an upstream changelog with a
+        # ``fix:`` line) and produces false-positive bumps -- see #1772.
+        candidate_lines = [commit.title]
+        for body_line in commit.body.split("\n"):
+            stripped = body_line.lstrip()
+            if stripped.startswith(("BREAKING CHANGE:", "BREAKING-CHANGE:")):
+                candidate_lines.append(stripped)
+
+        for message in candidate_lines:
             result = select_pattern.search(message)
 
             if result:

--- a/tests/test_bump_find_increment.py
+++ b/tests/test_bump_find_increment.py
@@ -133,7 +133,7 @@ DEPENDABOT_BODY = (
     "<summary>Commits</summary>\n"
     "<ul>\n"
     '<li><a href="...">b5b1a91</a>\n'
-    "fix: update <code>@​actions/artifact</code> to ^5.0.0 for Node.js 24\n"
+    "fix: update <code>@actions/artifact</code> to ^5.0.0 for Node.js 24\n"
     "punycode fix</li>\n"
     '<li><a href="...">5f643d3</a>\n'
     "chore: update license files</li>\n"

--- a/tests/test_bump_find_increment.py
+++ b/tests/test_bump_find_increment.py
@@ -122,3 +122,51 @@ def test_find_increment_sve(messages, expected_type):
         commits, regex=semantic_version_pattern, increments_map=semantic_version_map
     )
     assert increment_type == expected_type
+
+
+# Mimics the dependabot pull request body that triggered #1772: a ``ci:``
+# title with a commit body that quotes upstream changelog lines, including
+# ``fix: ...`` text. None of the body lines should bump the version.
+DEPENDABOT_BODY = (
+    "Bumps actions/upload-artifact from 5 to 6.\n"
+    "<details>\n"
+    "<summary>Commits</summary>\n"
+    "<ul>\n"
+    '<li><a href="...">b5b1a91</a>\n'
+    "fix: update <code>@​actions/artifact</code> to ^5.0.0 for Node.js 24\n"
+    "punycode fix</li>\n"
+    '<li><a href="...">5f643d3</a>\n'
+    "chore: update license files</li>\n"
+    "</ul>\n"
+    "</details>\n"
+)
+
+
+def test_find_increment_ignores_type_tokens_in_commit_body():
+    """Regression test for #1772: a ``ci:`` commit whose body lists upstream
+    commit messages -- including ones that look like ``fix:`` -- must not
+    trigger a PATCH bump. Only the title's commit type counts."""
+    commit = GitCommit(rev="test", title="ci: bump dep", body=DEPENDABOT_BODY)
+    increment_type = bump.find_increment(
+        [commit],
+        regex=ConventionalCommitsCz.bump_pattern,
+        increments_map=ConventionalCommitsCz.bump_map,
+    )
+    assert increment_type is None
+
+
+def test_find_increment_still_honors_breaking_change_in_body():
+    """The ``BREAKING CHANGE:`` / ``BREAKING-CHANGE:`` footer in a commit body
+    must still trigger a MAJOR bump even after the #1772 fix; only commit
+    *types* are now restricted to the title."""
+    commit = GitCommit(
+        rev="test",
+        title="feat: new user interface",
+        body="some body content\n\nBREAKING CHANGE: age is no longer supported",
+    )
+    increment_type = bump.find_increment(
+        [commit],
+        regex=ConventionalCommitsCz.bump_pattern,
+        increments_map=ConventionalCommitsCz.bump_map,
+    )
+    assert increment_type == "MAJOR"


### PR DESCRIPTION
## Description

Closes #1772.

### Why

`cz bump` was producing spurious `PATCH` version bumps on `ci:` commits whose bodies contained Dependabot-generated content. Dependabot's pull-request descriptions quote upstream repository changelogs verbatim, and those changelogs routinely contain lines such as `fix: update @actions/artifact to ^5.0.0 for Node.js 24 punycode fix`. Because `find_increment` in `commitizen/bump.py:37` (master) iterates over every line of `commit.message` — which is computed as `f"{self.title}\n\n{self.body}".strip()` at `commitizen/git.py:78–79` — those body lines are matched against the `bump_pattern` and counted as `fix:` commits, triggering a `PATCH` bump on a commit that is semantically a dependency-update automation entry with a `ci:` title.

The issue was initially closed as "working as designed" after a maintainer misread the log: the `fix:` line in question was not a commit in the user's repository — it was text inside the Dependabot PR body (which becomes the body of the squash-merged `ci:` commit). @Clockwork-Muse clarified this with a screenshot in February 2026, and @Lee-W reopened the issue. Subsequent verification against master (4.15.1) in the #1964 audit confirmed the false positive is still reproducible: a `ci:` commit whose body contains an unbulleted `fix: …` line at column 0 produces a `PATCH` bump and a spurious `### Fix` changelog section. The [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) places the commit type exclusively in the title (the first line); scanning every body line for type-prefixed text contradicts the spec and produces this class of false positive on auto-generated commit bodies.

### What changed

| File | Change |
| --- | --- |
| `commitizen/bump.py` | In `find_increment()`, replace the `commit.message.split("\n")` loop at line 37 (master) with a `candidate_lines` list containing only `commit.title` plus any body lines that begin with `BREAKING CHANGE:` or `BREAKING-CHANGE:` |
| `tests/test_bump_find_increment.py` | Add two regression tests: `test_find_increment_ignores_type_tokens_in_commit_body` (the Dependabot false-positive scenario) and `test_find_increment_still_honors_breaking_change_in_body` (confirming `MAJOR` is still triggered by a body footer) |

### How it works

- **Title-only type matching**: `candidate_lines` is initialised as `[commit.title]`. The `commit.title` attribute stores only the first line of the commit message (set at `commitizen/git.py:71`), so no body content can reach the `bump_pattern` via this path.
- **Body still scanned for breaking-change footers**: the body is split on `"\n"` and each line is tested with `stripped.startswith(("BREAKING CHANGE:", "BREAKING-CHANGE:"))` after a `lstrip()` call. Matching lines are appended to `candidate_lines` and then processed by the same `select_pattern.search()` call as the title.
- **`lstrip()` rather than `strip()` for footer indentation tolerance** — the non-obvious choice: the Conventional Commits spec allows trailers to be indented (e.g., `  BREAKING CHANGE: x`). Using `lstrip()` means such indented footers are still accepted, while a body line like `  fix: something` is stripped to `fix: something`, which does not start with either breaking-change token and so is correctly excluded. Using `strip()` instead would also work here, but `lstrip()` is semantically more precise — the trailing content of a footer is not guaranteed to be whitespace-free, so only left-stripping is warranted for the prefix check.
- **`commit.message` property untouched**: `commitizen/git.py:77–79` defines `message` as `title + "\n\n" + body` and this property is used elsewhere (changelog rendering, the `check` command). Only `find_increment` changes which lines it examines; every other consumer of `commit.message` is unaffected.

### Backward compatibility

- Any commit whose **title** begins with a conventional type (`fix:`, `feat:`, `perf:`, etc.) is still bumped exactly as before.
- `BREAKING CHANGE:` / `BREAKING-CHANGE:` footers in the commit body still trigger a `MAJOR` bump.
- The `feat!:` / `fix!:` exclamation-mark breaking-change syntax in the title is unaffected — it is matched against `commit.title` by the same `select_pattern`.
- `commit.message`, `commit.title`, and `commit.body` on `GitCommit` (`commitizen/git.py:60–79`) are untouched.
- All 12 pre-existing `test_find_increment_*` tests in `tests/test_bump_find_increment.py` pass; the full bump command integration test suite (131 tests) passes with the same 4 GPG-fixture tests deselected on Windows as before.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes (see "Steps to Test" below)
- [x] Update the documentation for the changes

## Expected Behavior

| Scenario | Outcome |
| --- | --- |
| `ci:` commit whose body contains `fix: …` lines (Dependabot-style) | No bump — body type-prefixed lines are ignored |
| `fix: normal patch fix` in the commit title | `PATCH` bump — unchanged |
| `feat: new feature` title with `BREAKING CHANGE: old API removed` in the body | `MAJOR` bump — breaking-change footer still honoured |
| `feat!: breaking change flagged in title` | `MAJOR` bump — exclamation-mark syntax in title still honoured |
| `ci:` commit with a bulleted body line `- fix: addresses CVE-…` | No bump — leading `- ` prevents `startswith` match and the line is excluded |

## Steps to Test This Pull Request

```sh
git fetch fork fix/1772-anchor-bump-pattern-to-title
git checkout fork/fix/1772-anchor-bump-pattern-to-title

# 1. Targeted regression test.
uv run pytest tests/test_bump_find_increment.py -v

# 2. Reproduce-the-bug-then-verify-the-fix sequence.
python - <<'EOF'
from commitizen import bump
from commitizen.git import GitCommit
from commitizen.cz.conventional_commits import ConventionalCommitsCz

# Exact reproducer from #1772: a ci: commit whose body quotes an upstream
# changelog entry containing "fix: ..." at column 0.
DEPENDABOT_BODY = (
    "Bumps actions/upload-artifact from 5 to 6.\n"
    "fix: update @actions/artifact to ^5.0.0 for Node.js 24 punycode fix\n"
)

commit = GitCommit(
    rev="abc123",
    title="ci: bump actions/upload-artifact from 5 to 6 (#23)",
    body=DEPENDABOT_BODY,
)
result = bump.find_increment(
    [commit],
    regex=ConventionalCommitsCz.bump_pattern,
    increments_map=ConventionalCommitsCz.bump_map,
)
assert result is None, f"FAIL: expected None, got {result!r} — false-positive bump still present"
print("OK: Dependabot body does not trigger a bump")

# Confirm BREAKING CHANGE in body still works.
bc_commit = GitCommit(
    rev="def456",
    title="feat: new user interface",
    body="some detail\n\nBREAKING CHANGE: drops support for legacy config format",
)
result = bump.find_increment(
    [bc_commit],
    regex=ConventionalCommitsCz.bump_pattern,
    increments_map=ConventionalCommitsCz.bump_map,
)
assert result == "MAJOR", f"FAIL: expected MAJOR, got {result!r}"
print("OK: BREAKING CHANGE footer still triggers MAJOR")
EOF
```

## Additional Context

This fix was surfaced during the #1964 issue audit. The issue had been incorrectly closed in February 2026 after a maintainer misidentified the `fix:` line as a commit in the user's own repository; @Clockwork-Muse's follow-up comment and screenshot clarified that the line comes from Dependabot quoting an upstream changelog entry — it is not a commit in the user's repository at all. @namwoam was assigned in January 2026 and identified the correct code path (`commitizen/bump.py:37–38`, master) but proposed an author-filter approach; this PR takes the simpler route of anchoring the type match to the commit title only, which aligns with the Conventional Commits specification without introducing new configuration surface. @namwoam is welcome to take over if still active on this — please comment and this PR will be closed.