### PR TITLE
ci: make bump preview comment sticky

### DIFF
--- a/.github/workflows/pr-bump-preview.yml
+++ b/.github/workflows/pr-bump-preview.yml
@@ -84,11 +84,27 @@ jobs:
             esac
           } > comment.md
 
+      # Look up an existing preview comment so the next step edits it in
+      # place instead of appending a new one on every run.
+      # `peter-evans/create-or-update-comment` does not search by body
+      # itself -- it only creates new comments, or updates a specific
+      # `comment-id`.
+      - name: Find existing preview comment
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- commitizen-bump-preview -->"
+
       - name: Post or update PR comment
         uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # When empty (no prior comment found) a new one is created;
+          # otherwise the existing comment is edited in place.
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body-path: comment.md
-          body-includes: "<!-- commitizen-bump-preview -->"
           edit-mode: replace

--- a/docs/tutorials/github_actions.md
+++ b/docs/tutorials/github_actions.md
@@ -205,12 +205,20 @@ jobs:
                 ;;
             esac
           } > comment.md
-      - uses: peter-evans/create-or-update-comment@v4
+      - name: Find existing preview comment
+        id: find-comment
+        uses: peter-evans/find-comment@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
-          body-path: comment.md
+          comment-author: "github-actions[bot]"
           body-includes: "<!-- commitizen-bump-preview -->"
+      - uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: comment.md
           edit-mode: replace
 ```
 
@@ -235,10 +243,13 @@ jobs:
   `update_changelog_on_bump` is set in your config, also the changelog
   entries that would be produced). Exit code `21` (`NoneIncrementExit`)
   is treated as "no eligible bump" rather than a failure.
-- **Sticky comment**: The hidden HTML marker `<!-- commitizen-bump-preview -->`
-  lets [`peter-evans/create-or-update-comment`](https://github.com/peter-evans/create-or-update-comment)
-  find and replace the previous preview on every push, instead of leaving a
-  growing trail of comments.
+- **Sticky comment**: [`peter-evans/find-comment`](https://github.com/peter-evans/find-comment)
+  looks up an existing comment by the hidden HTML marker
+  `<!-- commitizen-bump-preview -->` and bot author, then
+  [`peter-evans/create-or-update-comment`](https://github.com/peter-evans/create-or-update-comment)
+  edits it in place (or creates a new one on the first run when the
+  marker is not yet present), instead of leaving a growing trail of
+  comments.
 
 [jinja]: https://github.com/commitizen-tools/commitizen/blob/master/commitizen/changelog.py
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description

The PR bump preview workflow appends a new comment on every run instead of editing the previous one -- see #2007, which has 6 duplicate comments.

Cause: it passes `body-includes` to `peter-evans/create-or-update-comment@v5`, but that action has no such input (see its [`action.yml`](https://github.com/peter-evans/create-or-update-comment/blob/main/action.yml)). It only creates new comments, or updates one identified by `comment-id`.

Fix: insert a `peter-evans/find-comment@v3` step ahead of the post step, then pass its `comment-id` output (empty on first run) to `create-or-update-comment`. Matches the documented pattern in the action's README. The same fix is applied to the tutorial example in `docs/tutorials/github_actions.md` (also bumped `@v4` -> `@v5` to match the workflow).

## Checklist

- [X] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [ ] Add test cases to all the changes you introduce
  - N/A -- GitHub Actions workflows have no in-repo test harness; end-to-end verification happens on the next PR sync after merge.
- [X] Run `uv run poe all` locally to ensure this change passes linter check and tests
  - Targeted: `prek run --files <changed>` -- all hooks pass. No Python sources touched.
- [X] Manually test the changes
- [X] Update the documentation for the changes

### Documentation Changes

- [X] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
  - Verified with `uv run mkdocs build --strict` -- exits 0, no warnings.
- [X] Check and fix any broken links (internal or external)

## Expected Behavior

After merge, each PR has at most one `Commitizen bump preview` comment from `github-actions[bot]`, updated in place on subsequent runs. Pre-existing duplicate comments are not pruned by this PR.

## Steps to Test This Pull Request

After merge:

1. Push a follow-up commit to any open same-repo PR (e.g. #2007) to trigger the workflow.
2. Confirm only one preview comment exists, with its body refreshed to the latest run.
3. Open a brand-new same-repo PR and confirm a single preview comment is created on the first run.

## Additional Context

Related: #1957 (workflow originally added).
