### PR TITLE
fix(version): recognize PEP 440 development tags

### DIFF
--- a/commitizen/version_schemes.py
+++ b/commitizen/version_schemes.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 Increment: TypeAlias = Literal["MAJOR", "MINOR", "PATCH"]  # TODO: deprecate
 Prerelease: TypeAlias = Literal["alpha", "beta", "rc"]
 _DEFAULT_VERSION_PARSER = re.compile(
-    r"v?(?P<version>([0-9]+)\.([0-9]+)(?:\.([0-9]+))?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z.]+)?(\w+)?)"
+    r"v?(?P<version>([0-9]+)\.([0-9]+)(?:\.([0-9]+))?(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\w+)?(?:\.dev\d+)?(?:\+[0-9A-Za-z.]+)?)"
 )
 
 

--- a/tests/commands/test_bump_command.py
+++ b/tests/commands/test_bump_command.py
@@ -237,6 +237,55 @@ def test_bump_command_prerelease(util: UtilFixture):
     assert git.tag_exist("0.2.0") is True
 
 
+def test_bump_devrelease_with_incremental_changelog(
+    tmp_commitizen_project: Path, util: UtilFixture, changelog_path: Path
+):
+    config_path = tmp_commitizen_project / "pyproject.toml"
+    config_path.write_text(
+        dedent(
+            """\
+            [project]
+            name = "dev-project"
+            version = "0.1.0"
+
+            [tool.commitizen]
+            version_provider = "uv"
+            update_changelog_on_bump = true
+            changelog_incremental = true
+            """
+        ),
+        encoding="utf-8",
+    )
+    lock_path = tmp_commitizen_project / "uv.lock"
+    lock_path.write_text(
+        dedent(
+            """\
+            version = 1
+            revision = 1
+
+            [[package]]
+            name = "dev-project"
+            version = "0.1.0"
+            source = { virtual = "." }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    util.create_file_and_commit("feat: first development release")
+    util.run_cli("bump", "--devrelease", "0", "--yes")
+    assert git.tag_exist("0.2.0.dev0") is True
+
+    util.create_file_and_commit("feat: next development release")
+    util.run_cli("bump", "--devrelease", "1", "--yes")
+    assert git.tag_exist("0.2.0.dev1") is True
+    changelog = changelog_path.read_text(encoding="utf-8")
+    assert "0.2.0.dev1" in changelog
+    assert "next development release" in changelog
+    assert 'version = "0.2.0.dev1"' in config_path.read_text(encoding="utf-8")
+    assert 'version = "0.2.0.dev1"' in lock_path.read_text(encoding="utf-8")
+
+
 @pytest.mark.usefixtures("tmp_commitizen_project")
 def test_bump_command_prerelease_increment(util: UtilFixture):
     # FINAL RELEASE

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -140,3 +140,25 @@ def test_is_version_tag_accepts_dotless_devrelease_in_custom_tag_format():
 
     extracted = rules.extract_version(_git_tag("version-1.2.3dev1"))
     assert str(extracted) == "1.2.3.dev1"
+
+
+def test_is_version_tag_accepts_pep440_devrelease():
+    rules = TagRules()
+
+    versions = [
+        ("0.2.0.dev0", "0.2.0.dev0"),
+        ("0.2.0dev0", "0.2.0.dev0"),
+        ("0.2.0.dev0+build.1", "0.2.0.dev0+build.1"),
+        ("0.2.0a1.dev0", "0.2.0a1.dev0"),
+        ("0.2.0a1.dev0+build.1", "0.2.0a1.dev0+build.1"),
+    ]
+    for tag, expected in versions:
+        assert rules.is_version_tag(tag) is True
+        assert str(rules.extract_version(_git_tag(tag))) == expected
+
+    assert rules.is_version_tag("0.2.0.not-a-release") is False
+
+    custom_rules = TagRules(tag_format="release-$version-final")
+    custom_tag = _git_tag("release-0.2.0.dev0-final")
+    assert custom_rules.is_version_tag(custom_tag) is True
+    assert str(custom_rules.extract_version(custom_tag)) == "0.2.0.dev0"


### PR DESCRIPTION
## Description

Fixes #1367.

The default `$version` parser rejected `.devN` tags that Commitizen itself creates. This keeps generated PEP 440 prerelease, development, and local-version combinations discoverable so the next incremental changelog can find the previous tag.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (OpenAI Codex)

Generated-by: OpenAI Codex following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Added regression coverage for the parser and sequential `uv`-provider bumps
- [x] Ran `uv run poe all` locally
- [x] Manually reproduced two sequential development bumps with incremental changelogs
- [x] Verified existing PEP 440, SemVer, custom tag-format, and invalid-tag coverage
- [x] Documentation is unchanged because no option or workflow changed

## Expected Behavior

After creating `0.2.0.dev0`, a subsequent `--devrelease 1` bump should recognize that tag and generate the `0.2.0.dev1` changelog, tag, `pyproject.toml`, and `uv.lock` updates.

## Steps to Test This Pull Request

1. Configure the `uv` version provider with `update_changelog_on_bump` and `changelog_incremental` enabled.
2. Run `cz bump --devrelease 0 --yes` after a feature commit.
3. Add another feature commit and run `cz bump --devrelease 1 --yes`.
4. Confirm the second bump succeeds and writes `0.2.0.dev1` to the tag, changelog, `pyproject.toml`, and `uv.lock`.
