### PR TITLE
ci: restore changelog updates

### DIFF
--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -39,7 +39,7 @@ jobs:
       - id: bump-version
         run: |
           old_sha="$(git rev-parse HEAD)"
-          cz --no-raise 21 bump --yes
+          cz --no-raise 21 bump --yes --changelog
 
           if [ "$(git rev-parse HEAD)" = "$old_sha" ]; then
             echo "No bump-eligible commits found, skipping release."

--- a/.github/workflows/bumpversion.yml
+++ b/.github/workflows/bumpversion.yml
@@ -39,7 +39,7 @@ jobs:
       - id: bump-version
         run: |
           old_sha="$(git rev-parse HEAD)"
-          cz --no-raise 21 bump --yes --changelog
+          cz --no-raise 21 bump --yes
 
           if [ "$(git rev-parse HEAD)" = "$old_sha" ]; then
             echo "No bump-eligible commits found, skipping release."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,21 @@ Follow these instructions in addition to any higher-level system or tool rules.
 - **Commit messages** must follow [Conventional Commits](https://www.conventionalcommits.org/) (enforced by commitizen itself).
 - **Pull requests** must follow the [Pull Request Guidelines](docs/contributing/pull_request.md) and the template in `.github/pull_request_template.md`.
 
+### Commit and Pull Request Types
+
+Choose the Conventional Commit type based on the change's release impact, not
+the files or subsystem it touches. The type controls automated version bumps:
+
+- `feat` triggers a minor release.
+- `fix`, `perf`, and `refactor` trigger a patch release.
+- `ci`, `docs`, `test`, `build`, and `chore` do not trigger a release.
+- A breaking-change marker triggers a major release.
+
+Use the same rule for pull request titles because squash merges use the title as
+the resulting commit message. In particular, use `ci:` for changes limited to
+workflows or release automation. A scope does not change release impact:
+`fix(ci): ...` still triggers a patch release.
+
 ## Setup and Validation
 
 > Full contributor guidelines (prerequisites, workflow, PR process): [`docs/contributing/contributing.md`](docs/contributing/contributing.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,92 @@
+## Unreleased
+
+## v4.18.0 (2026-08-19)
+
+### Feat
+
+- **commit**: add a tag(--body-length-limit) and a function for command commit (#1849)
+
+## v4.17.1 (2026-08-17)
+
+### Fix
+
+- **init**: skip hook question when no installer is present
+- **init**: use prek when installing hooks if pre-commit is missing
+
+## v4.17.0 (2026-07-29)
+
+### Feat
+
+- **cmd/version**: add support for `--next USE_GIT_COMMITS`
+
+### Fix
+
+- robuster agents
+- **version**: remove next from exclusive group
+- **bump**: use correct type for calling changelog
+
+## v4.16.5 (2026-07-16)
+
+### Fix
+
+- exclude star-history API from lychee link checker (#2029)
+
+## v4.16.4 (2026-06-22)
+
+### Fix
+
+- **providers/cargo**: don't crash on workspace member with fixed version
+
+## v4.16.3 (2026-05-30)
+
+### Fix
+
+- **check**: expand env vars in --rev-range (#2005)
+
+## v4.16.2 (2026-05-15)
+
+### Fix
+
+- **tags**: widen prerelease and devrelease tag regexes for SemVer2 (#1972)
+
+## v4.16.1 (2026-05-15)
+
+### Fix
+
+- **cz_customize**: derive bump_map_major_version_zero from bump_map (#1977)
+
+## v4.16.0 (2026-05-12)
+
+### Feat
+
+- **hooks**: support interactive hooks scripts
+
+## v4.15.1 (2026-05-06)
+
+### Fix
+
+- **security**: prevent command injection via shell=True (CWE-78) (#1941)
+
+## v4.15.0 (2026-05-03)
+
+### Feat
+
+- **version**: add MANUAL_VERSION, --next and --patch to version command (#1724)
+
+## v4.14.0 (2026-05-03)
+
+### Feat
+
+- add `--allow-no-commit` to `changelog` command (#1868)
+
+## v4.13.10 (2026-04-11)
+
+### Fix
+
+- **ci**: use commitizen bot to push tags and commits
+- **init**: set semver2 as default if not python
+- change deprecated value and bump versions
+
 ## v4.13.9 (2026-02-25)
 
 ### Fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ version_files = [
 version_provider = "uv"
 version_scheme = "pep440"
 annotated_tag = true
+update_changelog_on_bump = true
 changelog_incremental = true
 
 [tool.uv.build-backend]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ version_files = [
 version_provider = "uv"
 version_scheme = "pep440"
 annotated_tag = true
+changelog_incremental = true
 
 [tool.uv.build-backend]
 module-name = "commitizen"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
Please fill in the following content to let us know better about this change.
-->

## Description
<!-- Describe what the change is -->

The release workflow stopped committing `CHANGELOG.md` after migrating from `commitizen-action` to `setup-cz`, because the replacement configuration no longer enabled changelog updates during `cz bump`. GitHub release notes continued to be generated into a temporary file, leaving the repository changelog stale after v4.13.9.

This enables changelog generation on bump, uses incremental generation to preserve historical manual edits, and backfills all 13 releases from v4.13.10 through v4.18.0. It also documents release-triggering Conventional Commit and PR title types for AI agents to prevent CI-only changes from causing patch releases.

## Checklist

- [ ] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [x] Yes (GitHub Copilot)

Generated-by: GitHub Copilot following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [ ] Add test cases to all the changes you introduce (N/A: workflow/configuration change covered by existing bump and changelog tests)
- [ ] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [x] Update the documentation for the changes

### Documentation Changes
<!-- You can skip this section if you are not making any documentation changes -->

The repository changelog is backfilled from the existing release tags, and `AGENTS.md` now explains which commit and PR title types trigger releases.

- [ ] Run `uv run poe doc` locally to ensure the documentation pages renders correctly (N/A)
- [ ] Check and fix any broken links (internal or external) (N/A)

<!--
When running `uv run poe doc`, any broken internal documentation links will be reported in the console output like this:

```text
INFO    -  Doc file 'config.md' contains a link 'commands/bump.md#-post_bump_hooks', but the doc 'commands/bump.md' does not contain an anchor '#-post_bump_hooks'.
```
-->

## Expected Behavior
<!-- A clear and concise description of what you expected to happen -->

Each successful automated version bump commits the new changelog entry to `CHANGELOG.md`. Incremental generation updates only releases newer than the latest version already present.

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->

1. Run `uv run cz changelog --incremental` twice and confirm the second run leaves `CHANGELOG.md` unchanged.
2. Run `uv run cz bump --dry-run --yes --increment patch` and confirm the configured changelog-enabled bump is previewed.
3. Run `uv run pytest -q tests/commands/test_bump_command.py tests/commands/test_changelog_command.py`.
4. Run `uv run prek run check-yaml --files .github/workflows/bumpversion.yml`.

## Additional Context
<!-- Add any other RELATED ISSUE, context or screenshots about the pull request here. -->

The regression was introduced in [PR #1924](https://github.com/commitizen-tools/commitizen/pull/1924) by commit `97fb356d`, which replaced `commitizen-action` (defaulting to `--changelog`) with a direct `cz bump --yes` invocation without the equivalent configuration.