### PR TITLE
fix(commit): preserve blank lines with body length limit

### DIFF
--- a/commitizen/commands/commit.py
+++ b/commitizen/commands/commit.py
@@ -120,9 +120,12 @@ class Commit:
         if len(lines) < 3:
             return message
 
-        # First line is subject, second is blank line, rest are body lines
+        # Preserve intentional blank (or whitespace-only) lines while wrapping
+        # non-empty body lines. textwrap.wrap() returns [] for such lines, so
+        # they must be special-cased to avoid being silently dropped.
         wrapped_body_lines = chain.from_iterable(
-            textwrap.wrap(line, width=body_length_limit) for line in lines[2:]
+            textwrap.wrap(line, width=body_length_limit) if line.strip() else [line]
+            for line in lines[2:]
         )
         return "\n".join(chain(lines[:2], wrapped_body_lines))
 

--- a/tests/commands/test_commit_command.py
+++ b/tests/commands/test_commit_command.py
@@ -391,6 +391,11 @@ def test_commit_command_with_config_message_length_limit(
             id="preserves_line_breaks",
         ),
         pytest.param(
+            "Line1 is shorter than the limit but has paragraph break\n\nLine2 stays in a separate paragraph",
+            100,
+            id="preserves_blank_lines",
+        ),
+        pytest.param(
             "This is a very long line that exceeds 72 characters and should NOT be wrapped when body_length_limit is set to 0",
             0,
             id="disabled",
@@ -441,3 +446,49 @@ def test_commit_command_body_length_limit(
         assert len(body_lines) == 1, (
             "Body should not be wrapped when body_length_limit is set to 0"
         )
+
+
+@pytest.mark.usefixtures("staging_is_clean")
+def test_commit_command_body_length_limit_preserves_whitespace_only_lines(
+    config,
+    success_mock: MockType,
+    commit_mock,
+    mocker: MockFixture,
+):
+    """A whitespace-only body line must be kept, not just an empty one.
+
+    ``textwrap.wrap`` returns ``[]`` for a whitespace-only string just like it
+    does for an empty one, so ``_wrap_body`` must special-case it the same
+    way to avoid silently dropping the paragraph separator. This is asserted
+    directly (not via ``file_regression``) because the repository's
+    trailing-whitespace pre-commit hook would strip the whitespace-only line
+    from any committed fixture file, invalidating the comparison.
+    """
+    body = (
+        "Line1 is shorter than the limit but has paragraph break"
+        "\n   \n"
+        "Line2 stays in a separate paragraph"
+    )
+
+    mocker.patch(
+        "questionary.prompt",
+        return_value={
+            "prefix": "feat",
+            "subject": "add feature",
+            "scope": "",
+            "is_breaking_change": False,
+            "body": body,
+            "footer": "",
+        },
+    )
+
+    commands.Commit(config, {"body_length_limit": 100})()
+    success_mock.assert_called_once()
+    committed_message = commit_mock.call_args[0][0]
+    body_lines = committed_message.split("\n")[2:]
+
+    assert body_lines == [
+        "Line1 is shorter than the limit but has paragraph break",
+        "   ",
+        "Line2 stays in a separate paragraph",
+    ], "Whitespace-only body line should be preserved, not dropped"

--- a/tests/commands/test_commit_command/test_commit_command_body_length_limit_preserves_blank_lines_.txt
+++ b/tests/commands/test_commit_command/test_commit_command_body_length_limit_preserves_blank_lines_.txt
@@ -1,0 +1,5 @@
+feat: add feature
+
+Line1 is shorter than the limit but has paragraph break
+
+Line2 stays in a separate paragraph


### PR DESCRIPTION
## Description

Fix `body_length_limit` so it preserves intentional blank lines in commit bodies while still wrapping non-empty lines to the configured width.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: GitHub Copilot CLI following [the guidelines](http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions)

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests
- [x] Manually test the changes:
  - [x] Verify the feature/bug fix works as expected in real-world scenarios
  - [x] Test edge cases and error conditions
  - [x] Ensure backward compatibility is maintained
  - [x] Document any manual testing steps performed
- [ ] <s>Update the documentation for the changes</s> &mdash; not required, just a fix

### Documentation Changes

- [ ] <s>Run `uv run poe doc` locally to ensure the documentation pages renders correctly</s> &mdash; no documentation changes
- [ ] <s>Check and fix any broken links (internal or external)</s> &mdash; no documentation changes

## Expected Behavior

With `body_length_limit` enabled, Commitizen should preserve blank lines in the commit body and only wrap long non-empty lines.

## Steps to Test This Pull Request

1. Configure `body_length_limit = 80` or run `cz commit --body-length-limit 80`.
2. Create a commit message body with a paragraph break, for example:

   ```text
   First paragraph line

   Second paragraph line
   ```
3. Confirm the generated commit message still contains the blank separator line.
4. Run `uv run pytest tests/commands/test_commit_command.py -k body_length_limit`.
5. Run `uv run ruff check commitizen/commands/commit.py tests/commands/test_commit_command.py`.
6. Run `uv run ruff format --check commitizen/commands/commit.py tests/commands/test_commit_command.py`.

## Additional Context

This fixes a regression where `textwrap.wrap("")` caused empty body lines to be dropped when `body_length_limit` was enabled (#2079).
