### PR TITLE
feat(config): add strict_config to reject unknown configuration keys

### DIFF
--- a/commitizen/config/base_config.py
+++ b/commitizen/config/base_config.py
@@ -4,15 +4,26 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from commitizen.defaults import DEFAULT_SETTINGS, Settings
+from commitizen.exceptions import InvalidConfigurationError
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Iterable
 
     # Self is Python 3.11+ but backported in typing-extensions
     if sys.version_info < (3, 11):
         from typing_extensions import Self
     else:
         from typing import Self
+
+
+# Top-level keys that may appear in the commitizen section of a
+# configuration file. Derived from the Settings TypedDict plus
+# ``annotated_tag_message``, which is read from settings but predates the
+# TypedDict (see commitizen/commands/bump.py).
+KNOWN_SETTINGS: frozenset[str] = frozenset(
+    set(Settings.__required_keys__) | set(Settings.__optional_keys__)
+) | frozenset({"annotated_tag_message"})
 
 
 class BaseConfig:
@@ -48,6 +59,26 @@ class BaseConfig:
 
     def update(self, data: Settings) -> None:
         self._settings.update(data)
+
+    def _check_unknown_keys(self, keys: Iterable[str]) -> None:
+        """Raise when the configuration contains keys that are not known settings.
+
+        Only enforced when the ``strict_config`` setting is enabled. Unknown
+        top-level keys usually indicate a typo in the configuration file
+        (e.g. ``bump_mesage``); silently ignoring them makes such mistakes
+        hard to notice. Keys nested under ``customize`` and ``extras`` are
+        plugin-owned and deliberately not checked.
+        """
+        if not self._settings.get("strict_config"):
+            return
+
+        unknown_keys = sorted(key for key in keys if key not in KNOWN_SETTINGS)
+        if unknown_keys:
+            raise InvalidConfigurationError(
+                f"Unknown configuration key(s) in {self.path}: "
+                f"{', '.join(unknown_keys)}. "
+                "Check for typos in your configuration file."
+            )
 
     def _parse_setting(self, data: bytes | str) -> None:
         raise NotImplementedError()

--- a/commitizen/config/json_config.py
+++ b/commitizen/config/json_config.py
@@ -65,6 +65,8 @@ class JsonConfig(BaseConfig):
             raise InvalidConfigurationError(f"Failed to parse {self.path}: {e}")
 
         try:
-            self.settings.update(doc["commitizen"])
+            commitizen_section = doc["commitizen"]
+            self.settings.update(commitizen_section)
+            self._check_unknown_keys(commitizen_section.keys())
         except KeyError:
             pass

--- a/commitizen/config/toml_config.py
+++ b/commitizen/config/toml_config.py
@@ -10,7 +10,9 @@ from .base_config import BaseConfig
 
 if TYPE_CHECKING:
     import sys
+    from collections.abc import Mapping
     from pathlib import Path
+    from typing import Any
 
     # Self is Python 3.11+ but backported in typing-extensions
     if sys.version_info < (3, 11):
@@ -65,6 +67,8 @@ class TomlConfig(BaseConfig):
             raise InvalidConfigurationError(f"Failed to parse {self.path}: {e}")
 
         try:
-            self.settings.update(doc["tool"]["commitizen"])  # type: ignore[index,typeddict-item] # TODO: fix this
+            commitizen_section: Mapping[str, Any] = doc["tool"]["commitizen"]  # type: ignore[index, assignment]
+            self.settings.update(commitizen_section)  # type: ignore[typeddict-item] # TODO: fix this
+            self._check_unknown_keys(commitizen_section.keys())
         except exceptions.NonExistentKey:
             pass

--- a/commitizen/config/yaml_config.py
+++ b/commitizen/config/yaml_config.py
@@ -51,7 +51,9 @@ class YAMLConfig(BaseConfig):
             raise InvalidConfigurationError(f"Failed to parse {self.path}: {e}")
 
         try:
