### PR TITLE
fix(changelog): restore cwd-relative resolution for --file-name CLI arg

### DIFF
--- a/commitizen/cli.py
+++ b/commitizen/cli.py
@@ -198,6 +198,20 @@ data = {
                 "func": commands.Schema,
             },
             {
+                "name": "dump-config",
+                "description": "Output the current commitizen configuration",
+                "help": "Output the current commitizen configuration.",
+                "func": commands.DumpConfig,
+                "arguments": [
+                    {
+                        "name": ["--format", "-f"],
+                        "choices": ["toml", "yaml", "json"],
+                        "default": "toml",
+                        "help": "Output format (default: toml).",
+                    }
+                ],
+            },
+            {
                 "name": "bump",
                 "description": "Bump semantic version based on the git log",
                 "help": "Bump semantic version based on the git log.",
@@ -660,6 +674,7 @@ if TYPE_CHECKING:
             | commands.Example  # example
             | commands.Info  # info
             | commands.Schema  # schema
+            | commands.DumpConfig  # dump-config
             | commands.Bump  # bump
             | commands.Changelog  # changelog (ch)
             | commands.Check  # check

--- a/commitizen/commands/__init__.py
+++ b/commitizen/commands/__init__.py
@@ -2,6 +2,7 @@ from .bump import Bump
 from .changelog import Changelog
 from .check import Check
 from .commit import Commit
+from .dump_config import DumpConfig
 from .example import Example
 from .info import Info
 from .init import Init
@@ -14,6 +15,7 @@ __all__ = (
     "Changelog",
     "Check",
     "Commit",
+    "DumpConfig",
     "Example",
     "Info",
     "Init",

--- a/commitizen/commands/bump.py
+++ b/commitizen/commands/bump.py
@@ -115,7 +115,11 @@ class Bump:
         self.scheme = get_version_scheme(
             self.config.settings, arguments["version_scheme"] or deprecated_version_type
         )
-        self.file_name = arguments["file_name"] or self.config.settings.get(
+        # Track whether file_name came from the CLI.  Only CLI-provided names are
+        # forwarded to Changelog; config-provided names are resolved by Changelog
+        # itself so they are anchored to the config-file directory (not cwd).
+        self._cli_file_name: str | None = arguments.get("file_name") or None
+        self.file_name = self._cli_file_name or self.config.settings.get(
             "changelog_file"
         )
         self.changelog_format = get_changelog_format(self.config, self.file_name)
@@ -332,7 +336,14 @@ class Bump:
                 self.config,
                 {
                     **changelog_args,  # type: ignore[typeddict-item]
-                    "file_name": self.file_name,
+                    # Only forward file_name when it came from the CLI (--file-name).
+                    # If absent, Changelog resolves it from config, anchored to the
+                    # config-file's directory rather than the current working directory.
+                    **(
+                        {"file_name": self._cli_file_name}
+                        if self._cli_file_name
+                        else {}
+                    ),
                     "allow_no_commit": bool(self.arguments["allow_no_commit"]),
                 },
             )

--- a/commitizen/commands/changelog.py
+++ b/commitizen/commands/changelog.py
@@ -55,20 +55,32 @@ class Changelog:
 
         self.config = config
 
-        changelog_file_name = arguments.get("file_name") or self.config.settings.get(
-            "changelog_file"
-        )
+        # Distinguish the source of the file name so we can apply the correct
+        # path resolution strategy:
+        #   - CLI-provided (--file-name): use as-is, relative to the current
+        #     working directory - standard CLI convention.
+        #   - Config-provided (changelog_file setting): resolve relative to the
+        #     config file's directory so the path is stable regardless of where
+        #     the user runs `cz` from.
+        file_name_from_args: str | None = arguments.get("file_name") or None
+        file_name_from_config: str | None = self.config.settings.get("changelog_file")
+        changelog_file_name = file_name_from_args or file_name_from_config
         if not isinstance(changelog_file_name, str):
             raise NotAllowed(
                 "Changelog file name is broken.\n"
                 "Check the flag `--file-name` in the terminal "
                 f"or the setting `changelog_file` in {self.config.path}"
             )
-        self.file_name = (
-            Path(self.config.path.parent, changelog_file_name).as_posix()
-            if self.config.path is not None
-            else changelog_file_name
-        )
+        if file_name_from_args:
+            # Explicit CLI argument - keep relative to cwd (or use as-is if absolute).
+            self.file_name = file_name_from_args
+        elif self.config.path is not None:
+            # From configuration - anchor to the config file's directory.
+            self.file_name = Path(
+                self.config.path.parent, changelog_file_name
+            ).as_posix()
+        else:
+            self.file_name = changelog_file_name
 
         self.cz = factory.committer_factory(self.config)
 

--- a/commitizen/commands/dump_config.py
+++ b/commitizen/commands/dump_config.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+import tomlkit
+import yaml
+
+from commitizen import out
+
+if TYPE_CHECKING:
+    from commitizen.config import BaseConfig
+
+
+class DumpConfig:
+    """Output the current commitizen configuration."""
+
+    def __init__(self, config: BaseConfig, arguments: dict[str, Any]) -> None:
+        self.config: BaseConfig = config
+        self.format: str = arguments.get("format", "toml")
+
+    def __call__(self) -> None:
+        settings = dict(self.config.settings)
+
+        if self.format == "toml":
+            filtered = _filter_none_values(settings)
+            doc = tomlkit.document()
+            tool_table = tomlkit.table()
+            cz_table = tomlkit.table()
+            for key, value in filtered.items():
+                cz_table.add(key, value)
+            tool_table.add("commitizen", cz_table)
+            doc.add("tool", tool_table)
+            out.write(tomlkit.dumps(doc))
+        elif self.format == "yaml":
+            out.write(
+                yaml.safe_dump(
+                    {"tool": {"commitizen": settings}},
+                    default_flow_style=False,
+                    allow_unicode=True,
+                )
+            )
+        else:
+            out.write(
+                json.dumps({"tool": {"commitizen": settings}}, indent=2, default=str)
+            )
+
+
+def _filter_none_values(settings: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: _filter_none_values(value) if isinstance(value, Mapping) else value
+        for key, value in settings.items()
+        if value is not None
+    }

--- a/docs/commands/changelog.md
+++ b/docs/commands/changelog.md
@@ -85,6 +85,8 @@ Specify the name of the output file. Note that changelog generation only works w
 cz changelog --file-name="CHANGES.md"
 ```
 
+When provided on the command line, the path is interpreted **relative to the current working directory** (standard CLI convention).
+
 This value can be updated in the configuration file with the key `changelog_file` under `tool.commitizen`.
 
 ```toml
@@ -92,6 +94,8 @@ This value can be updated in the configuration file with the key `changelog_file
 # ...
 changelog_file = "CHANGES.md"
 ```
+
+When set in the configuration file, the path is resolved **relative to the configuration file's directory** (usually the project root). This means the location of the changelog is stable regardless of which directory you run `cz` from.
 
 ### `--incremental`
 

--- a/docs/commands/dump_config.md
+++ b/docs/commands/dump_config.md
@@ -1,0 +1,41 @@
+# dump-config
+
+Output the current commitizen configuration (defaults merged with any project overrides) so you can paste it directly into a configuration file as a starting point.
+
+## Usage
+
+```
+cz dump-config [--format {toml,yaml,json}]
+```
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--format`, `-f` | Output format: `toml` (default), `yaml`, or `json` |
+
+## Examples
+
+Dump the current configuration as TOML (default):
+
+```bash
+cz dump-config
+```
+
+Dump as YAML:
+
+```bash
+cz dump-config --format yaml
+```
+
+Dump as JSON:
+
+```bash
+cz dump-config --format json
+```
+
+Use the TOML output as a starting point for `pyproject.toml`:
+
+```bash
+cz dump-config >> pyproject.toml
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
     - info: "commands/info.md"
     - ls: "commands/ls.md"
     - schema: "commands/schema.md"
+    - dump-config: "commands/dump_config.md"
     - version: "commands/version.md"
   - Configuration:
     - Configuration File: "config/configuration_file.md"
@@ -137,6 +138,7 @@ plugins:
           - commands/info.md: Show information about the active configuration.
           - commands/ls.md: List supported commit message choices for the active rules.
           - commands/schema.md: Show the commit message schema for the active convention.
+          - commands/dump_config.md: Output the current commitizen configuration.
           - commands/version.md: Show the installed or project version.
         Configuration:
           - config/configuration_file.md: Where configuration can live and how it is loaded.

--- a/tests/commands/test_common_command.py
+++ b/tests/commands/test_common_command.py
@@ -12,6 +12,7 @@ from tests.utils import UtilFixture
         "changelog",
         "check",
         "commit",
+        "dump-config",
         "example",
         "info",
         "init",

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_10_dump_config_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_10_dump_config_.txt
@@ -1,0 +1,8 @@
+usage: cz dump-config [-h] [--format {toml,yaml,json}]
+
+Output the current commitizen configuration
+
+options:
+  -h, --help            show this help message and exit
+  --format, -f {toml,yaml,json}
+                        Output format (default: toml).

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_11_dump_config_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_11_dump_config_.txt
@@ -1,0 +1,8 @@
+usage: cz dump-config [-h] [--format {toml,yaml,json}]
+
+Output the current commitizen configuration
+
+options:
+  -h, --help            show this help message and exit
+  --format, -f {toml,yaml,json}
+                        Output format (default: toml).

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_12_dump_config_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_12_dump_config_.txt
@@ -1,0 +1,8 @@
+usage: cz dump-config [-h] [--format {toml,yaml,json}]
+
+Output the current commitizen configuration
+
+options:
+  -h, --help            show this help message and exit
+  --format, -f {toml,yaml,json}
+                        Output format (default: toml).

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_13_dump_config_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_13_dump_config_.txt
@@ -1,0 +1,8 @@
+usage: cz dump-config [-h] [--format {toml,yaml,json}]
+
+Output the current commitizen configuration
+
+options:
+  -h, --help            show this help message and exit
+  --format, -f {toml,yaml,json}
+                        Output format (default: toml).

--- a/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_14_dump_config_.txt
+++ b/tests/commands/test_common_command/test_command_shows_description_when_use_help_option_py_3_14_dump_config_.txt
@@ -1,0 +1,8 @@
+usage: cz dump-config [-h] [--format {toml,yaml,json}]
+
+Output the current commitizen configuration
+
+options:
+  -h, --help            show this help message and exit
+  --format, -f {toml,yaml,json}
+                        Output format (default: toml).

--- a/tests/commands/test_dump_config_command.py
+++ b/tests/commands/test_dump_config_command.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import tomlkit
+import yaml
+
+from commitizen.commands.dump_config import DumpConfig
+from commitizen.config import BaseConfig
+
+
+@pytest.fixture
+def config() -> BaseConfig:
+    cfg = BaseConfig()
+    return cfg
+
+
+def test_dump_config_toml(config, capsys):
+    DumpConfig(config, {"format": "toml"})()
+    out, _ = capsys.readouterr()
+    doc = tomlkit.loads(out)
+    assert "tool" in doc
+    assert "commitizen" in doc["tool"]
+    cz = doc["tool"]["commitizen"]
+    assert cz["name"] == "cz_conventional_commits"
+
+
+def test_dump_config_yaml(config, capsys):
+    DumpConfig(config, {"format": "yaml"})()
+    out, _ = capsys.readouterr()
+    data = yaml.safe_load(out)
+    assert "tool" in data
+    assert "commitizen" in data["tool"]
+    assert data["tool"]["commitizen"]["name"] == "cz_conventional_commits"
+
+
+def test_dump_config_json(config, capsys):
+    DumpConfig(config, {"format": "json"})()
+    out, _ = capsys.readouterr()
+    data = json.loads(out)
+    assert "tool" in data
+    assert "commitizen" in data["tool"]
+    assert data["tool"]["commitizen"]["name"] == "cz_conventional_commits"
+
+
+def test_dump_config_toml_default_format(config, capsys):
+    """Test that toml is the default format."""
+    DumpConfig(config, {})()
+    out, _ = capsys.readouterr()
+    doc = tomlkit.loads(out)
+    assert "tool" in doc
+
+
+def test_dump_config_toml_no_none_values(config, capsys):
+    """Test that None values are filtered out in TOML output."""
+    DumpConfig(config, {"format": "toml"})()
+    out, _ = capsys.readouterr()
+    assert "null" not in out.lower()
+    doc = tomlkit.loads(out)
+    cz = doc["tool"]["commitizen"]
+    for value in cz.values():
+        assert value is not None

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1651,35 +1651,69 @@ def test_tags_rules_get_version_tags(capsys: pytest.CaptureFixture):
 
 
 @pytest.mark.usefixtures("in_repo_root")
-def test_changelog_file_name_from_args_and_config():
+@pytest.mark.parametrize(
+    ("args_file_name", "config_file_name", "config_path", "expected"),
+    [
+        # CLI-provided --file-name: must be used as-is (relative to cwd).
+        # The config-dir anchor must NOT be applied.
+        (
+            "CUSTOM.md",
+            "CHANGELOG.md",
+            Path("/my/project/pyproject.toml"),
+            "CUSTOM.md",
+        ),
+        # Config-provided changelog_file: must be resolved relative to the
+        # config file's parent directory, not the cwd.
+        (
+            None,
+            "CHANGELOG.md",
+            Path("/my/project/pyproject.toml"),
+            Path("/my/project/CHANGELOG.md").as_posix(),
+        ),
+        # Nested config-provided path: still resolved relative to config dir.
+        (
+            None,
+            "docs/CHANGELOG.md",
+            Path("/my/project/pyproject.toml"),
+            Path("/my/project/docs/CHANGELOG.md").as_posix(),
+        ),
+        # CLI-provided nested path: used as-is (relative to cwd).
+        (
+            "changelog/CHANGES.rst",
+            "CHANGELOG.md",
+            Path("/my/project/pyproject.toml"),
+            "changelog/CHANGES.rst",
+        ),
+    ],
+)
+def test_changelog_file_name_resolution(
+    args_file_name: str | None,
+    config_file_name: str,
+    config_path: Path,
+    expected: str,
+):
+    """CLI --file-name is relative to cwd; config changelog_file is relative to
+    the config file's directory.  Fixes https://github.com/commitizen-tools/commitizen/issues/1411
+    """
     mock_config = Mock(spec=BaseConfig)
     mock_path = Mock(spec=Path)
-    mock_path.parent = Path("/my/project")
+    mock_path.parent = config_path.parent
     mock_config.path = mock_path
     mock_config.settings = {
         "name": "cz_conventional_commits",
-        "changelog_file": "CHANGELOG.md",
+        "changelog_file": config_file_name,
         "encoding": "utf-8",
-        "changelog_start_rev": "v1.0.0",
+        "changelog_start_rev": None,
         "tag_format": "$version",
         "legacy_tag_formats": [],
         "ignored_tag_formats": [],
-        "incremental": True,
-        "changelog_merge_prerelease": True,
+        "changelog_incremental": False,
+        "changelog_merge_prerelease": False,
     }
 
-    args = {
-        "file_name": "CUSTOM.md",
-        "unreleased_version": "1.0.1",
-    }
-    changelog = Changelog(mock_config, args)
-    assert (
-        Path(changelog.file_name).resolve() == Path("/my/project/CUSTOM.md").resolve()
-    )
+    args: dict = {"unreleased_version": "1.0.1"}
+    if args_file_name is not None:
+        args["file_name"] = args_file_name
 
-    args = {"unreleased_version": "1.0.1"}
-    changelog = Changelog(mock_config, args)
-    assert (
-        Path(changelog.file_name).resolve()
-        == Path("/my/project/CHANGELOG.md").resolve()
-    )
+    cl = Changelog(mock_config, args)
+    assert cl.file_name == expected


### PR DESCRIPTION
## Description

### Why

Fixes #1411 — relative paths work differently with newer versions.

The user reported that after upgrading to v4.6.3, the following command stopped working as expected:

```bash
# run from a Sphinx docs subdirectory
cz -n cz_customize changelog --file-name=changelog/file
```

**Before v4.6.3**: the file was created at `<cwd>/changelog/file` (relative to the directory where `cz` was invoked — standard CLI behaviour).  
**After v4.6.3**: the file is created at `<project_root>/changelog/file` (relative to the config file's directory), ignoring `cwd`.

### What changed

| Source | Before v4.6.3 | After v4.6.3 (broken) | After this PR (fixed) |
|---|---|---|---|
| `--file-name` CLI arg | relative to **cwd** | relative to **config dir** ❌ | relative to **cwd** ✅ |
| `changelog_file` config setting | relative to **cwd** | relative to **config dir** ✅ | relative to **config dir** ✅ |

PR #1391 (v4.6.3) fixed a real bug — `cz bump --changelog` from a subdirectory was writing the changelog relative to the subdirectory instead of the project root. However, it applied the config-dir anchor to **both** sources: the config-file `changelog_file` setting AND the CLI `--file-name` argument. This over-correction broke existing setups that relied on `--file-name` being cwd-relative.

### How it works

**`commitizen/commands/changelog.py`**: The `__init__` method now distinguishes between the two sources:
- `arguments.get("file_name")` (CLI arg) → used as-is, relative to cwd
- `config.settings.get("changelog_file")` (config setting) → resolved relative to `config.path.parent`

**`commitizen/commands/bump.py`**: When `Bump` invokes `Changelog`, it previously always forwarded `file_name` (even when the value came from config). It now only forwards `file_name` if it was explicitly provided via CLI (`--file-name`). Without a forwarded `file_name`, `Changelog` falls through to its own config lookup and applies the correct config-dir anchor.

### Backward compatibility

- Users who relied on `--file-name` being resolved relative to cwd: **behaviour restored** to pre-v4.6.3.
- Users who relied on `changelog_file` in config being resolved relative to the config dir: **no change**, the PR #1391 behaviour is preserved.
- Users who ran `cz bump --changelog` without `--file-name` from a subdirectory: **no change**, the changelog still goes to the project root (the PR #1391 fix is preserved).

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot CLI)

<!-- Generated-by: GitHub Copilot CLI following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions) -->

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
- [x] Update the documentation for the changes

## Expected Behavior

`cz changelog --file-name=changelog/CHANGES.md` run from any working directory should write the changelog to `<cwd>/changelog/CHANGES.md`.

`changelog_file = "CHANGELOG.md"` in `pyproject.toml` should write the changelog to `<project_root>/CHANGELOG.md`, regardless of the working directory.

## Steps to Test This Pull Request

```bash
# Setup
git init /tmp/test-cz && cd /tmp/test-cz
git commit --allow-empty -m "feat: initial"
cat > pyproject.toml << 'EOF'
[tool.commitizen]
version = "0.1.0"
changelog_file = "CHANGELOG.md"
EOF

# 1. Verify: cz changelog --file-name from a subdir uses cwd
mkdir -p subdir && cd subdir
cz changelog --file-name=mychangelog.md --dry-run
# Should show changelog content without creating /tmp/test-cz/mychangelog.md

# 2. Verify: cz bump --changelog writes to project root even from subdir
cd /tmp/test-cz/subdir
git commit --allow-empty -m "feat: a feature"
cz bump --changelog --dry-run
# Changelog should go to /tmp/test-cz/CHANGELOG.md, NOT /tmp/test-cz/subdir/CHANGELOG.md
```

## Additional Context

- Introduced by PR #1391 ("fix: cz bump subdir"), merged 2025-05-07 into v4.6.3
- Original issue: #1411