### PR TITLE
fix(providers/cargo): don't crash on workspace member with fixed version

### DIFF
--- a/commitizen/providers/cargo_provider.py
+++ b/commitizen/providers/cargo_provider.py
@@ -82,15 +82,15 @@ class CargoProvider(TomlProvider):
                     ).get("package", {})
                     if TYPE_CHECKING:
                         assert isinstance(package_content, dict)
-                    try:
-                        version_workspace = package_content["version"]["workspace"]
-                        if version_workspace is True:
-                            package_name = package_content["name"]
-                            if TYPE_CHECKING:
-                                assert isinstance(package_name, str)
-                            members_inheriting.append(package_name)
-                    except NonExistentKey:
-                        pass
+                    version_field = package_content.get("version")
+                    if (
+                        isinstance(version_field, dict)
+                        and version_field.get("workspace") is True
+                    ):
+                        package_name = package_content["name"]
+                        if TYPE_CHECKING:
+                            assert isinstance(package_name, str)
+                        members_inheriting.append(package_name)
 
             for i, package in enumerate(packages):
                 if package["name"] in members_inheriting:

--- a/tests/providers/test_cargo_provider.py
+++ b/tests/providers/test_cargo_provider.py
@@ -451,3 +451,80 @@ checksum = "123abc"
     assert file.read_text() == dedent(expected_workspace_toml)
     # The lock file should remain unchanged since the member doesn't inherit workspace version
     assert lock_file.read_text() == dedent(expected_lock_content)
+
+
+def test_cargo_provider_workspace_member_with_fixed_version(
+    config: BaseConfig,
+    chdir: Path,
+):
+    """Regression test for https://github.com/commitizen-tools/commitizen/issues/2001.
+
+    A workspace member with a hardcoded ``version = "x.y.z"`` string (rather
+    than ``version.workspace = true``) used to crash ``set_lock_version`` with
+    ``TypeError: string indices must be integers, not 'str'`` because the code
+    unconditionally subscripted ``package["version"]["workspace"]``.
+    """
+    workspace_toml = """\
+[workspace]
+members = ["member_with_fixed_version"]
+
+[workspace.package]
+version = "0.1.0"
+"""
+
+    # Real Cargo syntax for a workspace member that opts out of the
+    # workspace-inherited version by pinning its own.
+    member_content = """\
+[package]
+name = "member_with_fixed_version"
+version = "0.9.0"
+"""
+
+    lock_content = """\
+[[package]]
+name = "member_with_fixed_version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123abc"
+"""
+
+    expected_workspace_toml = """\
+[workspace]
+members = ["member_with_fixed_version"]
+
+[workspace.package]
+version = "42.1"
+"""
+
+    # The pinned member must not be bumped because it does not inherit the
+    # workspace version.
+    expected_lock_content = """\
+[[package]]
+name = "member_with_fixed_version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "123abc"
+"""
+
+    filename = CargoProvider.filename
+    file = chdir / filename
+    file.write_text(dedent(workspace_toml))
+
+    os.mkdir(chdir / "member_with_fixed_version")
+    member_file = chdir / "member_with_fixed_version" / "Cargo.toml"
+    member_file.write_text(dedent(member_content))
+
+    lock_filename = CargoProvider.lock_filename
+    lock_file = chdir / lock_filename
+    lock_file.write_text(dedent(lock_content))
+
+    config.settings["version_provider"] = "cargo"
+
+    provider = get_provider(config)
+    assert isinstance(provider, CargoProvider)
+    assert provider.get_version() == "0.1.0"
+
+    # Must not raise TypeError: string indices must be integers, not 'str'.
+    provider.set_version("42.1")
+    assert file.read_text() == dedent(expected_workspace_toml)
+    assert lock_file.read_text() == dedent(expected_lock_content)


### PR DESCRIPTION
## Description

Fix a `TypeError: string indices must be integers, not 'str'` crash in `CargoProvider` when bumping a Cargo workspace whose members include a crate with a hardcoded version.

While iterating workspace members in `CargoProvider.set_lock_version`, the code subscripted `package["version"]["workspace"]` inside a `try`/`except` block that only caught `NonExistentKey`. If a member's `Cargo.toml` declared a hardcoded version (`version = "x.y.z"`) instead of `version.workspace = true`, `package["version"]` was a tomlkit `String` and the subscript raised `TypeError`, which the existing handler did not catch.

The fix replaces the exception-driven check with an `isinstance` type guard so the inheritance lookup only runs when `version` is an actual table.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [ ] Update the documentation for the changes (no user-facing behavior change)

### Documentation Changes

No documentation changes.

## Expected Behavior

`cz bump` against a Cargo workspace whose members include a crate with a hardcoded `version = "x.y.z"` (real Cargo syntax for opting out of the workspace-inherited version) succeeds:

- the workspace version in `[workspace.package]` is bumped,
- the lock file is rewritten,
- members that declare `version.workspace = true` get their lock entries bumped,
- members that pin their own version are left untouched,
- no `TypeError` is raised.

## Steps to Test This Pull Request

A regression test is added in `tests/providers/test_cargo_provider.py`:
`test_cargo_provider_workspace_member_with_fixed_version`.

Manual repro (also covered by the new test):

1. Create a workspace `Cargo.toml`:

   ```toml
   [workspace]
   members = ["pinned"]

   [workspace.package]
   version = "0.1.0"
   ```

2. Add a member `pinned/Cargo.toml`:

   ```toml
   [package]
   name = "pinned"
   version = "0.9.0"
   ```

3. Create a matching `Cargo.lock` and configure commitizen with `version_provider = "cargo"`.

4. Run `cz bump --yes`. Before this fix, it crashes with `TypeError: string indices must be integers, not 'str'`. With the fix, the workspace version is bumped and the pinned member's lock entry is preserved.

Verified locally:

- `uv run poe format` -- clean
- `uv run poe lint` -- ruff + mypy clean
- `uv run pytest tests/providers/test_cargo_provider.py` -- 7 passed (including the new regression test)
- `uv run prek run --files commitizen/providers/cargo_provider.py tests/providers/test_cargo_provider.py` -- clean

The new test was also confirmed to fail on the unpatched code with the exact `TypeError` from the bug report.

## Additional Context

- Fixes #2001.
- Related prior art: #1715 (closed, same reporter, never rebased) and #1733 (open, draft, broader virtual-manifest rewrite). This PR is scoped narrowly to the crash and intentionally does not overlap with #1733's restructuring.
