### PR TITLE
ci(docspublish): make cli_interactive gif regeneration deterministic

### DIFF
--- a/.github/workflows/docspublish.yml
+++ b/.github/workflows/docspublish.yml
@@ -25,7 +25,9 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y ffmpeg ttyd
-          go install github.com/charmbracelet/vhs@latest
+          # Pin VHS to a known version so gif rendering is deterministic across runs.
+          # Bump this version intentionally when you want to refresh all interactive screenshots.
+          go install github.com/charmbracelet/vhs@v0.11.0
       - name: Install dependencies
         run: |
           uv --version
@@ -33,6 +35,33 @@ jobs:
       - name: Update CLI screenshots
         run: |
           uv run --no-sync poe doc:screenshots
+      - name: Discard cli_interactive regeneration when render inputs are unchanged
+        # VHS gif output drifts by a few bytes between runs even when sources are
+        # identical, which used to produce a noisy stream of `docs(cli/screenshots)`
+        # commits. Keep regenerated gifs only when something that can actually
+        # change the rendered content has changed in this push (the tape sources,
+        # or any commitizen source code the tapes execute), or when manually
+        # dispatched.
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Manual run; keeping any regenerated cli_interactive gifs."
+            exit 0
+          fi
+          before="${{ github.event.before }}"
+          if [[ -z "$before" || "$before" == "0000000000000000000000000000000000000000" ]]; then
+            echo "No previous SHA available (first push or new branch); keeping any regenerated cli_interactive gifs."
+            exit 0
+          fi
+          if ! git rev-parse --verify "$before^{commit}" >/dev/null 2>&1; then
+            echo "Previous SHA $before is unreachable; keeping any regenerated cli_interactive gifs."
+            exit 0
+          fi
+          if git diff --quiet "$before" HEAD -- docs/images/'*.tape' docs/images/shared/ commitizen/; then
+            echo "Tape sources and commitizen/ unchanged since $before; discarding cli_interactive gif regeneration to avoid byte-level churn."
+            git checkout -- docs/images/cli_interactive/
+          else
+            echo "Render inputs changed since $before (tapes or commitizen/); keeping regenerated cli_interactive gifs."
+          fi
       - name: Commit and push updated CLI screenshots
         run: |
           git config --global user.name "github-actions[bot]"

--- a/docs/images/bump.tape
+++ b/docs/images/bump.tape
@@ -57,12 +57,17 @@ Type "cz bump"
 Sleep 500ms
 Enter
 
-# Wait for the "Is this the first tag created?" prompt
-Sleep 2s
+# Wait for the "Is this the first tag created?" prompt to render
+Wait+Screen /Is this the first tag/
+
+# Small visual pause so the prompt is readable before the answer
+Sleep 500ms
 
 # Answer Yes to "Is this the first tag created?" (default is Yes, just press Enter)
 Enter
-Sleep 3s
+
+# Wait for cz bump to finish (the "Done!" success line is printed last)
+Wait+Screen /Done!/
 
 # Step 3: Show new version after bump
 Type "cz version --project"

--- a/docs/images/commit.tape
+++ b/docs/images/commit.tape
@@ -29,38 +29,41 @@ Type "cz commit"
 Sleep 500ms
 Enter
 
-# Wait for first prompt to appear
-Sleep 1s
-
-# Question 1: Select the type of change (move down to "feat")
+# Q1: prefix -- select the type of change (move down to "feat")
+Wait+Screen /Select the type of change/
+Sleep 500ms
 Down
 Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 2: Scope (optional, skip)
+# Q2: scope (optional, skip)
+Wait+Screen /What is the scope/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 3: Subject
+# Q3: subject
+Wait+Screen /imperative summary/
+Sleep 500ms
 Type "awesome new feature"
 Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 4: Is this a BREAKING CHANGE? (No)
+# Q4: body (optional, skip)
+Wait+Screen /additional contextual information/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 5: Body (optional, skip)
+# Q5: is_breaking_change (No)
+Wait+Screen /BREAKING CHANGE\?/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 6: Footer (optional, skip)
+# Q6: footer (optional, skip)
+Wait+Screen /Footer\. Information/
+Sleep 500ms
 Enter
