### PR TITLE
fix(check): expand env vars in rev_range arg

### DIFF
--- a/commitizen/commands/check.py
+++ b/commitizen/commands/check.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 import sys
 from pathlib import Path
@@ -41,6 +42,8 @@ class Check:
         self.commit_msg_file = arguments.get("commit_msg_file")
         self.commit_msg = arguments.get("message")
         self.rev_range = arguments.get("rev_range")
+        if self.rev_range is not None:
+            self.rev_range = os.path.expandvars(self.rev_range)
         self.allow_abort = bool(
             arguments.get("allow_abort", config.settings["allow_abort"])
         )

--- a/tests/commands/test_check_command.py
+++ b/tests/commands/test_check_command.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from io import StringIO
 from typing import TYPE_CHECKING, Any
 
@@ -448,3 +449,25 @@ def test_check_command_with_custom_validator_failed(
         util.run_cli(
             "--name", "cz_custom_validator", "check", "--commit-msg-file", "some_file"
         )
+
+
+@pytest.mark.parametrize(
+    ("rev_range", "expected"),
+    [
+        ("HEAD~5..HEAD", "HEAD~5..HEAD"),
+        ("$PRE_COMMIT_FROM_REF..$PRE_COMMIT_TO_REF", "v1.0.0..v1.1.0"),
+        ("${PRE_COMMIT_FROM_REF}..${PRE_COMMIT_TO_REF}", "v1.0.0..v1.1.0"),
+    ],
+)
+def test_check_command_expands_env_vars_in_rev_range(
+    config, mocker: MockFixture, rev_range: str, expected: str
+):
+    git_get_commits = mocker.patch(
+        "commitizen.git.get_commits", return_value=_build_fake_git_commits(COMMIT_LOG)
+    )
+    mocker.patch.dict(
+        os.environ,
+        {"PRE_COMMIT_FROM_REF": "v1.0.0", "PRE_COMMIT_TO_REF": "v1.1.0"},
+    )
+    commands.Check(config=config, arguments={"rev_range": rev_range})()
+    git_get_commits.assert_called_once_with(None, expected)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->


## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)
-->

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes
<!-- You can skip this section if you are not making any documentation changes -->


- [ ] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external)

<!--
When running `uv run poe doc`, any broken internal documentation links will be reported in the console output like this:

```text
INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
```
-->

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->
The `commitizen-branch` pre-push hook should successfully validate commit messages
using the ref range provided by pre-commit via the `PRE_COMMIT_FROM_REF` and
`PRE_COMMIT_TO_REF` environment variables.

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->
1. Add the following to your `.pre-commit-config.yaml`:
```yaml
   repos:
     - repo: https://github.com/commitizen-tools/commitizen
       rev: master
       hooks:
         - id: commitizen
           stages: [commit-msg]
         - id: commitizen-branch
           stages: [pre-push]
```
2. Install the pre-commit hooks:
   `pre-commit install --hook-type pre-commit --hook-type commit-msg --hook-type pre-push`
3. Make a commit with a valid conventional commit message:
   `git commit -m "feat: my new feature"`
4. Run `git push` — the `commitizen-branch` hook should pass instead of failing with:
   `fatal: ambiguous argument '$PRE_COMMIT_FROM_REF..$PRE_COMMIT_TO_REF': unknown revision or path not in the working tree`

**Environment used for testing:**
- Python 3.14.3
- commitizen 4.15.1
- pre-commit 4.6.0

## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->
The root cause is that pre-commit passes `args` directly to the process as a list
without shell interpolation, so `$PRE_COMMIT_FROM_REF..$PRE_COMMIT_TO_REF` arrives
as a literal string to `cz check` rather than being expanded to actual git SHAs.
Pre-commit does set these as environment variables in the hook process, so
`os.path.expandvars()` correctly resolves them at runtime.

Closes #1923
Closes #1912
Related to #704