### PR TITLE
test(coverage): omit pure typing module commitizen/question.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,7 @@ omit = [
     '*/virtualenv/*',
     '*/virtualenvs/*',
     '*/tests/*',
+    'commitizen/question.py',
 ]
 
 


### PR DESCRIPTION
## Description

Excludes `commitizen/question.py` from coverage reporting by adding it to the `[tool.coverage.report].omit` list in `pyproject.toml`.

`commitizen/question.py` defines TypedDicts (`Choice`, `ListQuestion`, `InputQuestion`, `ConfirmQuestion`), `Literal` discriminators, and the `CzQuestion` union — pure static-typing constructs with no runtime code paths to exercise. Coverage therefore reports the file as `0%`, which is misleading: the lines do not represent untested logic, they represent type definitions whose only consumers are type checkers.

### How
- Add `''commitizen/question.py''` to the `omit` list under `[tool.coverage.report]` in `pyproject.toml`.

### Why
- Removes a misleading `0%` coverage row for a file that has no runtime behavior to test.
- Aligns the coverage report with the file''s actual purpose (typing-only).
- Discussed in #1904 and agreed there.

### What
- One-line addition to `pyproject.toml`. No source/test code changes.

### Verification
- Ran `uv run poe cover` locally; `commitizen/question.py` no longer appears in the coverage report. `TOTAL` coverage rises from the previous baseline accordingly (now `99%`).
- Ran `uv run poe lint` — `ruff check` and `mypy` both pass.
- Ran `uv run poe format` — no files changed.

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI (Claude Opus 4.7) following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [X] Add test cases to all the changes you introduce — N/A (configuration-only change to coverage tool)
- [X] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [X] Manually test the changes:
  - [X] Verify the feature/bug fix works as expected in real-world scenarios — confirmed `question.py` is no longer reported by `uv run poe cover`
  - [X] Test edge cases and error conditions — N/A
  - [X] Ensure backward compatibility is maintained — coverage tool config only; no runtime impact
  - [X] Document any manual testing steps performed — see *Steps to Test* below
- [X] Update the documentation for the changes — N/A (no user-facing behavior change)

### Documentation Changes

N/A.

## Expected Behavior

After this change, `uv run poe cover` no longer lists `commitizen/question.py` as `0%` covered, because it is excluded from the coverage report along with the other entries in the `omit` list.

## Steps to Test This Pull Request

1. `uv sync --frozen --group base --group test --group linters`
2. `uv run poe cover`
3. Confirm that `commitizen/question.py` does **not** appear in the coverage report (previously it appeared as `7 7 0%`).

## Additional Context

Closes #1904.
