### PR TITLE
docs(tutorial): fix setup-cz link

### DIFF
--- a/docs/tutorials/release-scm.md
+++ b/docs/tutorials/release-scm.md
@@ -24,7 +24,7 @@ git push --follow-tags
 ```
 
 !!! tip
-    Wrap this in a CI job to fully automate releases when using the `scm` provider using [setup-cz](github.com/commitizen-tools/setup-cz)
+    Wrap this in a CI job to fully automate releases when using the `scm` provider using [setup-cz](https://github.com/commitizen-tools/setup-cz)
 
 ## Why Can't I Bump with SCM?
 


### PR DESCRIPTION
## Description

Add the missing `https://` scheme to the `setup-cz` link in the SCM release tutorial. Without the scheme, Lychee interpreted the URL as a repository-relative file path and generated repeated broken-link reports.

## Checklist

- [ ] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [X] Yes (GitHub Copilot, powered by GPT-5.6 Sol)

Generated-by: [GitHub Copilot](https://github.com/features/copilot) following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [ ] Add test cases to all the changes you introduce
- [ ] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [ ] Manually test the changes:
  - [ ] Verify the feature/bug fix works as expected in real-world scenarios
  - [ ] Test edge cases and error conditions
  - [ ] Ensure backward compatibility is maintained
  - [ ] Document any manual testing steps performed
- [ ] Update the documentation for the changes

### Documentation Changes

- [ ] Run `uv run poe doc` locally to ensure the documentation pages renders correctly
- [X] Check and fix any broken links (internal or external)

## Expected Behavior

Lychee resolves the `setup-cz` link as an external GitHub URL instead of a missing local file.

## Steps to Test This Pull Request

1. Run `lychee --config lychee.toml docs/tutorials/release-scm.md`.
2. Confirm both links pass with zero errors.

## Additional Context

Lychee reports 2 links checked, 2 successful, and 0 errors for the affected document.

Fixes: #2071