-            self.settings.update(doc["commitizen"])
+            commitizen_section = doc["commitizen"]
+            self.settings.update(commitizen_section)
+            self._check_unknown_keys(commitizen_section.keys())
         except (KeyError, TypeError):
             pass
 

--- a/commitizen/defaults.py
+++ b/commitizen/defaults.py
@@ -55,6 +55,7 @@ class Settings(TypedDict, total=False):
     pre_bump_hooks: list[str] | None
     prerelease_offset: int
     retry_after_failure: bool
+    strict_config: bool
     style: list[tuple[str, str]]
     tag_format: str
     template: str | None
@@ -90,6 +91,7 @@ DEFAULT_SETTINGS: Settings = {
     "ignored_tag_formats": [],
     "bump_message": None,  # bumped v$current_version to $new_version
     "retry_after_failure": False,
+    "strict_config": False,
     "allow_abort": False,
     "allowed_prefixes": [
         "Merge",

--- a/docs/config/configuration_file.md
+++ b/docs/config/configuration_file.md
@@ -237,6 +237,7 @@ Key configuration categories include:
 - **Changelog**: `changelog_file`, `changelog_format`, `changelog_incremental`, `update_changelog_on_bump`
 - **Bumping**: `bump_message`, `major_version_zero`, `prerelease_offset`, `pre_bump_hooks`, `post_bump_hooks`
 - **Commit Validation**: `allowed_prefixes`, `message_length_limit`, `allow_abort`, `retry_after_failure`
+- **Configuration Validation**: `strict_config` - reject unknown keys in the configuration file
 - **Customization**: `customize`, `style`, `use_shortcuts`, `template`, `extras`
 
 ## Customization

--- a/docs/config/option.md
+++ b/docs/config/option.md
@@ -33,6 +33,25 @@ Style for the prompts.
 
 It will merge this value with default style. See [Styling your prompts with your favorite colors](https://github.com/tmbo/questionary#additional-features) for more details.
 
+## `strict_config`
+
+Reject unknown keys in the `[tool.commitizen]` (or `commitizen`) section of the configuration file.
+
+- Type: `bool`
+- Default: `false`
+
+When enabled, any unknown top-level key makes Commitizen fail with an `InvalidConfigurationError` listing the offending keys. This is useful to catch typos such as `bump_mesage` instead of silently ignoring them.
+
+Keys nested under `customize` and `extras` are plugin-owned and are not checked.
+
+**Example**
+
+```toml title="pyproject.toml"
+[tool.commitizen]
+name = "cz_conventional_commits"
+strict_config = true
+```
+
 ## `customize`
 
 Custom rules for committing and bumping.

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -109,6 +109,7 @@ _settings: dict[str, Any] = {
     "prerelease_offset": 0,
     "encoding": "utf-8",
     "always_signoff": False,
+    "strict_config": False,
     "template": None,
     "extras": {},
     "breaking_change_exclamation_in_title": False,
@@ -150,6 +151,7 @@ _new_settings: dict[str, Any] = {
     "prerelease_offset": 0,
     "encoding": "utf-8",
     "always_signoff": False,
+    "strict_config": False,
     "template": None,
     "extras": {},
     "breaking_change_exclamation_in_title": False,
@@ -497,3 +499,61 @@ class TestYamlConfig:
 
         with pytest.raises(InvalidConfigurationError, match=re.escape(config_file)):
             YAMLConfig(data=existing_content, path=path)
+
+
+class TestStrictConfig:
+    @pytest.mark.parametrize(
+        ("config_content", "config_path"),
+        [
+            pytest.param(
+                '[tool.commitizen]\nname = "cz_conventional_commits"\n'
+                'strict_config = true\nbump_mesage = "typo"\n',
+                "pyproject.toml",
+                id="toml",
+            ),
+            pytest.param(
+                '{"commitizen": {"name": "cz_conventional_commits", '
+                '"strict_config": true, "bump_mesage": "typo"}}',
+                ".cz.json",
+                id="json",
+            ),
+            pytest.param(
+                "commitizen:\n  name: cz_conventional_commits\n"
+                "  strict_config: true\n  bump_mesage: typo\n",
+                ".cz.yaml",
+                id="yaml",
+            ),
+        ],
+    )
+    def test_strict_config_rejects_unknown_keys(
+        self, tmp_path, config_content, config_path
+    ):
+        path = tmp_path / config_path
+        path.write_text(config_content, encoding="utf-8")
+
+        with pytest.raises(InvalidConfigurationError, match="bump_mesage"):
+            config.create_config(data=config_content, path=path)
+
+    def test_unknown_keys_allowed_when_strict_config_disabled(self, tmp_path):
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            '[tool.commitizen]\nname = "cz_conventional_commits"\nunknown_key = 1\n',
+            encoding="utf-8",
+        )
+
+        conf = config.create_config(data=path.read_text(), path=path)
+
+        assert conf.settings["name"] == "cz_conventional_commits"
+
+    def test_known_keys_accepted_when_strict_config_enabled(self, tmp_path):
+        path = tmp_path / "pyproject.toml"
+        path.write_text(
+            '[tool.commitizen]\nname = "cz_conventional_commits"\n'
+            'strict_config = true\nannotated_tag_message = "bump: $current_version"\n',
+            encoding="utf-8",
+        )
+
+        conf = config.create_config(data=path.read_text(), path=path)
+
+        assert conf.settings["strict_config"] is True
+        assert conf.settings["annotated_tag_message"] == "bump: $current_version"


### PR DESCRIPTION
## Description

Closes #300.

Adds a new `strict_config` configuration option (default `false`). When enabled, Commitizen rejects unknown top-level keys in the `[tool.commitizen]` (or `commitizen`) section of the configuration file with an `InvalidConfigurationError` listing the offending keys — the same spirit as pytest's `--strict-markers`. This makes typos like `bump_mesage` fail loudly instead of being silently ignored.

Changes:
- `Settings` TypedDict + `DEFAULT_SETTINGS`: new `strict_config` key
- `BaseConfig._check_unknown_keys()`: validates parsed top-level keys against the known settings (derived from the `Settings` TypedDict, plus `annotated_tag_message` which predates the TypedDict)
- TOML, JSON and YAML parsers now call the check after loading their section
- Docs: new `strict_config` section in `docs/config/option.md` and a category entry in `configuration_file.md`
- Tests: parametrized over TOML/JSON/YAML for reject-on-unknown, plus allow-when-disabled and accept-known-keys cases

Keys nested under `customize` and `extras` are plugin-owned and deliberately not checked.

## Checklist

- [x] I have read the [contributing guidelines](https://commitizen-tools.github.io/commitizen/contributing/contributing)

### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

<!--
Generated-by: Hermes Agent (Nous Research) following the guidelines at http://commitizen-tools.github.io/commitizen/contributing/pull_request/#ai-assisted-contributions
-->

### Code Changes

- [x] Add test cases to all the changes you introduce
- [x] Run `uv run poe all` locally to ensure this change passes linter check and tests (ruff check, ruff format --check, mypy, full pytest suite — see below)
- [x] Manually test the changes:
  - [x] Verified the feature works as expected: `strict_config = true` + typo'd key → `InvalidConfigurationError` naming the key; same config without `strict_config` → loads normally; valid keys with strict mode on → loads normally
  - [x] Tested edge cases: all three config formats (TOML/JSON/YAML), missing commitizen section, `annotated_tag_message` (consumed but not in the TypedDict) accepted
  - [x] Backward compatibility maintained: option defaults to `false`, so existing configurations are unaffected
- [x] Update the documentation for the changes

### Tests

- Full suite: `1314 passed, 2 xfailed` (`uv run pytest -n auto`)
- `ruff check` clean, `ruff format --check` clean, `mypy commitizen/` clean
