### PR TITLE
feat(customize): add required field for input questions

### DIFF
--- a/commitizen/cz/customize/customize.py
+++ b/commitizen/cz/customize/customize.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
 
     from jinja2 import Template
 
@@ -22,6 +22,13 @@ from commitizen.cz.base import BaseCommitizen
 from commitizen.exceptions import MissingCzCustomizeConfigError
 
 __all__ = ["CustomizeCommitsCz"]
+
+_REQUIRED_ANSWER_MSG = "This answer is required."
+
+
+def _required_validator(val: str) -> bool | str:
+    """Return True when *val* is non-blank, otherwise an error message."""
+    return True if val.strip() else _REQUIRED_ANSWER_MSG
 
 
 class CustomizeCommitsCz(BaseCommitizen):
@@ -50,7 +57,16 @@ class CustomizeCommitsCz(BaseCommitizen):
                 setattr(self, attr_name, value)
 
     def questions(self) -> list[CzQuestion]:
-        return self.custom_settings.get("questions", [{}])  # type: ignore[return-value]
+        raw_questions: Iterable[CzQuestion] = self.custom_settings.get(
+            "questions", [{}]
+        )  # type: ignore[assignment]
+        result: list[CzQuestion] = []
+        for raw in raw_questions:
+            q: dict[str, Any] = dict(raw)
+            if q.get("type") == "input" and q.pop("required", False):
+                q["validate"] = _required_validator
+            result.append(q)  # type: ignore[arg-type]
+        return result
 
     def message(self, answers: Mapping[str, Any]) -> str:
         message_template = Template(self.custom_settings.get("message_template", ""))

--- a/commitizen/question.py
+++ b/commitizen/question.py
@@ -21,6 +21,8 @@ class InputQuestion(TypedDict, total=False):
     name: str
     message: str
     filter: Callable[[str], str]
+    validate: Callable[[str], bool | str]
+    required: bool
 
 
 class ConfirmQuestion(TypedDict):

--- a/docs/customization/config_file.md
+++ b/docs/customization/config_file.md
@@ -45,6 +45,7 @@ Example:
     type = "input"
     name = "message"
     message = "Body."
+    required = true
 
     [[tool.commitizen.customize.questions]]
     type = "confirm"
@@ -181,6 +182,7 @@ Example:
 | `default`   | `Any`  | `None`  | (OPTIONAL) The default value for this question.                                                                                                                                                 |
 | `filter`    | `str`  | `None`  | (OPTIONAL) Validator for user's answer. **(Work in Progress)**                                                                                                                                  |
 | `multiline` | `bool` | `False` | (OPTIONAL) Enable multiline support when `type = input`.                                                                                                                                        |
+| `required`  | `bool` | `False` | (OPTIONAL) When `true` and `type = input`, the user cannot submit an empty answer. An error message ("This answer is required.") is displayed until a non-blank value is entered.               |
 | `use_search_filter` | `bool` | `False` | (OPTIONAL) Enable search/filter functionality for list/select type questions. This allows users to type and filter through the choices.                                                  |
 | `use_jk_keys` | `bool` | `True` | (OPTIONAL) Enable/disable j/k keys for navigation in list/select type questions. Set to false if you prefer arrow keys only.                                                                    |
 

--- a/tests/test_cz_customize.py
+++ b/tests/test_cz_customize.py
@@ -609,3 +609,105 @@ def test_change_type_map(config):
 def test_change_type_map_unicode(config_with_unicode):
     cz = CustomizeCommitsCz(config_with_unicode)
     assert cz.change_type_map == {"✨ feature": "Feat", "🐛 bug fix": "Fix"}
