### PR TITLE
docs(release-scm): fix setup-cz link

### DIFF
--- a/docs/tutorials/release-scm.md
+++ b/docs/tutorials/release-scm.md
@@ -24,7 +24,7 @@ git push --follow-tags
 ```
 
 !!! tip
-    Wrap this in a CI job to fully automate releases when using the `scm` provider using [setup-cz](github.com/commitizen-tools/setup-cz)
+    Wrap this in a CI job to fully automate releases when using the `scm` provider using [setup-cz](https://github.com/commitizen-tools/setup-cz)
 
 ## Why Can't I Bump with SCM?
 


### PR DESCRIPTION
## Description
The setup-cz link in `docs/tutorials/release-scm.md` was missing the `https://` scheme (it read `github.com/commitizen-tools/setup-cz`), so it rendered as a broken/relative link instead of a working hyperlink. This adds the full scheme.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

### Code Changes

Not applicable — documentation-only change, no code modified.

- [ ] Add test cases to all the changes you introduce
- [ ] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes

- [x] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [x] Check and fix any broken links (internal or external)

## Expected Behavior
In `docs/tutorials/release-scm.md`, the setup-cz link inside the "Wrap this in a CI job…" tip block renders as a clickable hyperlink pointing to `https://github.com/commitizen-tools/setup-cz`.
In `docs/tutorials/release-scm.md`, the setup-cz link inside the "Wrap this in a CI job…" tip block renders as a clickable hyperlink pointing to `https://github.com/commitizen-tools/setup-cz`.

## Steps to Test This Pull Request
1. Run `uv run poe doc` to build the docs site locally
2. Open the `tutorials/release-scm.md` page and find the tip block just above "Why Can't I Bump with SCM?"
3. Confirm the setup-cz link is clickable and resolves to `https://github.com/commitizen-tools/setup-cz`

## Additional Context