-Sleep 1s
 
 # Wait for commit success message
-Sleep 1s
+Sleep 2s
 
 Source shared/cleanup.tape

--- a/docs/images/init.tape
+++ b/docs/images/init.tape
@@ -15,51 +15,55 @@ Type "cz init"
 Sleep 500ms
 Enter
 
-# Wait for welcome message and first prompt
-Sleep 500ms
-Sleep 1s
-
-# Question 1: Please choose a supported config file
+# Q1: Please choose a supported config file
 # Default is .cz.toml, just press Enter
+Wait+Screen /Please choose a supported config/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 2: Please choose a cz (commit rule)
+# Q2: Please choose a cz (commit rule)
 # Default is cz_conventional_commits, just press Enter
+Wait+Screen /Please choose a cz/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 3: Choose the source of the version
-# Default is "commitizen: Fetch and set version in commitizen config, just press Enter"
+# Q3: Choose the source of the version
+# Default is "commitizen", just press Enter
+Wait+Screen /Choose the source of the version/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 4: Choose version scheme
+# Q4: Choose version scheme
 # Default is semver, just press Enter
+Wait+Screen /Choose version scheme/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 5: Please enter the correct version format
+# Q5: Please enter the correct version format
 # Default is "$version", just press Enter
+Wait+Screen /Please enter the correct version format/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 6: Create changelog automatically on bump
+# Q6: Create changelog automatically on bump
 # Default is Yes, just press Enter
+Wait+Screen /Create changelog automatically on bump/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 7: Keep major version zero (0.x) during breaking changes
+# Q7: Keep major version zero (0.x) during breaking changes
 # Default is Yes, just press Enter
+Wait+Screen /Keep major version zero/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 8: What types of pre-commit hook you want to install?
-# Default is [commit-msg], just press Enter to accept
+# Q8: What types of pre-commit hook you want to install?
+# Default is [], just press Enter to accept
+Wait+Screen /types of pre-commit hook/
+Sleep 500ms
 Enter
-Sleep 1s
 
 # Wait for completion message
-Sleep 1s
+Sleep 2s
 
 Source shared/cleanup.tape

--- a/docs/images/shortcut_custom.tape
+++ b/docs/images/shortcut_custom.tape
@@ -83,23 +83,21 @@ Type "cz commit"
 Sleep 500ms
 Enter
 
-# Wait for first prompt to appear
-Sleep 2s
-
-# Question 1: Select the type of change (press d to "docs")
+# Q1: prefix -- press "d" shortcut for "docs"
+Wait+Screen /Select the type of change/
 Sleep 1s
 Type "d"
 Sleep 2s
 Enter
-Sleep 1s
 
-# Question 2: Commit body
+# Q2: Commit body
+Wait+Screen /Commit body/
+Sleep 500ms
 Type "demo with custom keys"
 Sleep 500ms
 Enter
-Sleep 500ms
 
 # Wait for commit success message
-Sleep 1s
+Sleep 2s
 
 Source shared/cleanup.tape

--- a/docs/images/shortcut_default.tape
+++ b/docs/images/shortcut_default.tape
@@ -42,39 +42,41 @@ Type "cz commit"
 Sleep 500ms
 Enter
 
-# Wait for first prompt to appear
-Sleep 2s
-
-# Question 1: Select the type of change (press d to "docs")
+# Q1: prefix -- press "d" shortcut for "docs"
+Wait+Screen /Select the type of change/
 Sleep 1s
 Type "d"
 Sleep 2s
 Enter
-Sleep 1s
 
-# Question 2: Scope (optional, skip)
+# Q2: scope (optional, skip)
+Wait+Screen /What is the scope/
+Sleep 500ms
 Enter
-Sleep 1s
 
-# Question 3: Subject
+# Q3: subject
+Wait+Screen /imperative summary/
+Sleep 500ms
 Type "demo with custom keys"
 Sleep 500ms
 Enter