+
+
+# ---------------------------------------------------------------------------
+# Tests for `required` field on input questions
+# ---------------------------------------------------------------------------
+
+TOML_WITH_REQUIRED = r"""
+    [tool.commitizen.customize]
+    message_template = "{{message}}"
+
+    [[tool.commitizen.customize.questions]]
+    type = "input"
+    name = "message"
+    message = "Body."
+    required = true
+
+    [[tool.commitizen.customize.questions]]
+    type = "input"
+    name = "optional_note"
+    message = "Optional note."
+"""
+
+TOML_WITHOUT_REQUIRED = r"""
+    [tool.commitizen.customize]
+    message_template = "{{message}}"
+
+    [[tool.commitizen.customize.questions]]
+    type = "input"
+    name = "message"
+    message = "Body."
+"""
+
+
+def test_required_question_has_validate_callable():
+    """A question with required=true should expose a validate callable."""
+    config = TomlConfig(data=TOML_WITH_REQUIRED, path=Path("not_exist.toml"))
+    cz = CustomizeCommitsCz(config)
+    questions = cz.questions()
+
+    required_q = questions[0]
+    assert "validate" in required_q
+    assert callable(required_q["validate"])
+
+
+def test_required_field_is_removed_from_question_dict():
+    """The `required` key must not be forwarded to questionary."""
+    config = TomlConfig(data=TOML_WITH_REQUIRED, path=Path("not_exist.toml"))
+    cz = CustomizeCommitsCz(config)
+    for q in cz.questions():
+        assert "required" not in q
+
+
+def test_required_validator_rejects_empty_input():
+    """Validator must reject empty and whitespace-only strings."""
+    config = TomlConfig(data=TOML_WITH_REQUIRED, path=Path("not_exist.toml"))
+    cz = CustomizeCommitsCz(config)
+    validate = cz.questions()[0]["validate"]
+
+    assert validate("") is not True
+    assert validate("   ") is not True
+    assert isinstance(validate(""), str)  # error message
+
+
+def test_required_validator_accepts_nonempty_input():
+    """Validator must accept any non-whitespace-only input."""
+    config = TomlConfig(data=TOML_WITH_REQUIRED, path=Path("not_exist.toml"))
+    cz = CustomizeCommitsCz(config)
+    validate = cz.questions()[0]["validate"]
+
+    assert validate("hello") is True
+    assert validate("  hi  ") is True
+
+
+def test_optional_question_has_no_validate():
+    """Questions without required=true must not get a validate callable."""
+    config = TomlConfig(data=TOML_WITHOUT_REQUIRED, path=Path("not_exist.toml"))
+    cz = CustomizeCommitsCz(config)
+    assert "validate" not in cz.questions()[0]
+
+
+def test_optional_question_in_mixed_config():
+    """Only questions with required=true receive a validator; others are unaffected."""
+    config = TomlConfig(data=TOML_WITH_REQUIRED, path=Path("not_exist.toml"))
+    cz = CustomizeCommitsCz(config)
+    questions = cz.questions()
+
+    required_q = questions[0]
+    optional_q = questions[1]
+
+    assert "validate" in required_q
+    assert "validate" not in optional_q
+
+
+def test_required_does_not_mutate_config_settings():
+    """Processing questions must not mutate the underlying config data."""
+    config = TomlConfig(data=TOML_WITH_REQUIRED, path=Path("not_exist.toml"))
+    cz = CustomizeCommitsCz(config)
+    # Call questions() twice; the second call must still work correctly.
+    cz.questions()
+    questions = cz.questions()
+    assert "required" not in questions[0]
+    assert "validate" in questions[0]


### PR DESCRIPTION
## Description

Closes #1231.

Adds a `required` field to `cz_customize` input questions so users can enforce non-empty answers without writing a custom Python validator.

### Why

Users who configure commit rules entirely through `pyproject.toml` / `.cz.json` / `.cz.yaml` have no way to mark a free-text question as mandatory. They must either accept empty answers silently or write a Python class just to add a one-line validator. This PR provides a zero-code path for the common case.

### What changed

| File | Change |
|---|---|
| `commitizen/question.py` | Added `validate` and `required` optional fields to `InputQuestion` TypedDict |
| `commitizen/cz/customize/customize.py` | `questions()` now shallow-copies each question dict; if `type == "input"` and `required=True`, pops `required` and injects a `validate` callable that rejects blank input |
| `docs/customization/config_file.md` | Added `required` row to the questions field table; added `required = true` to the TOML example |
| `tests/test_cz_customize.py` | Seven new unit tests covering the required validator behaviour |

### How it works

When `questions()` processes each question from the config:

1. A shallow copy of the question dict is made (avoids mutating the parsed config on repeated calls).
2. If the question has `type = "input"` and `required = true`, the `required` key is popped and replaced with `validate = _required_validator`.
3. `_required_validator` returns `True` for non-blank strings and `"This answer is required."` for empty/whitespace-only input — the exact signature questionary expects.
4. All other question types (`list`, `confirm`) pass through unchanged; `required` is meaningless there since both always return a value.

### Backward compatibility

Fully backward-compatible. The `required` key defaults to `False` (absent), so existing configs are unaffected. No CLI flags, exit codes, or public APIs changed.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot CLI)

<!-- Generated-by: GitHub Copilot CLI following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions) -->

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [x] Update the documentation for the changes

## Expected Behavior

| Scenario | Before | After |
|---|---|---|
| `required = true` on an input question | `KeyError` / unknown key passed to questionary | `validate` callable injected; empty input is rejected with `"This answer is required."` |
| `required` absent / `false` | question passes through as-is | question passes through as-is (no change) |
| `list` or `confirm` question with no `required` key | unchanged | unchanged |
| calling `questions()` twice on the same config | N/A | second call still works correctly (no mutation) |

## Steps to Test This Pull Request

```toml
# pyproject.toml
[tool.commitizen]
name = "cz_customize"

[tool.commitizen.customize]
message_template = "{{change_type}}: {{message}}"

[[tool.commitizen.customize.questions]]
type = "list"
name = "change_type"
message = "Type"
choices = [{value = "feat", name = "feat"}, {value = "fix", name = "fix"}]

[[tool.commitizen.customize.questions]]
type = "input"
name = "message"
message = "Describe the change (required):"
required = true

[[tool.commitizen.customize.questions]]
type = "input"
name = "note"
message = "Optional note:"
```

```sh
# 1. Reproduce original problem (empty answer silently accepted)
git checkout v4.15.1
cz commit  # pick a type, press Enter on empty message -> commit succeeds

# 2. Verify fix
git checkout feat/1231-customize-question-required
cz commit  # pick a type, press Enter on empty message -> "This answer is required." shown
           # type something -> commit proceeds normally
```

## Additional Context

Related issue: #1231
