### PR TITLE
test: normalize argparse choice snapshots

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import sys
 import types
@@ -17,6 +18,29 @@ from commitizen.exceptions import (
 )
 from tests.utils import UtilFixture
 
+ARGPARSE_CHOICES_PATTERN = re.compile(r"\(choose from (?P<choices>[^)]*)\)")
+ARGPARSE_QUOTED_CHOICE_PATTERN = re.compile(r"'([^']*)'")
+
+
+def normalize_argparse_choice_quotes(text: str) -> str:
+    def normalize_match(match: re.Match[str]) -> str:
+        choices = ARGPARSE_QUOTED_CHOICE_PATTERN.sub(r"\1", match.group("choices"))
+        return f"(choose from {choices})"
+
+    return ARGPARSE_CHOICES_PATTERN.sub(normalize_match, text)
+
+
+def test_normalize_argparse_choice_quotes():
+    text = (
+        "cz: error: argument {init,commit}: invalid choice: 'invalidCommand' "
+        "(choose from 'init', 'commit')"
+    )
+
+    assert normalize_argparse_choice_quotes(text) == (
+        "cz: error: argument {init,commit}: invalid choice: 'invalidCommand' "
+        "(choose from init, commit)"
+    )
+
 
 @pytest.mark.usefixtures("python_version", "consistent_terminal_output")
 def test_no_argv(util: UtilFixture, capsys, file_regression):
@@ -29,29 +53,7 @@ def test_no_argv(util: UtilFixture, capsys, file_regression):
 
 @pytest.mark.parametrize(
     "arg",
-    [
-        "--invalid-arg",
-        pytest.param(
-            "invalidCommand",
-            marks=pytest.mark.skipif(
-                (3, 14, 5) <= sys.version_info < (3, 15),
-                reason=(
-                    "Python 3.14.5 restored argparse choice quoting (CPython "
-                    "gh-130750); the checked-in fixture matches the 3.14.0-4 "
-                    "unquoted format. See #1990."
-                ),
-            ),
-        ),
-    ],
-)
-@pytest.mark.skipif(
-    sys.version_info[:2] == (3, 12) and sys.version_info < (3, 12, 7),
-    reason=(
-        "argparse stopped quoting choices in 3.13 (CPython gh-129019), "
-        "backported to 3.12.7. The reference snapshot reflects the "
-        "no-quote format, so older 3.12.x patches (3.12.0-3.12.6) print "
-        "quoted choices and fail. See commitizen-tools/commitizen#1864."
-    ),
+    ["--invalid-arg", "invalidCommand"],
 )
 @pytest.mark.usefixtures("python_version", "consistent_terminal_output")
 def test_invalid_command(util: UtilFixture, capsys, file_regression, arg):
@@ -59,6 +61,8 @@ def test_invalid_command(util: UtilFixture, capsys, file_regression, arg):
         util.run_cli(arg)
     out, err = capsys.readouterr()
     assert out == ""
+    if arg == "invalidCommand":
+        err = normalize_argparse_choice_quotes(err)
     file_regression.check(err, extension=".txt")
 
 

--- a/tests/test_cli/test_invalid_command_py_3_10_invalidCommand_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_10_invalidCommand_.txt
@@ -1,4 +1,4 @@
 usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
-cz: error: argument {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}: invalid choice: 'invalidCommand' (choose from 'init', 'commit', 'c', 'ls', 'example', 'info', 'schema', 'bump', 'changelog', 'ch', 'check', 'version')
+cz: error: argument {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}: invalid choice: 'invalidCommand' (choose from init, commit, c, ls, example, info, schema, bump, changelog, ch, check, version)

--- a/tests/test_cli/test_invalid_command_py_3_11_invalidCommand_.txt
+++ b/tests/test_cli/test_invalid_command_py_3_11_invalidCommand_.txt
@@ -1,4 +1,4 @@
 usage: cz [-h] [--config CONFIG] [--debug] [-n NAME] [-nr NO_RAISE]
           {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}
           ...
-cz: error: argument {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}: invalid choice: 'invalidCommand' (choose from 'init', 'commit', 'c', 'ls', 'example', 'info', 'schema', 'bump', 'changelog', 'ch', 'check', 'version')
+cz: error: argument {init,commit,c,ls,example,info,schema,bump,changelog,ch,check,version}: invalid choice: 'invalidCommand' (choose from init, commit, c, ls, example, info, schema, bump, changelog, ch, check, version)


### PR DESCRIPTION
## Description

Fixes #1990 by normalizing only the volatile argparse `(choose from ...)` choice list before the invalid-command snapshot assertion. This lets the `invalidCommand` parametrization run again on Python 3.14.5+, while keeping the command failure, usage output, and invalid value covered.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (OpenAI GPT-5)

Generated-by: OpenAI GPT-5 following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [ ] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes

No documentation changes.

- [ ] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [ ] Check and fix any broken links (internal or external)

## Expected Behavior

`tests/test_cli.py::test_invalid_command[invalidCommand]` should pass across Python patch releases that differ only in whether argparse quotes the `choose from` entries.

## Steps to Test This Pull Request

1. `UV_CACHE_DIR=$PWD/.uv-cache UV_PROJECT_ENVIRONMENT=$PWD/.venv314 uv run --python python3.14 --group test pytest tests/test_cli.py::test_normalize_argparse_choice_quotes tests/test_cli.py::test_invalid_command -q`
2. `UV_CACHE_DIR=$PWD/.uv-cache UV_PROJECT_ENVIRONMENT=$PWD/.venv314 uv run --python python3.14 ruff check tests/test_cli.py`
3. `UV_CACHE_DIR=$PWD/.uv-cache UV_PROJECT_ENVIRONMENT=$PWD/.venv314 uv run --python python3.14 ruff format --check tests/test_cli.py`
4. `git diff --check`

## Additional Context

I did not run the full `uv run poe all` suite locally because this change is isolated to `tests/test_cli.py` and the targeted Python 3.14.5 regression plus ruff checks cover the changed behavior.