-Sleep 500ms
 
-# Question 4: Is this a BREAKING CHANGE? (No)
-Enter
+# Q4: body (optional, skip)
+Wait+Screen /additional contextual information/
 Sleep 500ms
+Enter
 
-# Question 5: Body (optional, skip)
-Enter
+# Q5: is_breaking_change (No)
+Wait+Screen /BREAKING CHANGE\?/
 Sleep 500ms
+Enter
 
-# Question 6: Footer (optional, skip)
-Enter
+# Q6: footer (optional, skip)
+Wait+Screen /Footer\. Information/
 Sleep 500ms
+Enter
 
 # Wait for commit success message
-Sleep 1s
+Sleep 2s
 
 Source shared/cleanup.tape


### PR DESCRIPTION
## Description

Every push to `master` currently produces a noisy `docs(cli/screenshots)` auto-commit (20+ in a row in recent history) because VHS renders byte-different gifs from identical sources. This PR removes both sources of churn:

1. **CI guard** -- a new `Discard cli_interactive regeneration when render inputs are unchanged` step diffs `docs/images/*.tape`, `docs/images/shared/`, and the `commitizen/` package between `github.event.before` and `HEAD`; if nothing under those paths changed, the regenerated gifs are reset and never committed. The `commitizen/` arm preserves legitimate code-driven screenshot updates (e.g. renaming a prompt in `commitizen/cz/conventional_commits/conventional_commits.py` or `commitizen/commands/init.py`). `workflow_dispatch` always keeps the regen so intentional refreshes still work. Missing/zero/unreachable `before` SHAs fall through to keeping the regen.
2. **Pin VHS to v0.11.0** so deliberate refreshes are reproducible across runs.

It also rewrites the 5 `.tape` files to wait for cz prompt strings via `Wait+Screen /regex/` (a v0.11 feature) instead of fixed `Sleep` delays. This removes the remaining frame-timing nondeterminism, and a future cz prompt rename will fail the 15s `Wait` timeout in CI instead of silently producing the wrong gif.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI (claude-opus-4.7-1m-internal) following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- N/A: no Python code path changed; CI workflow + VHS tape changes only.
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
  - Pre-existing unrelated failures on Windows (`test_bump_minor_increment_signed`: local gpg setup; `test_breaking_change_content_v1_beta`: flaky in parallel run, passes in isolation). Not introduced by this PR.
- [x] Manually test the changes:
  - `vhs validate` passes on all 5 tapes.
  - `Wait+Screen` regexes grepped verbatim from `commitizen/cz/conventional_commits/conventional_commits.py`, `commitizen/commands/init.py`, `commitizen/commands/bump.py`.
  - Full render verification deferred to CI on first merge (native Windows vhs hangs on ttyd+WSL bash; not a tape issue).

## Expected Behavior

- Pushes that don't touch tape sources or any `commitizen/` source file produce no `docs(cli/screenshots)` auto-commit.
- Pushes that modify a tape, or any code the tapes execute, still commit the new gif.
- Manual `workflow_dispatch` always commits the regen (intentional-refresh lever after a VHS bump).
- A future cz prompt rename fails the matching `Wait+Screen` after 15s in CI.

## Steps to Test This Pull Request

```bash
# Validate tape syntax
cd docs/images
vhs validate bump.tape commit.tape init.tape shortcut_default.tape shortcut_custom.tape

# (optional, Linux/WSL) Render and eyeball-diff against current gifs
uv sync --group base
uv run poe doc:screenshots
```

End-to-end CI behaviour is observable on the next push to `master` after merge: should produce no `docs(cli/screenshots)` auto-commit unless the push touches a tape or `commitizen/` source.

## Additional Context

Follow-ups scoped out of this PR:

- Parallelize `scripts/gen_cli_interactive_gifs.py` (separate PR #2010).
- Drop the `Set Shell bash` + hardcoded `/tmp/commitizen-example` constraints in `shared/base.tape` so tapes can render natively on Windows.
- Switch the auto-commit step to open a PR instead of pushing directly.