### PR TITLE
feat: add cz dump-config command to output effective configuration

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -198,6 +198,20 @@ data = {
                 "func": commands.Schema,
             },
             {
+                "name": "dump-config",
+                "description": "Output the current commitizen configuration",
+                "help": "Output the current commitizen configuration.",
+                "func": commands.DumpConfig,
+                "arguments": [
+                    {
+                        "name": ["--format", "-f"],
+                        "choices": ["toml", "yaml", "json"],
+                        "default": "toml",
+                        "help": "Output format (default: toml).",
+                    }
+                ],
+            },
+            {
                 "name": "bump",
                 "description": "Bump semantic version based on the git log",
                 "help": "Bump semantic version based on the git log.",
@@ -660,6 +674,7 @@ if TYPE_CHECKING:
             | commands.Example  # example
             | commands.Info  # info
             | commands.Schema  # schema
+            | commands.DumpConfig  # dump-config
             | commands.Bump  # bump
             | commands.Changelog  # changelog (ch)
             | commands.Check  # check

--- a/commitizen/commands/__init__.py
+++ b/commitizen/commands/__init__.py
@@ -2,6 +2,7 @@ from .bump import Bump
 from .changelog import Changelog
 from .check import Check
 from .commit import Commit
+from .dump_config import DumpConfig
 from .example import Example
 from .info import Info
 from .init import Init
@@ -14,6 +15,7 @@ __all__ = (
     "Changelog",
     "Check",
     "Commit",
+    "DumpConfig",
     "Example",
     "Info",
     "Init",

--- a/commitizen/commands/dump_config.py
+++ b/commitizen/commands/dump_config.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+import tomlkit
+import yaml
+
+from commitizen import out
+
+if TYPE_CHECKING:
+    from commitizen.config import BaseConfig
+
+
+class DumpConfig:
+    """Output the current commitizen configuration."""
+
+    def __init__(self, config: BaseConfig, arguments: dict[str, Any]) -> None:
+        self.config: BaseConfig = config
+        self.format: str = arguments.get("format", "toml")
+
+    def __call__(self) -> None:
+        settings = dict(self.config.settings)
+
+        if self.format == "toml":
+            filtered = _filter_none_values(settings)
+            doc = tomlkit.document()
+            tool_table = tomlkit.table()
+            cz_table = tomlkit.table()
+            for key, value in filtered.items():
+                cz_table.add(key, value)
+            tool_table.add("commitizen", cz_table)
+            doc.add("tool", tool_table)
+            out.write(tomlkit.dumps(doc))
+        elif self.format == "yaml":
+            out.write(
+                yaml.safe_dump(
+                    {"tool": {"commitizen": settings}},
+                    default_flow_style=False,
+                    allow_unicode=True,
+                )
+            )
+        else:
+            out.write(
+                json.dumps({"tool": {"commitizen": settings}}, indent=2, default=str)
+            )
+
+
+def _filter_none_values(settings: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: _filter_none_values(value) if isinstance(value, Mapping) else value
+        for key, value in settings.items()
+        if value is not None
+    }

--- a/docs/commands/dump_config.md
+++ b/docs/commands/dump_config.md
@@ -1,0 +1,41 @@
+# dump-config
+
+Output the current commitizen configuration (defaults merged with any project overrides) so you can paste it directly into a configuration file as a starting point.
+
+## Usage
+
+```
+cz dump-config [--format {toml,yaml,json}]
+```
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--format`, `-f` | Output format: `toml` (default), `yaml`, or `json` |
+
+## Examples
+
+Dump the current configuration as TOML (default):
+
+```bash
+cz dump-config
+```
+
+Dump as YAML:
+
+```bash
+cz dump-config --format yaml
+```
+
+Dump as JSON:
+
+```bash
+cz dump-config --format json
+```
+
+Use the TOML output as a starting point for `pyproject.toml`:
+
+```bash
+cz dump-config >> pyproject.toml
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
     - info: "commands/info.md"
     - ls: "commands/ls.md"
     - schema: "commands/schema.md"
+    - dump-config: "commands/dump_config.md"
     - version: "commands/version.md"
   - Configuration:
     - Configuration File: "config/configuration_file.md"
@@ -137,6 +138,7 @@ plugins:
           - commands/info.md: Show information about the active configuration.
           - commands/ls.md: List supported commit message choices for the active rules.
           - commands/schema.md: Show the commit message schema for the active convention.
+          - commands/dump_config.md: Output the current commitizen configuration.
           - commands/version.md: Show the installed or project version.
         Configuration:
           - config/configuration_file.md: Where configuration can live and how it is loaded.

--- a/tests/commands/test_common_command.py
+++ b/tests/commands/test_common_command.py
@@ -12,6 +12,7 @@ from tests.utils import UtilFixture
         "changelog",
         "check",
         "commit",
+        "dump-config",
         "example",
         "info",
         "init",

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_10_dump_config_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_10_dump_config_.txt
@@ -1,0 +1,8 @@
+usage: cz dump-config [-h] [--format {toml,yaml,json}]
+
+Output the current commitizen configuration
+
+options:
+  -h, --help            show this help message and exit
+  --format, -f {toml,yaml,json}
+                        Output format (default: toml).

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_11_dump_config_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_11_dump_config_.txt
@@ -1,0 +1,8 @@
+usage: cz dump-config [-h] [--format {toml,yaml,json}]
+
+Output the current commitizen configuration
+
+options:
+  -h, --help            show this help message and exit
+  --format, -f {toml,yaml,json}
+                        Output format (default: toml).

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_12_dump_config_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_12_dump_config_.txt
@@ -1,0 +1,8 @@
+usage: cz dump-config [-h] [--format {toml,yaml,json}]
+
+Output the current commitizen configuration
+
+options:
+  -h, --help            show this help message and exit
+  --format, -f {toml,yaml,json}
+                        Output format (default: toml).

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_13_dump_config_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_13_dump_config_.txt
@@ -1,0 +1,8 @@
+usage: cz dump-config [-h] [--format {toml,yaml,json}]
+
+Output the current commitizen configuration
+
+options:
+  -h, --help            show this help message and exit
+  --format, -f {toml,yaml,json}
+                        Output format (default: toml).

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_14_dump_config_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_14_dump_config_.txt
@@ -1,0 +1,8 @@
+usage: cz dump-config [-h] [--format {toml,yaml,json}]
+
+Output the current commitizen configuration
+
+options:
+  -h, --help            show this help message and exit
+  --format, -f {toml,yaml,json}
+                        Output format (default: toml).

--- a/tests/commands/test_dump_config_command.py
+++ b/tests/commands/test_dump_config_command.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import tomlkit
+import yaml
+
+from commitizen.commands.dump_config import DumpConfig
+from commitizen.config import BaseConfig
+
+
+@pytest.fixture
+def config() -> BaseConfig:
+    cfg = BaseConfig()
+    return cfg
+
+
+def test_dump_config_toml(config, capsys):
+    DumpConfig(config, {"format": "toml"})()
+    out, _ = capsys.readouterr()
+    doc = tomlkit.loads(out)
+    assert "tool" in doc
+    assert "commitizen" in doc["tool"]
+    cz = doc["tool"]["commitizen"]
+    assert cz["name"] == "cz_conventional_commits"
+
+
+def test_dump_config_yaml(config, capsys):
+    DumpConfig(config, {"format": "yaml"})()
+    out, _ = capsys.readouterr()
+    data = yaml.safe_load(out)
+    assert "tool" in data
+    assert "commitizen" in data["tool"]
+    assert data["tool"]["commitizen"]["name"] == "cz_conventional_commits"
+
+
+def test_dump_config_json(config, capsys):
+    DumpConfig(config, {"format": "json"})()
+    out, _ = capsys.readouterr()
+    data = json.loads(out)
+    assert "tool" in data
+    assert "commitizen" in data["tool"]
+    assert data["tool"]["commitizen"]["name"] == "cz_conventional_commits"
+
+
+def test_dump_config_toml_default_format(config, capsys):
+    """Test that toml is the default format."""
+    DumpConfig(config, {})()
+    out, _ = capsys.readouterr()
+    doc = tomlkit.loads(out)
+    assert "tool" in doc
+
+
+def test_dump_config_toml_no_none_values(config, capsys):
+    """Test that None values are filtered out in TOML output."""
+    DumpConfig(config, {"format": "toml"})()
+    out, _ = capsys.readouterr()
+    assert "null" not in out.lower()
+    doc = tomlkit.loads(out)
+    cz = doc["tool"]["commitizen"]
+    for value in cz.values():
+        assert value is not None


### PR DESCRIPTION
## Description

Adds a new `cz dump-config` command that prints the **effective** Commitizen configuration (defaults merged with any project overrides) in TOML, YAML, or JSON format. Users can paste the output directly into a configuration file as a starting template and tweak from there — which is exactly the use-case raised in #1331.

### Why

Users working with monorepos or custom commit conventions (like the reporter in #1331) struggle because overriding a single setting (e.g. `customize.questions`) replaces the entire default. There was no way to see the full effective config without reading source code. `cz dump-config` solves this by exposing the merged settings.

### What changed

| Area | Change |
|---|---|
| `commitizen/commands/dump_config.py` | New `DumpConfig` command class |
| `commitizen/commands/__init__.py` | Export `DumpConfig` |
| `commitizen/cli.py` | Register `dump-config` subparser with `--format` argument |
| `tests/commands/test_dump_config_command.py` | New tests for all three formats |
| `tests/commands/test_common_command.py` | Add `dump-config` to help-snapshot parametrize list |
| `tests/commands/test_common_command/` | Help snapshot files for py 3.10–3.14 |
| `docs/commands/dump_config.md` | Command documentation |
| `mkdocs.yml` | Add `dump-config` to nav |

### How it works

1. `DumpConfig.__call__()` reads `config.settings` (a `Settings` TypedDict containing defaults merged with user config).
2. For **TOML** (default): `None` values are filtered out (TOML cannot represent `null`), then the dict is wrapped in a `[tool.commitizen]` section and serialised with `tomlkit.dumps()`.
3. For **YAML**: the dict (with `None` values preserved as `null`) is wrapped in `tool.commitizen` and serialised with `yaml.safe_dump()`.
4. For **JSON**: same wrapping, serialised with `json.dumps(indent=2)`.

All three formats mirror the input structure so the output can be pasted directly into `pyproject.toml`, `.cz.yaml`, or `.cz.json`.

### Backward compatibility

Purely additive — new subcommand only. No existing commands, APIs, or config keys changed.

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [X] Add test cases to all the changes you introduce
- [X] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [X] Manually test the changes:
  - [X] Verify the feature/bug fix works as expected in real-world scenarios
  - [X] Test edge cases and error conditions
  - [X] Ensure backward compatibility is maintained
  - [X] Document any manual testing steps performed
- [X] Update the documentation for the changes

### Documentation Changes

- [X] Added `docs/commands/dump_config.md`
- [X] Updated `mkdocs.yml` nav

## Expected Behavior

| Command | Expected output |
|---|---|
| `cz dump-config` | TOML block under `[tool.commitizen]` with effective settings (no `null` values) |
| `cz dump-config --format yaml` | YAML block under `tool.commitizen` with effective settings |
| `cz dump-config --format json` | JSON object `{"tool": {"commitizen": {...}}}` |

## Steps to Test This Pull Request

```bash
# 1. Install the branch
git checkout feat/1331-dump-config-command

# 2. Dump default config as TOML
cz dump-config
# Expected: [tool.commitizen] block with name = "cz_conventional_commits" etc.

# 3. Dump as YAML
cz dump-config --format yaml
# Expected: tool:\n  commitizen:\n    name: cz_conventional_commits ...

# 4. Dump as JSON
cz dump-config --format json
# Expected: {"tool": {"commitizen": {"name": "cz_conventional_commits", ...}}}

# 5. Verify no null values in TOML output
cz dump-config | grep -i null
# Expected: no output (null values are filtered)

# 6. Round-trip test: dump → paste → compare
cz dump-config > /tmp/dumped.toml
# Verify the file is valid TOML: python -c "import tomlkit; tomlkit.loads(open('/tmp/dumped.toml').read())"
```

## Additional Context

Closes #1331.

The maintainer suggested this could be layered on top of `cz init` (#1331 comment), but a standalone `cz dump-config` is cleaner and more composable (pipe to a file, diff against a known config, etc.).
